### PR TITLE
Adding local ProblemList.txt to disable failed tests in adoptopenjdk test build

### DIFF
--- a/OpenJDK_Playlist/ProblemList.txt
+++ b/OpenJDK_Playlist/ProblemList.txt
@@ -1,0 +1,137 @@
+# List of tests that should not be run by adoptOpenjdk playlist:
+#   1. Does not run with jtreg -samevm mode
+#   2. Causes problems in jtreg -samevm mode for jtreg or tests that follow it
+#   3. The test is too slow or consumes too many system resources
+#   4. The test fails when run on any official build systems
+
+# More than one label is allowed but must be on the same line.
+#
+#############################################################################
+#
+# Fixing the tests:
+#
+# Some tests just may need to be run with "othervm", and that can easily be
+#   done my adding a @run line (or modifying any existing @run):
+#      @run main/othervm NameOfMainClass
+#   Make sure this @run follows any use of @library.
+#   Otherwise, if the test is a samevm possibility, make sure the test is
+#     cleaning up after itself, closing all streams, deleting temp files, etc.
+#
+# Keep in mind that the bug could be in many places, and even different per
+#   platform, it could be a bug in any one of:
+#      - the testcase
+#      - the jdk (jdk classes, native code, or hotspot)
+#      - the native compiler
+#      - the javac compiler
+#      - the OS (depends on what the testcase does)
+#
+# If you managed to really fix one of these tests, here is how you can
+#    remove tests from this list:
+#  1. Make sure test passes on all platforms with samevm, or mark it othervm
+#  2. Make sure test passes on all platforms when run with it's entire group
+#  3. Make sure both VMs are tested, -server and -client, if possible
+#  4. Make sure you try the -d64 option on Solaris
+#  5. Use a tool like JPRT or something to verify these results
+#  6. Delete lines in this file, include the changes with your test changes
+#
+# You may need to repeat your testing 2 or even 3 times to verify good
+#   results, some of these samevm failures are not very predictable.
+#
+#############################################################################
+
+############################################################################
+
+# jdk_awt
+
+############################################################################
+
+# jdk_beans 
+
+############################################################################
+
+# jdk_core
+
+############################################################################
+
+# jdk_lang
+
+############################################################################
+
+# jdk_management
+
+############################################################################
+
+# jdk_jmx
+
+############################################################################
+
+# jdk_math
+
+############################################################################
+
+# jdk_other
+
+############################################################################
+
+# jdk_net
+
+############################################################################
+
+# jdk_io
+
+java/io/Serializable/unresolvableObjectStreamClass/UnresolvableObjectStreamClass.java	107 generic-all
+
+############################################################################
+
+# jdk_jdi
+
+
+############################################################################
+
+# jdk_nio
+
+############################################################################
+
+# jdk_rmi
+
+############################################################################
+
+# jdk_security
+
+############################################################################
+
+# jdk_sound
+
+############################################################################
+
+# jdk_swing
+
+############################################################################
+
+# jdk_text
+
+############################################################################
+
+# jdk_time
+
+############################################################################
+
+# jdk_tools
+
+############################################################################
+
+# jdk_jdi
+
+############################################################################
+
+# jdk_util
+
+############################################################################
+
+# svc_tools
+
+############################################################################
+
+# jdk_other
+
+############################################################################

--- a/OpenJDK_Playlist/build.xml
+++ b/OpenJDK_Playlist/build.xml
@@ -15,8 +15,11 @@
 	</target>
 
 	<target name="dist" depends="init" description="generate the distribution">
+		<copy todir="${dist}">
+			<fileset dir="${src}" includes="*.xml, ProblemList.txt"/>
+		</copy>
 		<copy todir="${DEST}">
-			<fileset dir="${src}" includes="*.xml, *.mk"/>
+			<fileset dir="${src}" includes="*.mk"/>
 		</copy>
 	</target>
 	

--- a/OpenJDK_Playlist/playlist.xml
+++ b/OpenJDK_Playlist/playlist.xml
@@ -55,6 +55,7 @@
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
 	-jdk:$(Q)$(JDK_HOME)$(Q) \
 	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
