### PR TITLE
dockerize openjdk test

### DIFF
--- a/Build/docker/Dockerfile
+++ b/Build/docker/Dockerfile
@@ -1,0 +1,62 @@
+# (C) Copyright IBM Corporation 2017.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This Dockerfile in Build/docker dir is used to create an image with
+# AdoptOpenJDK jdk binary installed. Basic test dependent executions
+# are installed during the building process.
+#
+# Build example: `docker build -t adoptopenjdk-test .`
+#
+# This Dockerfile builds image based on adoptopenjdk/openjdk8:latest.
+# If you want to build image based on other images, please use
+# `--build-arg list` to specify your base image
+#
+# Build example: `docker build --build-arg IMAGE_NAME=<image_name> --build-arg IMAGE_VERSION=<image_version >-t adoptopenjdk-test .`
+
+ARG IMAGE_NAME=adoptopenjdk/openjdk8
+ARG IMAGE_VERSION=latest
+
+FROM ${IMAGE_NAME}:${IMAGE_VERSION}
+
+# Install required OS and testing tools
+RUN apt-get update \
+  && apt-get install -qq -y --no-install-recommends \
+    ant \
+    ant-contrib \
+    autoconf \
+    bash \
+    build-essential \
+    ca-certificates \
+    git \
+    make \
+    perl \
+    unzip \
+    wget \
+    vim \
+    zip \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install Perl modules for test framework
+RUN echo yes | cpan install JSON Text::CSV
+
+# These two folders are used testing purpose.
+# In the `docker run` command, user also need mount <JDK_ROOT>
+# and <openjdk-test_root_dir> to the Docker image by using cmd:
+#   `docker run -it -v <path_to_JDK_root>:/java -v <path_to_openjdk_test_root_dir>:/test <your_image_name>`
+VOLUME ["/test","/java"]
+
+# Shell script to automate test execution
+COPY ./mktest.sh /mktest.sh
+
+CMD /bin/bash /mktest.sh

--- a/Build/docker/README.md
+++ b/Build/docker/README.md
@@ -1,0 +1,20 @@
+# Dockerize AdoptOpenJDK Testing
+
+### What is our motivation?
+
+* We want to simplify test execution as much as possible.
+* We want to minimize the OS requirement to ease users' work.
+* We want to automate test process by just running one command. To run the test,
+you can simply run `docker run -it -v <path to test jdk>:/java -v <path to test root folder>:/test <docker_image_name>`
+
+### How to use this Dockerfile
+
+We assume you have already cloned this repo to your local machine.
+
+1. Execute get.sh in the test root folder to get all dependencies.
+2. Build the docker image: `docker build -t openjdk-test .`
+3. If you want to get into the Docker image to manually run tests, the command is: 
+   `docker run -it -v <path_to_JDK_root>:/java -v <path_to_openjdk_test_root_dir>:/test <your_image_name> /bin/bash` , then you could follow the README.md in test root to run tests manually.
+
+   If you want to automatically execute tests, the command is:
+   `docker run -it -v <path_to_JDK_root>:/java -v <path_to_openjdk_test_root_dir>:/test <your_image_name>`

--- a/Build/docker/mktest.sh
+++ b/Build/docker/mktest.sh
@@ -1,0 +1,49 @@
+#/bin/bash
+#
+# (C) Copyright IBM Corporation 2017.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if [ -d /java/jre/bin ];then
+	echo "Using mounted Java8"
+	export JAVA_BIN=/java/jre/bin
+	export JAVA_HOME=/java
+	export PATH=$JAVA_HOME/bin:$PATH
+	java -version
+elif [ -d /java/bin ]; then
+	echo "Using mounted Java9"
+	export JAVA_BIN=/java/bin
+	export JAVA_HOME=/java
+	export PATH=$JAVA_HOME/bin:$PATH
+	java -version
+else
+	echo "Using docker image default Java"
+	java_path=$(type -p java)
+	suffix="/java"
+	java_root=${java_path%$suffix}
+	export JAVA_BIN="$java_root"
+	echo "JAVA_BIN is: $JAVA_BIN"
+	$JAVA_BIN/java -version
+fi
+
+export SPEC=linux_x86-64
+export JAVA_VERSION=SE80
+
+
+cd /test/TestConfig
+make -f run_configure.mk
+make compile
+make sanity
+
+/bin/bash


### PR DESCRIPTION
* new Dockerfile added to Build/docker 
* test executable dependencies are installed in Dockerfile
* docker image can be used to execute test automatically
* documented shell script to run openjdk tests within a docker container

Signed-off-by: Tianyu Zuo <tianyu@ca.ibm.com>