### PR TITLE
Delete openjdkbinary dir, ensuring a fully fresh environment

### DIFF
--- a/Build/jenkins/Jenkinsfile_x86-64_linux
+++ b/Build/jenkins/Jenkinsfile_x86-64_linux
@@ -15,6 +15,18 @@ pipeline {
 					sh 'printenv'
             		sh 'chmod 755 $OPENJDK_TEST/maketest.sh'
                 	sh 'chmod 755 $OPENJDK_TEST/get.sh'
+                	script {
+                		if (fileExists('openjdkbinary')) {
+                			dir('openjdkbinary') {
+                				deleteDir()
+                			}
+                		}
+                		if (fileExists('jvmtest')) {
+                			dir('jvmtest') {
+                				deleteDir()
+                			}
+                		}
+                	}
                 	sh '$OPENJDK_TEST/get.sh $WORKSPACE $OPENJDK_TEST'
 					}
                 }

--- a/Build/jenkins/Jenkinsfile_x86-64_linux_anyagent
+++ b/Build/jenkins/Jenkinsfile_x86-64_linux_anyagent
@@ -16,6 +16,18 @@ pipeline {
 					sh 'printenv'
             		sh 'chmod 755 $OPENJDK_TEST/maketest.sh'
                 	sh 'chmod 755 $OPENJDK_TEST/get.sh'
+                	script {
+                		if (fileExists('openjdkbinary')) {
+                			dir('openjdkbinary') {
+                				deleteDir()
+                			}
+                		}
+                		if (fileExists('jvmtest')) {
+                			dir('jvmtest') {
+                				deleteDir()
+                			}
+                		}
+                	}
                 	sh '$OPENJDK_TEST/get.sh $WORKSPACE $OPENJDK_TEST'
 					}
                 }

--- a/Build/jenkins/Jenkinsfile_x86-64_linux_experimental
+++ b/Build/jenkins/Jenkinsfile_x86-64_linux_experimental
@@ -16,6 +16,18 @@ pipeline {
 					sh 'printenv'
             		sh 'chmod 755 $OPENJDK_TEST/maketest.sh'
                 	sh 'chmod 755 $OPENJDK_TEST/get.sh'
+                	script {
+                		if (fileExists('openjdkbinary')) {
+                			dir('openjdkbinary') {
+                				deleteDir()
+                			}
+                		}
+                		if (fileExists('jvmtest')) {
+                			dir('jvmtest') {
+                				deleteDir()
+                			}
+                		}
+                	}
                 	sh '$OPENJDK_TEST/get.sh $WORKSPACE $OPENJDK_TEST'
 					}
                 }

--- a/Build/jenkins/Jenkinsfile_x86-64_windows
+++ b/Build/jenkins/Jenkinsfile_x86-64_windows
@@ -14,6 +14,18 @@ pipeline {
 				timestamps{
             		sh 'chmod 755 $OPENJDK_TEST/maketest.sh'
                 	sh 'chmod 755 $OPENJDK_TEST/get.sh'
+                	script {
+                		if (fileExists('openjdkbinary')) {
+                			dir('openjdkbinary') {
+                				deleteDir()
+                			}
+                		}
+                		if (fileExists('jvmtest')) {
+                			dir('jvmtest') {
+                				deleteDir()
+                			}
+                		}
+                	}
                 	sh '$OPENJDK_TEST/get.sh $WORKSPACE $OPENJDK_TEST'
 					}
                 }


### PR DESCRIPTION
Only delete the whole workspace when build success to enable debug. 
We have enabled new build to wipe out SCM repository.  

So need to delete anything non-SCM repository under the workspace for new build.
 
Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>