### PR TITLE
exclude Scala container test from regular test execution

### DIFF
--- a/Build/docker/mktest.sh
+++ b/Build/docker/mktest.sh
@@ -20,12 +20,14 @@ if [ -d /java/jre/bin ];then
 	export JAVA_BIN=/java/jre/bin
 	export JAVA_HOME=/java
 	export PATH=$JAVA_HOME/bin:$PATH
+	export JAVA_VERSION=SE80
 	java -version
 elif [ -d /java/bin ]; then
 	echo "Using mounted Java9"
 	export JAVA_BIN=/java/bin
 	export JAVA_HOME=/java
 	export PATH=$JAVA_HOME/bin:$PATH
+	export JAVA_VERSION=SE90
 	java -version
 else
 	echo "Using docker image default Java"
@@ -33,13 +35,13 @@ else
 	suffix="/java"
 	java_root=${java_path%$suffix}
 	export JAVA_BIN="$java_root"
+	export JAVA_VERSION=SE80
 	echo "JAVA_BIN is: $JAVA_BIN"
 	$JAVA_BIN/java -version
+
 fi
 
 export SPEC=linux_x86-64
-export JAVA_VERSION=SE80
-
 
 cd /test/TestConfig
 make -f run_configure.mk

--- a/TestConfig/scripts/build_test.xml
+++ b/TestConfig/scripts/build_test.xml
@@ -32,7 +32,7 @@
 			<property name="JAVAC" value="${JAVA_BIN}/../../bin/javac" />
 		</else>
 	</if>
-	
+
 	<var name="build.list" value= "" />
 	<if>
 		<equals arg1="${BUILD_LIST}" arg2=""/>
@@ -43,7 +43,7 @@
 			<for list="${BUILD_LIST}" param="builddir">
 				<sequential>
 					<if>
-						<equals arg1="${build.list}" arg2="" /> 
+						<equals arg1="${build.list}" arg2="" />
 						<then>
 							<var name="build.list" value="@{builddir}/build.xml" />
 						</then>
@@ -67,8 +67,7 @@
 					<property name="JAVA_VERSION" value="${JAVA_VERSION}" />
 					<property name="compiler.javac" value="${JAVAC}" />
 					<fileset dir="../../" includes="${build.list}" >
-						<exclude name="TEST_*/build.xml" />
-						<exclude name="cmd*/build.xml" />
+						<exclude name="thirdparty_containers/build.xml" />
 					</fileset>
 				</subant>
 			</then>
@@ -79,7 +78,6 @@
 					<property name="JAVA_VERSION" value="${JAVA_VERSION}" />
 					<property name="compiler.javac" value="${JAVAC}" />
 					<fileset dir="../../" includes="${build.list}" >
-						<exclude name="TEST_*/build.xml" />
 					</fileset>
 				</subant>
 			</else>

--- a/TestConfig/scripts/testKitGen/makeGenTool/mkgen.pl
+++ b/TestConfig/scripts/testKitGen/makeGenTool/mkgen.pl
@@ -16,7 +16,7 @@ use Data::Dumper;
 use feature 'say';
 
 use constant DEBUG => 0;
- 
+
 my @allGroups = ( "sanity", "extended", "promotion", "openjdk" );
 
 my $headerComments =
