### PR TITLE
Update jenkinsfile to accept parameters

### DIFF
--- a/Build/jenkins/Jenkinsfile
+++ b/Build/jenkins/Jenkinsfile
@@ -1,0 +1,71 @@
+#!groovy
+pipeline {
+    agent {label "${params.MACHINE_LABEL}&&x64&&test"}
+    parameters {
+		choice (choices: 'x64_linux\nx64_mac\ns390x_linux\nppc64le_linux\naarch64_linux', description: 'PLATFORM?', name: 'PLATFORM')
+		choice (choices: 'SE90\nSE80', description: 'What is JAVA_VERSION?', name: 'JAVA_VERSION')
+		choice (choices: 'openjdk9-openj9\nopenjdk9\nopenjdk8', description: 'What is JVM Version?', name: 'JVM_VERSION')
+		choice (choices: 'openjdk\nsanity\nextended', description: 'What is test level?', name: 'TARGET')
+		choice (choices: 'linux\nmac', description: 'What is machine label?', name: 'MACHINE_LABEL')
+		}
+	environment {
+                JCL_VERSION='current'
+                OPENJDK_TEST="$WORKSPACE/openjdk-test"
+                SPEC='linux_x86-64'
+                }
+    stages {
+        stage('Setup') {
+            steps {
+				timestamps{
+					sh 'printenv'
+            		sh 'chmod 755 $OPENJDK_TEST/maketest.sh'
+                	sh 'chmod 755 $OPENJDK_TEST/get.sh'
+                	script {
+                		if (fileExists('openjdkbinary')) {
+                			dir('openjdkbinary') {
+                				deleteDir()
+                			}
+                		}
+                		if (fileExists('jvmtest')) {
+                			dir('jvmtest') {
+                				deleteDir()
+                			}
+                		}
+                	}
+                	sh "$OPENJDK_TEST/get.sh $WORKSPACE $OPENJDK_TEST ${params.PLATFORM} ${params.JVM_VERSION}"
+					}
+                }
+        }
+        stage('Build') {
+            steps {
+				timestamps{
+                	echo 'Building tests...'
+                	withEnv(["JAVA_BIN=$WORKSPACE/openjdkbinary/j2sdk-image/${(params.JAVA_VERSION == 'SE80') ? 'jre/' : ''}bin",
+                	"JAVA_VERSION=${params.JAVA_VERSION}"]) {
+                		sh '$OPENJDK_TEST/maketest.sh $OPENJDK_TEST'
+					}
+                }
+            }
+        }
+        stage('Test') {
+            steps {
+				timestamps{
+                	echo 'Running tests...'
+                	withEnv(["JAVA_BIN=$WORKSPACE/openjdkbinary/j2sdk-image/${(params.JAVA_VERSION == 'SE80') ? 'jre/' : ''}bin",
+                	"JAVA_VERSION=${params.JAVA_VERSION}"]) {
+                		sh "$OPENJDK_TEST/maketest.sh $OPENJDK_TEST ${params.TARGET}"
+					}
+				}
+            }
+        }
+    }
+    post {
+    	always {
+ 			step([$class: "TapPublisher", testResults: "**/*.tap"])
+            archiveArtifacts artifacts: '**/*.tap', fingerprint: true
+            junit allowEmptyResults: true, keepLongStdio: true, testResults: '**/work/**/*.xml, **/junitreports/**/*.xml'
+            archiveArtifacts artifacts: '**/work/**/*.xml, **/junitreports/**/*.xml', fingerprint: true 
+ 		}
+ 	}
+    
+}

--- a/Build/jenkins/Jenkinsfile_x86-64_windows
+++ b/Build/jenkins/Jenkinsfile_x86-64_windows
@@ -24,8 +24,7 @@ pipeline {
                 		}
                 	}
                 	withEnv(["OPENJDK_TEST=${WORKSPACE}/openjdk-test"]) {
-	                	sh 'chmod 755 $OPENJDK_TEST/get.sh'
-						bat "${OPENJDK_TEST}/get.bat ${WORKSPACE} ${OPENJDK_TEST}"
+	                	bat "${OPENJDK_TEST}/get.bat ${WORKSPACE} ${OPENJDK_TEST}"
 					}
                 }
             }
