### PR TITLE
Using groups instead of pacakges to specify tests components

### DIFF
--- a/OpenJDK_Playlist/playlist.xml
+++ b/OpenJDK_Playlist/playlist.xml
@@ -30,6 +30,24 @@
 			<tag>openjdk</tag>
 		</tags>
 	</test>
+	
+	<test>
+		<testCaseName>jdk_beans</testCaseName>
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(JTREG_DIR)$(D)lib$(D)jtreg.jar$(Q) \
+	-agentvm -a -ea -esa -v:fail,error,time -retain:fail,error -ignore:quiet -timeoutFactor:4 -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
+	-w $(Q)$(TEST_RESROOT)$(D)work$(Q) \
+	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
+	-jdk:$(Q)$(JDK_HOME)$(Q) \
+	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
+	$(Q)$(JTREG_TEST_DIR):jdk_beans$(Q); \
+	$(TEST_STATUS)</command>
+		<subsets>
+			<subset>SE80</subset>
+		</subsets>
+		<tags>
+			<tag>extended</tag>
+		</tags>
+	</test>
 	<test>
 		<testCaseName>jdk_io</testCaseName>
 		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(JTREG_DIR)$(D)lib$(D)jtreg.jar$(Q) \
@@ -38,7 +56,7 @@
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
 	-jdk:$(Q)$(JDK_HOME)$(Q) \
 	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
-	$(Q)$(JTREG_TEST_DIR)$(D)java$(D)io$(Q); \
+	$(Q)$(JTREG_TEST_DIR):jdk_io$(Q); \
 	$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>
@@ -55,7 +73,7 @@
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
 	-jdk:$(Q)$(JDK_HOME)$(Q) \
 	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
-	$(Q)$(JTREG_TEST_DIR)$(D)java$(D)lang$(Q); \
+	$(Q)$(JTREG_TEST_DIR):jdk_lang$(Q); \
 	$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>
@@ -72,7 +90,7 @@
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
 	-jdk:$(Q)$(JDK_HOME)$(Q) \
 	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
-	$(Q)$(JTREG_TEST_DIR)$(D)java$(D)math$(Q); \
+	$(Q)$(JTREG_TEST_DIR):jdk_math$(Q); \
 	$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>
@@ -82,14 +100,14 @@
 		</tags>
 	</test>
 	<test>
-		<testCaseName>jdk_net1</testCaseName>
+		<testCaseName>jdk_other</testCaseName>
 		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(JTREG_DIR)$(D)lib$(D)jtreg.jar$(Q) \
 	-agentvm -a -ea -esa -v:fail,error,time -retain:fail,error -ignore:quiet -timeoutFactor:4 -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
 	-w $(Q)$(TEST_RESROOT)$(D)work$(Q) \
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
 	-jdk:$(Q)$(JDK_HOME)$(Q) \
 	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
-	$(Q)$(JTREG_TEST_DIR)$(D)com$(D)sun$(D)net$(Q); \
+	$(Q)$(JTREG_TEST_DIR):jdk_other$(Q); \
 	$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>
@@ -99,14 +117,14 @@
 		</tags>
 	</test>
 	<test>
-		<testCaseName>jdk_net2</testCaseName>
+		<testCaseName>jdk_net</testCaseName>
 		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(JTREG_DIR)$(D)lib$(D)jtreg.jar$(Q) \
 	-agentvm -a -ea -esa -v:fail,error,time -retain:fail,error -ignore:quiet -timeoutFactor:4 -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
 	-w $(Q)$(TEST_RESROOT)$(D)work$(Q) \
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
 	-jdk:$(Q)$(JDK_HOME)$(Q) \
 	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
-	$(Q)$(JTREG_TEST_DIR)$(D)java$(D)net$(Q); \
+	$(Q)$(JTREG_TEST_DIR):jdk_net$(Q); \
 	$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>
@@ -123,7 +141,7 @@
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
 	-jdk:$(Q)$(JDK_HOME)$(Q) \
 	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
-	$(Q)$(JTREG_TEST_DIR)$(D)java$(D)nio$(Q); \
+	$(Q)$(JTREG_TEST_DIR):jdk_nio$(Q); \
 	$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>
@@ -140,7 +158,41 @@
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
 	-jdk:$(Q)$(JDK_HOME)$(Q) \
 	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
