### PR TITLE
integrate dockerized scala test with testKitGen

### DIFF
--- a/thirdparty_containers/scala/build.xml
+++ b/thirdparty_containers/scala/build.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<project name="Scala-Test" default="build" basedir=".">
+	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+	<description>
+		Build Scala test Docker image
+	</description>
+
+	<!-- set properties for this build -->
+	<property name="DEST" value="${BUILD_ROOT}/containerTest/scala-test" />
+	<property name="dist" location="${DEST}/${JAVA_VERSION}" />
+	<property name="src" location="." />
+
+	<target name="init">
+		<mkdir dir="${dist}"/>
+	</target>
+
+	<target name="clean_image" depends="init" description="build scala test docker image">
+		<exec executable="docker">
+			<arg line="rmi -f adoptopenjdk-scala-test" />
+		</exec>
+	</target>
+
+	<target name="build_image" depends="clean_image" description="build scala test docker image">
+		<exec executable="docker">
+			<arg line="build -t adoptopenjdk-scala-test -f dockerfile/Dockerfile ." />
+		</exec>
+	</target>
+
+	<target name="dist" depends="build_image" description="generate the distribution">
+		<copy todir="${DEST}">
+			<fileset dir="${src}" includes="*.xml, *.mk"/>
+		</copy>
+	</target>
+
+	<target name="build" >
+		<antcall target="dist" inheritall="true" />
+	</target>
+</project>

--- a/thirdparty_containers/scala/dockerfile/Dockerfile
+++ b/thirdparty_containers/scala/dockerfile/Dockerfile
@@ -1,0 +1,61 @@
+# (C) Copyright IBM Corporation 2017.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This Dockerfile in Build/docker dir is used to create an image with
+# AdoptOpenJDK jdk binary installed. Basic test dependent executions
+# are installed during the building process.
+#
+# Build example: `docker build -t adoptopenjdk-scala-test .`
+#
+# This Dockerfile builds image based on adoptopenjdk/openjdk8:latest.
+# If you want to build image based on other images, please use
+# `--build-arg list` to specify your base image
+#
+# Build example: `docker build --build-arg IMAGE_NAME=<image_name> --build-arg IMAGE_VERSION=<image_version >-t adoptopenjdk-scala-test .`
+
+ARG IMAGE_NAME=adoptopenjdk/openjdk8
+ARG IMAGE_VERSION=latest
+
+FROM ${IMAGE_NAME}:${IMAGE_VERSION}
+
+# install test dependent executable files
+RUN apt-get update \
+	&& apt-get -y install \
+	ant \
+	apt-transport-https \
+	ca-certificates \
+	dirmngr \
+	curl \
+	git \
+	make \
+	unzip \
+	vim \
+	wget
+
+#install sbt
+RUN echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823
+RUN apt-get update && apt-get install -y sbt
+
+VOLUME ["/scala","/java"]
+ENV JAVA_HOME=/java \
+    PATH=/java/bin:$PATH \
+    JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
+
+
+# This is the main script to run scala tests
+COPY ./dockerfile/scala-test.sh /scala-test.sh
+
+ENTRYPOINT ["/bin/bash", "/scala-test.sh"]
+CMD ["--version"]

--- a/thirdparty_containers/scala/dockerfile/scala-test.sh
+++ b/thirdparty_containers/scala/dockerfile/scala-test.sh
@@ -1,0 +1,57 @@
+#/bin/bash
+#
+# (C) Copyright IBM Corporation 2017.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if [ -d /java/jre/bin ];then
+	echo "Using mounted Java8"
+	export JAVA_BIN=/java/jre/bin
+	export JAVA_HOME=/java
+	export PATH=$JAVA_BIN:$PATH
+	java -version
+elif [ -d /java/bin ]; then
+	echo "Using mounted Java9"
+	export JAVA_BIN=/java/bin
+	export JAVA_HOME=/java
+	export PATH=$JAVA_BIN:$PATH
+	java -version
+else
+	echo "Using docker image default Java"
+	java_path=$(type -p java)
+	suffix="/java"
+	java_root=${java_path%$suffix}
+	export JAVA_BIN="$java_root"
+	echo "JAVA_BIN is: $JAVA_BIN"
+	$JAVA_BIN/java -version
+fi
+
+TEST_SUITE=$1
+export JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
+#begin scala test
+echo "PATH is : $PATH"
+echo "JAVA_HOME is : $JAVA_HOME"
+echo "type -p java is :"
+type -p java
+echo "java -version is: \n"
+java -version
+cd /scala
+ls .
+pwd
+echo "Begin to execute Scala test with cmd: sbt \"partest $TEST_SUITE\"" && \
+echo "Try to echo Scala version by using sbt \"scala -version\"" && \
+sbt "scala -version"
+
+echo "Begin to execute Scala test with cmd: sbt \"partest $TEST_SUITE\"" && \
+sbt "partest $TEST_SUITE"

--- a/thirdparty_containers/scala/playlist.xml
+++ b/thirdparty_containers/scala/playlist.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+-->
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
+	<test>
+		<testCaseName>scala_test</testCaseName>
+		<command>docker run -it --rm -v $(JDK_HOME):/java -v $(SCALA_ROOT):/scala adoptopenjdk-scala-test:latest "jvm pos neg"</command>
+		<subsets>
+			<subset>SE80</subset>
+			<subset>SE90</subset>
+		</subsets>
+		<tags>
+			<tag>extended</tag>
+		</tags>
+	</test>
+</playlist>


### PR DESCRIPTION
* Add containerTest folder for all dockerized test
* Add scala-test under containerTest project
* build.xml is used to build scala-test docker image
* playlist.xml is used to execute the dockerized scala-test image
* dockerized scala test now run "jvm, pos and net" test suite
* more test suites can be added if needed
* the dockerized scala test can now be built and triggered by testkitGen
* To build and run scala test, you need to export environment variable:
  - export BUILD_LIST="containerTest/scala-test"


Signed-off-by: Tianyu Zuo <tianyu@ca.ibm.com>