@@ -35,8 +34,7 @@ pipeline {
 				timestamps{
                 	echo 'Building tests...'
                  	withEnv(["OPENJDK_TEST=${WORKSPACE}/openjdk-test", "JAVA_BIN=${WORKSPACE}/openjdkbinary/j2sdk-image/jre/bin"]) {
-	                	sh 'chmod 755 $OPENJDK_TEST/maketest.sh'
-						bat "${OPENJDK_TEST}/maketest.bat ${OPENJDK_TEST}"
+	                	bat "${OPENJDK_TEST}/maketest.bat ${OPENJDK_TEST}"
 					}
 				}
             }

--- a/OpenJDK_Playlist/disabledplaylist.xml
+++ b/OpenJDK_Playlist/disabledplaylist.xml
@@ -14,6 +14,23 @@
 -->
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
 	<test>
+		<testCaseName>OpenJDK_stackWalker</testCaseName>
+		<command>$(JAVA_COMMAND) $(CMPRSSPTRS) -Xmx512m -jar $(Q)$(JTREG_DIR)$(D)lib$(D)jtreg.jar$(Q) \
+	-agentvm -a -ea -esa -v:fail,error,time -retain:fail,error -ignore:quiet -timeoutFactor:4 -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
+	-w $(Q)$(TEST_RESROOT)$(D)work$(Q) \
+	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
+	-jdk:$(Q)$(JDK_HOME)$(Q) \
+	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
+	$(Q)$(JTREG_TEST_DIR)$(D)java$(D)lang$(D)StackWalker$(Q); \
+	$(TEST_STATUS)</command>
+		<subsets>
+			<subset>SE90</subset>
+		</subsets>
+		<tags>
+			<tag>openjdk</tag>
+		</tags>
+	</test>
+	<test>
 		<testCaseName>jdk_awt</testCaseName>
 		<command>export DISPLAY=:1; $(JAVA_COMMAND) -Xmx512m -jar $(Q)$(JTREG_DIR)$(D)lib$(D)jtreg.jar$(Q) \
 	$(JTREG_BASIC_OPTIONS)  -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \

--- a/OpenJDK_Playlist/playlist.xml
+++ b/OpenJDK_Playlist/playlist.xml
@@ -14,23 +14,6 @@
 -->
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
 	<test>
-		<testCaseName>OpenJDK_stackWalker</testCaseName>
-		<command>$(JAVA_COMMAND) $(CMPRSSPTRS) -Xmx512m -jar $(Q)$(JTREG_DIR)$(D)lib$(D)jtreg.jar$(Q) \
-	-agentvm -a -ea -esa -v:fail,error,time -retain:fail,error -ignore:quiet -timeoutFactor:4 -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
-	-w $(Q)$(TEST_RESROOT)$(D)work$(Q) \
-	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
-	-jdk:$(Q)$(JDK_HOME)$(Q) \
-	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
-	$(Q)$(JTREG_TEST_DIR)$(D)java$(D)lang$(D)StackWalker$(Q); \
-	$(TEST_STATUS)</command>
-		<subsets>
-			<subset>SE90</subset>
-		</subsets>
-		<tags>
-			<tag>openjdk</tag>
-		</tags>
-	</test>
-	<test>
 		<testCaseName>hotspot_all</testCaseName>
 		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(JTREG_DIR)$(D)lib$(D)jtreg.jar$(Q) \
 	$(JTREG_BASIC_OPTIONS) -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
@@ -125,9 +108,10 @@
 	$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>
+			<subset>SE90</subset>
 		</subsets>
 		<tags>
-			<tag>extended</tag>
+			<tag>openjdk</tag>
 		</tags>
 	</test>
 	<test>

--- a/get.sh
+++ b/get.sh
@@ -14,10 +14,10 @@
 
 openjdktest=$(pwd)
 # possible platforms : x64_linux | x64_mac | s390x_linux | ppc64le_linux | aarch64_linux 
-platform=x64_linux
 if [ "$#" -gt 2 ]
 then
 platform=$3
+jvm_version=$4
 fi
 
 if [ "$#" -eq 1 ]
@@ -29,7 +29,7 @@ else
 	cd $1
 	mkdir openjdkbinary
 	cd openjdkbinary
-	download_url="https://api.adoptopenjdk.net/openjdk/releases/$platform/latest/binary"
+	download_url="https://api.adoptopenjdk.net/$jvm_version/releases/$platform/latest/binary"
 	wget --no-check-certificate ${download_url}
 	jar_file_name=`ls`
 	tar -zxvf $jar_file_name


### PR DESCRIPTION
Tested with openjdk8-linux/mac, openjdk-openj9:linux
update jdk_math to openjdk group in playlist.xml to test openj9 jdk.

 Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>