-	$(Q)$(JTREG_TEST_DIR)$(D)java$(D)security$(Q); \
+	$(Q)$(JTREG_TEST_DIR):jdk_security1$(Q); \
+	$(TEST_STATUS)</command>
+		<subsets>
+			<subset>SE80</subset>
+		</subsets>
+		<tags>
+			<tag>extended</tag>
+		</tags>
+	</test>
+	<test>
+		<testCaseName>jdk_security2</testCaseName>
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(JTREG_DIR)$(D)lib$(D)jtreg.jar$(Q) \
+	-agentvm -a -ea -esa -v:fail,error,time -retain:fail,error -ignore:quiet -timeoutFactor:4 -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
+	-w $(Q)$(TEST_RESROOT)$(D)work$(Q) \
+	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
+	-jdk:$(Q)$(JDK_HOME)$(Q) \
+	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
+	$(Q)$(JTREG_TEST_DIR):jdk_security2$(Q); \
+	$(TEST_STATUS)</command>
+		<subsets>
+			<subset>SE80</subset>
+		</subsets>
+		<tags>
+			<tag>extended</tag>
+		</tags>
+	</test>
+		<test>
+		<testCaseName>jdk_security3</testCaseName>
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(JTREG_DIR)$(D)lib$(D)jtreg.jar$(Q) \
+	-agentvm -a -ea -esa -v:fail,error,time -retain:fail,error -ignore:quiet -timeoutFactor:4 -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
+	-w $(Q)$(TEST_RESROOT)$(D)work$(Q) \
+	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
+	-jdk:$(Q)$(JDK_HOME)$(Q) \
+	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
+	$(Q)$(JTREG_TEST_DIR):jdk_security3$(Q); \
 	$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>
@@ -157,7 +209,7 @@
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
 	-jdk:$(Q)$(JDK_HOME)$(Q) \
 	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
-	$(Q)$(JTREG_TEST_DIR)$(D)java$(D)text$(Q); \
+	$(Q)$(JTREG_TEST_DIR):jdk_text$(Q); \
 	$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>
@@ -174,7 +226,7 @@
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
 	-jdk:$(Q)$(JDK_HOME)$(Q) \
 	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
-	$(Q)$(JTREG_TEST_DIR)$(D)java$(D)util$(Q); \
+	$(Q)$(JTREG_TEST_DIR):jdk_util$(Q); \
 	$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>
@@ -191,7 +243,7 @@
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
 	-jdk:$(Q)$(JDK_HOME)$(Q) \
 	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
-	$(Q)$(JTREG_TEST_DIR)$(D)java$(D)time$(Q); \
+	$(Q)$(JTREG_TEST_DIR):jdk_time$(Q); \
 	$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>
@@ -201,31 +253,14 @@
 		</tags>
 	</test>
 	<test>
-		<testCaseName>jdk_awt1</testCaseName>
+		<testCaseName>jdk_awt</testCaseName>
 		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(JTREG_DIR)$(D)lib$(D)jtreg.jar$(Q) \
 	-agentvm -a -ea -esa -v:fail,error,time -retain:fail,error -ignore:quiet -timeoutFactor:4 -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
 	-w $(Q)$(TEST_RESROOT)$(D)work$(Q) \
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
 	-jdk:$(Q)$(JDK_HOME)$(Q) \
 	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
-	$(Q)$(JTREG_TEST_DIR)$(D)com$(D)sun$(D)awt$(Q); \
-	$(TEST_STATUS)</command>
-		<subsets>
-			<subset>SE80</subset>
-		</subsets>
-		<tags>
-			<tag>extended</tag>
-		</tags>
-	</test>
-	<test>
-		<testCaseName>jdk_awt2</testCaseName>
-		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(JTREG_DIR)$(D)lib$(D)jtreg.jar$(Q) \
-	-agentvm -a -ea -esa -v:fail,error,time -retain:fail,error -ignore:quiet -timeoutFactor:4 -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
-	-w $(Q)$(TEST_RESROOT)$(D)work$(Q) \
-	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
-	-jdk:$(Q)$(JDK_HOME)$(Q) \
-	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
-	$(Q)$(JTREG_TEST_DIR)$(D)java$(D)awt$(Q); \
+	$(Q)$(JTREG_TEST_DIR):jdk_awt$(Q); \
 	$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>
@@ -242,7 +277,7 @@
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
 	-jdk:$(Q)$(JDK_HOME)$(Q) \
 	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
-	$(Q)$(JTREG_TEST_DIR)$(D)sun$(D)management$(Q); \
+	$(Q)$(JTREG_TEST_DIR):jdk_management$(Q); \
 	$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>
@@ -259,24 +294,7 @@
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
 	-jdk:$(Q)$(JDK_HOME)$(Q) \
 	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
-	$(Q)$(JTREG_TEST_DIR)$(D)com$(D)sun$(D)jmx$(Q); \
-	$(TEST_STATUS)</command>
-		<subsets>
-			<subset>SE80</subset>
-		</subsets>
-		<tags>
-			<tag>extended</tag>
-		</tags>
-	</test>
-	<test>
-		<testCaseName>jdk_security3</testCaseName>
-		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(JTREG_DIR)$(D)lib$(D)jtreg.jar$(Q) \
-	-agentvm -a -ea -esa -v:fail,error,time -retain:fail,error -ignore:quiet -timeoutFactor:4 -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
-	-w $(Q)$(TEST_RESROOT)$(D)work$(Q) \
-	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
-	-jdk:$(Q)$(JDK_HOME)$(Q) \
-	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
-	$(Q)$(JTREG_TEST_DIR)$(D)com$(D)sun$(D)jmx$(Q); \
+	$(Q)$(JTREG_TEST_DIR):jdk_jmx$(Q); \
 	$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>
