### PR TITLE
XServer on :1 and DISPLAY address configuration.

### DIFF
--- a/Build/ansible/playbooks/ubuntu_14_16_x86.yml
+++ b/Build/ansible/playbooks/ubuntu_14_16_x86.yml
@@ -27,16 +27,16 @@
         - make
         - openjdk-7-jdk
         - zip
+        - wget		
+        - git		
 
     - name: Install Test tools
       apt: name={{item}} state=installed
       with_items:    
         - ant
         - ant-contrib
-        - git
         - jq
         - perl
-        - wget
 
     - name: Create jenkins user
       action: user name=jenkins state=present

--- a/Build/ansible/playbooks/ubuntu_14_16_x86.yml
+++ b/Build/ansible/playbooks/ubuntu_14_16_x86.yml
@@ -133,7 +133,7 @@
             user=root
             job="/usr/bin/apt-get update && /usr/bin/apt-get -y upgrade"
             state=present
-			
+
     - name: Install Test tools
       apt: name={{item}} state=installed
       with_items:
@@ -149,8 +149,8 @@
       with_items:
         - xauth
         - xorg
-  	    - xserver-xorg-legacy 
-	  
+        - xserver-xorg-legacy 
+
     - name: Create X11 Wrapper config file
   	  shell: touch /etc/X11/Xwrapper.config
 	  
@@ -158,7 +158,7 @@
         dest: /etc/X11/Xwrapper.config	
         block: |
           allowed_users=anybody	
-  		  needs_root_rights=yes
+          needs_root_rights=yes
 	 
     - name: Start X11
       sudo: yes

--- a/Build/ansible/playbooks/ubuntu_14_16_x86.yml
+++ b/Build/ansible/playbooks/ubuntu_14_16_x86.yml
@@ -133,6 +133,39 @@
             user=root
             job="/usr/bin/apt-get update && /usr/bin/apt-get -y upgrade"
             state=present
+			
+    - name: Install Test tools
+      apt: name={{item}} state=installed
+      with_items:
+        - ant
+        - ant-contrib
+        - git
+        - jq
+        - perl
+        - wget
+
+    - name: Install X11
+      apt: name={{item}} state=latest update_cache=yes
+      with_items:
+        - xauth
+        - xorg
+  	    - xserver-xorg-legacy 
+	  
+    - name: Create X11 Wrapper config file
+  	  shell: touch /etc/X11/Xwrapper.config
+	  
+    - blockinfile:
+        dest: /etc/X11/Xwrapper.config	
+        block: |
+          allowed_users=anybody	
+  		  needs_root_rights=yes
+	 
+    - name: Start X11
+      sudo: yes
+      sudo_user: jenkins
+  	  shell: startx -- :1 &
+  	  ignore_errors: True
+  	  no_log: True
 
     - debug: msg='Send Slack notification, successful'
     - include: slack_notification/successful_slack.yml

--- a/Build/ansible/playbooks/ubuntu_14_16_x86.yml
+++ b/Build/ansible/playbooks/ubuntu_14_16_x86.yml
@@ -153,13 +153,13 @@
 
     - name: Create X11 Wrapper config file
   	  shell: touch /etc/X11/Xwrapper.config
-	  
+
     - blockinfile:
         dest: /etc/X11/Xwrapper.config	
         block: |
           allowed_users=anybody	
           needs_root_rights=yes
-	 
+
     - name: Start X11
       sudo: yes
       sudo_user: jenkins

--- a/OpenJDK_Playlist/playlist.xml
+++ b/OpenJDK_Playlist/playlist.xml
@@ -254,7 +254,7 @@
 	</test>
 	<test>
 		<testCaseName>jdk_awt</testCaseName>
-		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(JTREG_DIR)$(D)lib$(D)jtreg.jar$(Q) \
+		<command>export DISPLAY=:1; $(JAVA_COMMAND) -Xmx512m -jar $(Q)$(JTREG_DIR)$(D)lib$(D)jtreg.jar$(Q) \
 	-agentvm -a -ea -esa -v:fail,error,time -retain:fail,error -ignore:quiet -timeoutFactor:4 -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
 	-w $(Q)$(TEST_RESROOT)$(D)work$(Q) \
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
@@ -339,7 +339,7 @@
 	</test>
 	<test>
 		<testCaseName>jdk_swing</testCaseName>
-		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(JTREG_DIR)$(D)lib$(D)jtreg.jar$(Q) \
+		<command>export DISPLAY=:1; $(JAVA_COMMAND) -Xmx512m -jar $(Q)$(JTREG_DIR)$(D)lib$(D)jtreg.jar$(Q) \
 	-agentvm -a -ea -esa -v:fail,error,time -retain:fail,error -ignore:quiet -timeoutFactor:4 -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
 	-w $(Q)$(TEST_RESROOT)$(D)work$(Q) \
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \


### PR DESCRIPTION
After few tries using different approaches, I think this one was less intrusive.

As you can see, I managed to execute tests pointing to the XServer address that I used to start it.

![screen shot 2017-06-15 at 21 38 30](https://user-images.githubusercontent.com/629076/27201255-ea68e3e2-5214-11e7-83d9-6bcf829c6689.png)

I had to use a package called ```xserver-xorg-legacy``` that provides a way to enable XServer startup by any user through ```/etc/X11/Xwrapper.config``` file configuration to avoid the necessity of giving sudo powers to the user that will start the tests.

I'm assuming that tests will be kicked by **jenkins** user, let me know if I'm wrong.

Hope it help.

Thanks.