### PR TITLE
Exclude failure tests on linux

### DIFF
--- a/OpenJDK_Playlist/ProblemList.txt
+++ b/OpenJDK_Playlist/ProblemList.txt
@@ -39,6 +39,63 @@
 #
 #############################################################################
 
+#hotspot_jre
+gc/g1/TestShrinkAuxiliaryData05.java 110 generic-all
+gc/g1/TestShrinkAuxiliaryData10.java 110 generic-all
+gc/g1/TestShrinkAuxiliaryData15.java 110 generic-all
+gc/g1/TestShrinkAuxiliaryData20.java 110 generic-all
+runtime/os/AvailableProcessors.java	110	linux-all
+compiler/5091921/Test7005594.java	116	linux-all
+compiler/c1/TestUnresolvedFieldMain.java	116	linux-all
+compiler/jsr292/PollutedTrapCounts.java		116	linux-all
+compiler/jsr292/RedefineMethodUsedByMultipleMethodHandles.java	116	linux-all
+compiler/loopopts/UseCountedLoopSafepoints.java	116	linux-all
+compiler/types/correctness/OffTest.java	116	linux-all
+compiler/unsafe/TestRawAliasing.java	116	linux-all
+gc/TestVerifySilently.java	116	linux-all
+gc/TestVerifySubSet.java	116	linux-all
+gc/arguments/TestG1HeapRegionSize.java	116	linux-all
+gc/arguments/TestMinInitialErgonomics.java	116	linux-all
+gc/class_unloading/TestCMSClassUnloadingEnabledHWM.java	116	linux-all
+gc/class_unloading/TestG1ClassUnloadingHWM.java	116	linux-all
+gc/ergonomics/TestDynamicNumberOfGCThreads.java	116	linux-all
+gc/g1/TestEagerReclaimHumongousRegions.java	116	linux-all
+gc/g1/TestEagerReclaimHumongousRegionsClearMarkBits.java	116	linux-all
+gc/g1/TestEagerReclaimHumongousRegionsWithRefs.java	116	linux-all
+gc/g1/TestG1TraceEagerReclaimHumongousObjects.java	116	linux-all
+gc/g1/TestGCLogMessages.java	116	linux-all
+gc/g1/TestHumongousAllocInitialMark.java	116	linux-all
+gc/g1/TestPrintGCDetails.java	116	linux-all
+gc/g1/TestPrintRegionRememberedSetInfo.java	116	linux-all
+gc/g1/TestShrinkAuxiliaryData00.java	116	linux-all
+gc/g1/TestShrinkDefragmentedHeap.java	116	linux-all
+gc/g1/TestStringDeduplicationAgeThreshold.java	116	linux-all
+gc/g1/TestStringDeduplicationFullGC.java	116	linux-all
+gc/g1/TestStringDeduplicationInterned.java	116	linux-all
+gc/g1/TestStringDeduplicationPrintOptions.java	116	linux-all
+gc/g1/TestStringDeduplicationTableRehash.java	116	linux-all
+gc/g1/TestStringDeduplicationTableResize.java	116	linux-all
+gc/g1/TestStringDeduplicationYoungGC.java	116	linux-all
+gc/g1/TestStringSymbolTableStats.java	116	linux-all
+gc/logging/TestGCId.java	116	linux-all
+gc/whitebox/TestWBGC.java	116	linux-all
+runtime/ClassUnload/KeepAliveClass.java		120	linux-all
+runtime/ClassUnload/KeepAliveClassLoader.java	120	linux-all
+runtime/ClassUnload/KeepAliveObject.java	120	linux-all
+runtime/ClassUnload/KeepAliveSoftReference.java	120	linux-all
+runtime/ClassUnload/UnloadTest.java	120	linux-all
+runtime/Metaspace/FragmentMetaspaceSimple.java 120	linux-all
+runtime/ErrorHandling/TestCrashOnOutOfMemoryError.java	121	linux-all
+runtime/ErrorHandling/TestExitOnOutOfMemoryError.java	121	linux-all
+runtime/ErrorHandling/TestOnOutOfMemoryError.java	122	linux-all
+runtime/Final/PutfieldError.java	123	linux-all
+runtime/classFileParserBug/BadNameAndType.java	123	linux-all
+runtime/handlerInTry/LoadHandlerInTry.java	123	linux-all
+runtime/stackMapCheck/StackMapCheck.java	123	linux-all
+runtime/NMT/NMTWithCDS.java	124	linux-all
+runtime/memory/ReserveMemory.java	124	linux-all
+runtime/NMT/NMTWithCDS.java	124	linux-all
+serviceability/jvmti/TestRedefineWithUnresolvedClass.java	124	linux-all
 ############################################################################
 
 # jdk_awt