@@ -293,7 +311,7 @@
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
 	-jdk:$(Q)$(JDK_HOME)$(Q) \
 	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
-	$(Q)$(JTREG_TEST_DIR)$(D)java$(D)rmi$(Q); \
+	$(Q)$(JTREG_TEST_DIR):jdk_rmi$(Q); \
 	$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>
@@ -310,7 +328,7 @@
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
 	-jdk:$(Q)$(JDK_HOME)$(Q) \
 	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
-	$(Q)$(JTREG_TEST_DIR)$(D)javax$(D)sound$(Q); \
+	$(Q)$(JTREG_TEST_DIR):jdk_sound$(Q); \
 	$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>
@@ -327,7 +345,7 @@
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
 	-jdk:$(Q)$(JDK_HOME)$(Q) \
 	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
-	$(Q)$(JTREG_TEST_DIR)$(D)javax$(D)swing$(Q); \
+	$(Q)$(JTREG_TEST_DIR):jdk_swing$(Q); \
 	$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>
@@ -336,7 +354,7 @@
 			<tag>extended</tag>
 		</tags>
 	</test>
-		<test>
+	<test>
 		<testCaseName>jdk_sound</testCaseName>
 		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(JTREG_DIR)$(D)lib$(D)jtreg.jar$(Q) \
 	-agentvm -a -ea -esa -v:fail,error,time -retain:fail,error -ignore:quiet -timeoutFactor:4 -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
@@ -344,7 +362,24 @@
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
 	-jdk:$(Q)$(JDK_HOME)$(Q) \
 	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
-	$(Q)$(JTREG_TEST_DIR)$(D)javax$(D)sound$(Q); \
+	$(Q)$(JTREG_TEST_DIR):jdk_sound$(Q); \
+	$(TEST_STATUS)</command>
+		<subsets>
+			<subset>SE80</subset>
+		</subsets>
+		<tags>
+			<tag>extended</tag>
+		</tags>
+	</test>
+	<test>
+		<testCaseName>jdk_tools</testCaseName>
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(JTREG_DIR)$(D)lib$(D)jtreg.jar$(Q) \
+	-agentvm -a -ea -esa -v:fail,error,time -retain:fail,error -ignore:quiet -timeoutFactor:4 -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
+	-w $(Q)$(TEST_RESROOT)$(D)work$(Q) \
+	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
+	-jdk:$(Q)$(JDK_HOME)$(Q) \
+	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
+	$(Q)$(JTREG_TEST_DIR):jdk_tools$(Q); \
 	$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>
@@ -361,7 +396,41 @@
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
 	-jdk:$(Q)$(JDK_HOME)$(Q) \
 	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
-	$(Q)$(JTREG_TEST_DIR)$(D)com$(D)sun$(D)jdi$(Q); \
+	$(Q)$(JTREG_TEST_DIR):jdk_jdi$(Q); \
+	$(TEST_STATUS)</command>
+		<subsets>
+			<subset>SE80</subset>
+		</subsets>
+		<tags>
+			<tag>extended</tag>
+		</tags>
+	</test>
+	<test>
+		<testCaseName>jdk_jfr</testCaseName>
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(JTREG_DIR)$(D)lib$(D)jtreg.jar$(Q) \
+	-agentvm -a -ea -esa -v:fail,error,time -retain:fail,error -ignore:quiet -timeoutFactor:4 -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
+	-w $(Q)$(TEST_RESROOT)$(D)work$(Q) \
+	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
+	-jdk:$(Q)$(JDK_HOME)$(Q) \
+	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
+	$(Q)$(JTREG_TEST_DIR):jdk_jfr$(Q); \
+	$(TEST_STATUS)</command>
+		<subsets>
+			<subset>SE80</subset>
+		</subsets>
+		<tags>
+			<tag>extended</tag>
+		</tags>
+	</test>
+	<test>
+		<testCaseName>jdk_core</testCaseName>
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(JTREG_DIR)$(D)lib$(D)jtreg.jar$(Q) \
+	-agentvm -a -ea -esa -v:fail,error,time -retain:fail,error -ignore:quiet -timeoutFactor:4 -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
+	-w $(Q)$(TEST_RESROOT)$(D)work$(Q) \
+	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
+	-jdk:$(Q)$(JDK_HOME)$(Q) \
+	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
+	$(Q)$(JTREG_TEST_DIR):jdk_core$(Q); \
 	$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>


### PR DESCRIPTION
Using TEST.groups defined groups specify test components

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>