### PR TITLE
Enable openjdk9 testcase and add make target return code

### DIFF
--- a/OpenJDK_Playlist/playlist.xml
+++ b/OpenJDK_Playlist/playlist.xml
@@ -24,6 +24,7 @@
 	$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>
+			<subset>SE90</subset>
 		</subsets>
 		<tags>
 			<tag>extended</tag>
@@ -40,6 +41,7 @@
 	$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>
+			<subset>SE90</subset>
 		</subsets>
 		<tags>
 			<tag>extended</tag>
@@ -57,6 +59,7 @@
 	$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>
+			<subset>SE90</subset>
 		</subsets>
 		<tags>
 			<tag>extended</tag>
@@ -74,6 +77,7 @@
 	$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>
+			<subset>SE90</subset>
 		</subsets>
 		<tags>
 			<tag>extended</tag>
@@ -91,6 +95,7 @@
 	$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>
+			<subset>SE90</subset>
 		</subsets>
 		<tags>
 			<tag>extended</tag>
@@ -126,6 +131,7 @@
 	$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>
+			<subset>SE90</subset>
 		</subsets>
 		<tags>
 			<tag>extended</tag>
@@ -143,6 +149,7 @@
 	$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>
+			<subset>SE90</subset>
 		</subsets>
 		<tags>
 			<tag>extended</tag>
@@ -160,6 +167,7 @@
 	$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>
+			<subset>SE90</subset>
 		</subsets>
 		<tags>
 			<tag>extended</tag>
@@ -177,6 +185,7 @@
 	$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>
+			<subset>SE90</subset>
 		</subsets>
 		<tags>
 			<tag>extended</tag>
@@ -194,6 +203,7 @@
 	$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>
+			<subset>SE90</subset>
 		</subsets>
 		<tags>
 			<tag>extended</tag>
@@ -211,6 +221,7 @@
 	$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>
+			<subset>SE90</subset>
 		</subsets>
 		<tags>
 			<tag>extended</tag>
@@ -228,6 +239,7 @@
 	$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>
+			<subset>SE90</subset>
 		</subsets>
 		<tags>
 			<tag>extended</tag>
@@ -245,6 +257,7 @@
 	$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>
+			<subset>SE90</subset>
 		</subsets>
 		<tags>
 			<tag>extended</tag>
@@ -262,6 +275,7 @@
 	$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>
+			<subset>SE90</subset>
 		</subsets>
 		<tags>
 			<tag>extended</tag>
@@ -279,6 +293,7 @@
 	$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>
+			<subset>SE90</subset>
 		</subsets>
 		<tags>
 			<tag>extended</tag>
@@ -296,6 +311,7 @@
 	$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>
+			<subset>SE90</subset>
 		</subsets>
 		<tags>
 			<tag>extended</tag>
@@ -313,6 +329,7 @@
 	$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>
+			<subset>SE90</subset>
 		</subsets>
 		<tags>
 			<tag>extended</tag>
@@ -330,6 +347,7 @@
 	$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>
+			<subset>SE90</subset>
 		</subsets>
 		<tags>
 			<tag>extended</tag>
@@ -347,6 +365,7 @@
 	$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>
+			<subset>SE90</subset>
 		</subsets>
 		<tags>
 			<tag>extended</tag>
@@ -364,6 +383,7 @@
 	$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>
+			<subset>SE90</subset>
 		</subsets>
 		<tags>
 			<tag>extended</tag>
@@ -381,6 +401,7 @@
 	$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>
+			<subset>SE90</subset>
 		</subsets>
 		<tags>
 			<tag>extended</tag>
@@ -398,6 +419,7 @@
 	$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>
+			<subset>SE90</subset>
 		</subsets>
 		<tags>
 			<tag>extended</tag>

--- a/TestConfig/run_configure.mk
+++ b/TestConfig/run_configure.mk
@@ -30,6 +30,9 @@ endif
 autogen:
 	cd $(CURRENT_DIR)$(D)scripts$(D)testKitGen; \
 	perl testKitGen.pl $(OPTS); \
+	if [ $$? -ne 0 ] ; then \
+		exit 1; \
+	fi
 	cd $(CURRENT_DIR);
 
 AUTOGEN_FILES = $(wildcard $(CURRENT_DIR)$(D)jvmTest.mk)

--- a/maketest.sh
+++ b/maketest.sh
@@ -14,6 +14,9 @@
 cd $1/TestConfig
 if [ "$#" -eq 1 ];then
 	make -f run_configure.mk
+	if [ $? -ne 0 ]; then
+		exit 1
+	fi
 	make compile
 else
 	make $2


### PR DESCRIPTION
Add openjdk9 testcase

Add target return code to stop shell script or pipeline running when former step/stage fails.

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>