+	-exclude:$(Q)$(TEST_RESROOT)$(D)ProblemList.txt$(Q) \
 	$(Q)$(JTREG_TEST_DIR):jdk_beans$(Q); \
 	$(TEST_STATUS)</command>
 		<subsets>
@@ -73,6 +74,7 @@
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
 	-jdk:$(Q)$(JDK_HOME)$(Q) \
 	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
+	-exclude:$(Q)$(TEST_RESROOT)$(D)ProblemList.txt$(Q) \
 	$(Q)$(JTREG_TEST_DIR):jdk_io$(Q); \
 	$(TEST_STATUS)</command>
 		<subsets>
@@ -91,6 +93,7 @@
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
 	-jdk:$(Q)$(JDK_HOME)$(Q) \
 	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
+	-exclude:$(Q)$(TEST_RESROOT)$(D)ProblemList.txt$(Q) \
 	$(Q)$(JTREG_TEST_DIR):jdk_lang$(Q); \
 	$(TEST_STATUS)</command>
 		<subsets>
@@ -109,6 +112,7 @@
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
 	-jdk:$(Q)$(JDK_HOME)$(Q) \
 	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
+	-exclude:$(Q)$(TEST_RESROOT)$(D)ProblemList.txt$(Q) \
 	$(Q)$(JTREG_TEST_DIR):jdk_math$(Q); \
 	$(TEST_STATUS)</command>
 		<subsets>
@@ -127,6 +131,7 @@
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
 	-jdk:$(Q)$(JDK_HOME)$(Q) \
 	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
+	-exclude:$(Q)$(TEST_RESROOT)$(D)ProblemList.txt$(Q) \
 	$(Q)$(JTREG_TEST_DIR):jdk_other$(Q); \
 	$(TEST_STATUS)</command>
 		<subsets>
@@ -145,6 +150,7 @@
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
 	-jdk:$(Q)$(JDK_HOME)$(Q) \
 	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
+	-exclude:$(Q)$(TEST_RESROOT)$(D)ProblemList.txt$(Q) \
 	$(Q)$(JTREG_TEST_DIR):jdk_net$(Q); \
 	$(TEST_STATUS)</command>
 		<subsets>
@@ -163,6 +169,7 @@
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
 	-jdk:$(Q)$(JDK_HOME)$(Q) \
 	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
+	-exclude:$(Q)$(TEST_RESROOT)$(D)ProblemList.txt$(Q) \
 	$(Q)$(JTREG_TEST_DIR):jdk_nio$(Q); \
 	$(TEST_STATUS)</command>
 		<subsets>
@@ -181,6 +188,7 @@
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
 	-jdk:$(Q)$(JDK_HOME)$(Q) \
 	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
+	-exclude:$(Q)$(TEST_RESROOT)$(D)ProblemList.txt$(Q) \
 	$(Q)$(JTREG_TEST_DIR):jdk_security1$(Q); \
 	$(TEST_STATUS)</command>
 		<subsets>
@@ -199,6 +207,7 @@
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
 	-jdk:$(Q)$(JDK_HOME)$(Q) \
 	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
+	-exclude:$(Q)$(TEST_RESROOT)$(D)ProblemList.txt$(Q) \
 	$(Q)$(JTREG_TEST_DIR):jdk_security2$(Q); \
 	$(TEST_STATUS)</command>
 		<subsets>
@@ -217,6 +226,7 @@
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
 	-jdk:$(Q)$(JDK_HOME)$(Q) \
 	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
+	-exclude:$(Q)$(TEST_RESROOT)$(D)ProblemList.txt$(Q) \
 	$(Q)$(JTREG_TEST_DIR):jdk_security3$(Q); \
 	$(TEST_STATUS)</command>
 		<subsets>
@@ -235,6 +245,7 @@
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
 	-jdk:$(Q)$(JDK_HOME)$(Q) \
 	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
+	-exclude:$(Q)$(TEST_RESROOT)$(D)ProblemList.txt$(Q) \
 	$(Q)$(JTREG_TEST_DIR):jdk_text$(Q); \
 	$(TEST_STATUS)</command>
 		<subsets>
@@ -253,6 +264,7 @@
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
 	-jdk:$(Q)$(JDK_HOME)$(Q) \
 	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