@@ -46,19 +103,27 @@
 ############################################################################
 
 # jdk_beans 
-
-############################################################################
-
-# jdk_core
-
+java/beans/Introspector/Test8027648.java	117	linux-all
+java/beans/PropertyEditor/6380849/TestPropertyEditor.java	117	linux-all
+java/beans/PropertyEditor/TestColorClass.java	117	linux-all
+java/beans/PropertyEditor/TestColorClassJava.java	117	linux-all
+java/beans/PropertyEditor/TestColorClassNull.java	117	linux-all
+java/beans/PropertyEditor/TestColorClassValue.java	117	linux-all
+java/beans/PropertyEditor/TestFontClass.java	117	linux-all
+java/beans/PropertyEditor/TestFontClassJava.java	117	linux-all
+java/beans/PropertyEditor/TestFontClassNull.java	117	linux-all
+java/beans/PropertyEditor/TestFontClassValue.java	117	linux-all
+java/beans/XMLEncoder/java_awt_ScrollPane.java	117	linux-all
 ############################################################################
 
 # jdk_lang
+jdk/lambda/vm/InterfaceAccessFlagsTest.java	126	linux-all
+java/lang/Math/HypotTests.java	128	linux-all
 
 ############################################################################
 
 # jdk_management
-
+com/sun/management/DiagnosticCommandMBean/DcmdMBeanPermissionsTest.java 55	linux-all 
 ############################################################################
 
 # jdk_jmx
@@ -74,7 +139,7 @@
 ############################################################################
 
 # jdk_net
-
+java/net/NetworkInterface/GetMacAddress.java 111 linux-all
 ############################################################################
 
 # jdk_io
@@ -89,19 +154,30 @@ java/io/Serializable/unresolvableObjectStreamClass/UnresolvableObjectStreamClass
 ############################################################################
 
 # jdk_nio
-
+java/nio/Buffer/Basic.java 118	linux-all 
 ############################################################################
 
 # jdk_rmi
+java/rmi/Naming/legalRegistryNames/LegalRegistryNames.java 61	linux-all
 
 ############################################################################
 
 # jdk_security
+sun/security/tools/jarsigner/diffend.sh	113	linux-all
+sun/security/pkcs11/tls/TestKeyMaterial.java	71	linux-all
+sun/security/tools/jarsigner/emptymanifest.sh	114
+sun/security/pkcs11/Signature/TestDSAKeyLength.java	125 linux-all
+sun/security/pkcs11/Secmod/AddTrustedCert.java	125	linux-all
+sun/security/pkcs11/ec/TestECDH.java	125	linux-all
+sun/security/pkcs11/ec/TestECDSA.java	125	linux-all
+sun/security/pkcs11/ec/TestECGenSpec.java	125	linux-all
+sun/security/pkcs11/rsa/TestCACerts.java	125	linux-all
+sun/security/rsa/TestCACerts.java	125	linux-all
 
 ############################################################################
 
 # jdk_sound
-
+javax/sound/midi/Devices/InitializationHang.java 73	linux-all
 ############################################################################
 
 # jdk_swing
@@ -117,6 +193,12 @@ java/io/Serializable/unresolvableObjectStreamClass/UnresolvableObjectStreamClass
 ############################################################################
 
 # jdk_tools