@@ -43,7 +43,7 @@ sub runmkgen {
 	my $modesxml = $_[4];
 	my $ottawacsv = $_[5];
 	my $includeModesService = 1;
-	
+
 	if ( exists $ENV{'JCL_VERSION'} ) {
 		$JCL_VERSION = $ENV{'JCL_VERSION'};
 	} else {
@@ -59,7 +59,7 @@ sub runmkgen {
 			$sp_hs = getDataFromService('http://testmgmt.stage1.mybluemix.net/modesDictionaryService/getSpecPlatMapping', 'spec');
 		};
 	}
-	
+
 	if (!(($serviceResponse) && (%{$modes_hs}) && (%{$sp_hs}))) {
 		print "Cannot get data from modes service! Getting data from modes.xml and ottawa.csv...\n";
 		require "parseFiles.pl";
@@ -67,9 +67,9 @@ sub runmkgen {
 		$modes_hs = $data->{'modes'};
 		$sp_hs = $data->{'specPlatMapping'};
 	}
-	
+
 	generateOnDir();
-	
+
 	my $specToPlatmk = $projectRootDir . "/TestConfig/specToPlat.mk";
 	my $jvmTestmk = $projectRootDir . "/TestConfig/jvmTest.mk";
 	if ($output) {
@@ -78,10 +78,10 @@ sub runmkgen {
 		$specToPlatmk = $outputdir . "/specToPlat.mk";
 		$jvmTestmk = $outputdir . "/jvmTest.mk";
 	}
-	
+
 	specToPlatGen( $specToPlatmk, $graphSpecs );
 	print "\nGenerated $specToPlatmk\n";
-	
+
 	jvmTestGen( $jvmTestmk, \%tests, $allSubsets );
 	print "Generated $jvmTestmk\n";
 	return \%tests;
@@ -99,7 +99,7 @@ sub generateOnDir {
 	while ( my $entry = readdir $dir ) {
 		next if $entry eq '.' or $entry eq '..';
 		# temporarily exclude projects for CCM build (i.e., when JCL_VERSION is latest)
-		my $disabledDir = "cmdline_options_tester cmdline_options_testresources cmdLineTests JLM_Tests Jsr292 Jsr335";
+		my $disabledDir = "thirdparty_containers";
 		if (($JCL_VERSION ne "latest") or ($disabledDir !~ $entry )) {
 			my $projectDir  = $absolutedir . '/' . $entry;
 			if (( -f $projectDir ) && ( $entry eq 'playlist.xml' )) {
@@ -291,7 +291,7 @@ sub genMK {
 					$condition = "$name\_INVALID_PLATFORM_CHECK";
 					print $fhOut "$condition=\$(filter $string, \$(SPEC))\n";
 				}
-				
+
 				my $jvmtestroot = "\$(JVM_TEST_ROOT)\$(D)" . join("\$(D)", @{$currentdirs}) . "\$(D)$subset";
 				print $fhOut "$name: TEST_RESROOT=$jvmtestroot\n";
 
@@ -301,8 +301,8 @@ sub genMK {
 					print $fhOut "$name: JVM_OPTIONS=\$(RESERVED_OPTIONS) \$(EXTRA_OPTIONS)\n";
 				}
 
-				print $fhOut "$name: TEST_GROUP=level.$group\n"; 
-	
+				print $fhOut "$name: TEST_GROUP=level.$group\n";
+
 				my $indent .= "\t";
 				print $fhOut "$name:\n";
 				print $fhOut "$indent\@echo \"\" | tee -a TestTargetResult;\n";
@@ -312,7 +312,7 @@ sub genMK {
 				if ($condition) {
 					print $fhOut "ifeq (\$($condition),)\n";
 				}
-	
+
 				if ($jvmoptions) {
 					print $fhOut "$indent\@echo \"test with $var\" | tee -a TestTargetResult;\n";
 				}
@@ -368,9 +368,9 @@ sub genMK {
 			}
 		}
 		if ($isempty == 1) {
-			print $fhOut ";";	
+			print $fhOut ";";
 		}
-		
+
 		print $fhOut "\n";
 	}
 
@@ -378,7 +378,7 @@ sub genMK {
 
 	close $fhOut;
 	print "Generated $makeFile\n";
-	
+
 	return \%project;
 }
 
@@ -456,7 +456,7 @@ sub specToPlatGen {
 	my ( $specToPlatmk ) = @_;
 	open( my $fhOut, '>', $specToPlatmk ) or die "Cannot create file $specToPlatmk";
 	print $fhOut $headerComments;
-	
+
 	print $fhOut "PLATFORM=\n";
 	my $spec2platform = '';
 	my @graphSpecs_arr = split( ',', $graphSpecs );
@@ -521,7 +521,7 @@ sub subdir2make {
 		make_path($outputdir);
 		$makeFile = $outputdir . "/" . $mkName;
 	}
-	
+
 	open( my $fhOut, '>', $makeFile ) or die "Cannot create make file $makeFile";
 	my $mkname = basename($makeFile);
 	my %project = ();


### PR DESCRIPTION
* scala container test should only run with BUILD_LIST declared
* scala container test should be excluded from regular test execution
* strict scala container test into JCL_VERSION=current 

Fixes:#138 
Signed-off-by: Tianyu Zuo <tianyu@ca.ibm.com>