+	-exclude:$(Q)$(TEST_RESROOT)$(D)ProblemList.txt$(Q) \
 	$(Q)$(JTREG_TEST_DIR):jdk_util$(Q); \
 	$(TEST_STATUS)</command>
 		<subsets>
@@ -271,6 +283,7 @@
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
 	-jdk:$(Q)$(JDK_HOME)$(Q) \
 	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
+	-exclude:$(Q)$(TEST_RESROOT)$(D)ProblemList.txt$(Q) \
 	$(Q)$(JTREG_TEST_DIR):jdk_time$(Q); \
 	$(TEST_STATUS)</command>
 		<subsets>
@@ -289,6 +302,7 @@
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
 	-jdk:$(Q)$(JDK_HOME)$(Q) \
 	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
+	-exclude:$(Q)$(TEST_RESROOT)$(D)ProblemList.txt$(Q) \
 	$(Q)$(JTREG_TEST_DIR):jdk_management$(Q); \
 	$(TEST_STATUS)</command>
 		<subsets>
@@ -307,6 +321,7 @@
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
 	-jdk:$(Q)$(JDK_HOME)$(Q) \
 	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
+	-exclude:$(Q)$(TEST_RESROOT)$(D)ProblemList.txt$(Q) \
 	$(Q)$(JTREG_TEST_DIR):jdk_jmx$(Q); \
 	$(TEST_STATUS)</command>
 		<subsets>
@@ -325,6 +340,7 @@
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
 	-jdk:$(Q)$(JDK_HOME)$(Q) \
 	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
+	-exclude:$(Q)$(TEST_RESROOT)$(D)ProblemList.txt$(Q) \
 	$(Q)$(JTREG_TEST_DIR):jdk_rmi$(Q); \
 	$(TEST_STATUS)</command>
 		<subsets>
@@ -343,6 +359,7 @@
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
 	-jdk:$(Q)$(JDK_HOME)$(Q) \
 	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
+	-exclude:$(Q)$(TEST_RESROOT)$(D)ProblemList.txt$(Q) \
 	$(Q)$(JTREG_TEST_DIR):jdk_sound$(Q); \
 	$(TEST_STATUS)</command>
 		<subsets>
@@ -361,6 +378,7 @@
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
 	-jdk:$(Q)$(JDK_HOME)$(Q) \
 	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
+	-exclude:$(Q)$(TEST_RESROOT)$(D)ProblemList.txt$(Q) \
 	$(Q)$(JTREG_TEST_DIR):jdk_tools$(Q); \
 	$(TEST_STATUS)</command>
 		<subsets>
@@ -379,6 +397,7 @@
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
 	-jdk:$(Q)$(JDK_HOME)$(Q) \
 	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
+	-exclude:$(Q)$(TEST_RESROOT)$(D)ProblemList.txt$(Q) \
 	$(Q)$(JTREG_TEST_DIR):jdk_jdi$(Q); \
 	$(TEST_STATUS)</command>
 		<subsets>
@@ -397,6 +416,7 @@
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
 	-jdk:$(Q)$(JDK_HOME)$(Q) \
 	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
+	-exclude:$(Q)$(TEST_RESROOT)$(D)ProblemList.txt$(Q) \
 	$(Q)$(JTREG_TEST_DIR):jdk_jfr$(Q); \
 	$(TEST_STATUS)</command>
 		<subsets>
@@ -415,6 +435,7 @@
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
 	-jdk:$(Q)$(JDK_HOME)$(Q) \
 	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
+	-exclude:$(Q)$(TEST_RESROOT)$(D)ProblemList.txt$(Q) \
 	$(Q)$(JTREG_TEST_DIR):jdk_core$(Q); \
 	$(TEST_STATUS)</command>
 		<subsets>


### PR DESCRIPTION
Add local ProblemList.txt to exclude test failed in adoptOpenjdk build.

Example as:
```
# issue 107 jdk_io: java/io/Serializable/unresolvableObjectStreamClass/UnresolvableObjectStreamClass.java fail
java/io/Serializable/unresolvableObjectStreamClass/UnresolvableObjectStreamClass.java	generic-all
```
Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>