+sun/tools/jstatd/TestJstatdDefaults.java	115	linux-all
+sun/tools/jstatd/TestJstatdExternalRegistry.java	115	linux-all
+sun/tools/jstatd/TestJstatdPort.java	115	linux-all
+sun/tools/jstatd/TestJstatdPortAndServer.java	115	linux-all
+sun/tools/jstatd/TestJstatdServer.java	115	linux-all
+tools/launcher/TestSpecialArgs.java	115	linux-all
 
 ############################################################################
 
@@ -133,5 +215,5 @@ java/io/Serializable/unresolvableObjectStreamClass/UnresolvableObjectStreamClass
 ############################################################################
 
 # jdk_other
-
+javax/xml/ws/8172297/Main.java	119 linux-all
 ############################################################################

--- a/OpenJDK_Playlist/playlist.xml
+++ b/OpenJDK_Playlist/playlist.xml
@@ -37,6 +37,7 @@
 	-w $(Q)$(TEST_RESROOT)$(D)work$(Q) \
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
 	-jdk:$(Q)$(JDK_HOME)$(Q) \
+	-exclude:$(Q)$(TEST_RESROOT)$(D)ProblemList.txt$(Q) \
 	$(Q)$(JTREG_HOTSPOT_TEST_DIR):jre$(Q); \
 	$(TEST_STATUS)</command>
 		<subsets>
@@ -418,25 +419,6 @@
 	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
 	-exclude:$(Q)$(TEST_RESROOT)$(D)ProblemList.txt$(Q) \
 	$(Q)$(JTREG_TEST_DIR):jdk_jfr$(Q); \
-	$(TEST_STATUS)</command>
-		<subsets>
-			<subset>SE80</subset>
-			<subset>SE90</subset>
-		</subsets>
-		<tags>
-			<tag>extended</tag>
-		</tags>
-	</test>
-	<test>
-		<testCaseName>jdk_core</testCaseName>
-		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(JTREG_DIR)$(D)lib$(D)jtreg.jar$(Q) \
-	$(JTREG_BASIC_OPTIONS)  -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
-	-w $(Q)$(TEST_RESROOT)$(D)work$(Q) \
-	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
-	-jdk:$(Q)$(JDK_HOME)$(Q) \
-	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
-	-exclude:$(Q)$(TEST_RESROOT)$(D)ProblemList.txt$(Q) \
-	$(Q)$(JTREG_TEST_DIR):jdk_core$(Q); \
 	$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>

--- a/get.sh
+++ b/get.sh
@@ -33,7 +33,7 @@ else
 	wget -q --no-check-certificate --header 'Cookie: allow-download=1' ${download_url}
 	if [ $? -ne 0 ]; then
 		echo "Failed to retrieve the jdk binary, exiting"
-		exit
+		exit 1
 	fi
 	jar_file_name=`ls`
 	tar -zxf $jar_file_name
@@ -62,7 +62,7 @@ echo 'get jtreg...'
 wget -q --no-check-certificate https://ci.adoptopenjdk.net/job/jtreg/lastSuccessfulBuild/artifact/jtreg-4.2.0-tip.tar.gz
 if [ $? -ne 0 ]; then
 	echo "Failed to retrieve the jtreg binary, exiting"
-exit
+	exit 1
 fi
 tar xf jtreg-4.2.0-tip.tar.gz
 
@@ -75,6 +75,10 @@ if [[ $jvm_version =~ "openjdk9" ]]; then
 fi
 
 git clone -b dev -q https://github.com/AdoptOpenJDK/$openjdkGit.git
+if [ $? -ne 0 ]; then
+	echo "Failed to retrieve the openjdk, exiting"
+	exit 1
+fi
 
 openjdkDir=`ls -d */`
 openjdkDirName=${openjdkDir%?}


### PR DESCRIPTION
1. Open issues for failure tests
2. Exclude failure tests on local
3. Delete jdk_core group
4. Add return code when setting up failed.