### PR TITLE
Support releases, nightly and upstream different build version

### DIFF
--- a/buildenv/jenkins/Jenkinsfile
+++ b/buildenv/jenkins/Jenkinsfile
@@ -7,6 +7,9 @@ pipeline {
 		choice (choices: 'openjdk9-openj9\nopenjdk9\nopenjdk8', description: 'What is JVM Version?', name: 'JVM_VERSION')
 		choice (choices: 'openjdk\nsanity\nextended\nruntest', description: 'What is test level?', name: 'TARGET')
 		choice (choices: 'linux\nmac', description: 'What is machine label?', name: 'MACHINE_LABEL')
+		choice (choices: 'releases\nnightly\nupstream', description: 'Where is sdk?', name: 'SDK_RESOURCE')
+		string (defaultValue: "N/A", description: 'Upstream build name, only set when choose SDK_RESOURCE as upstream', name: 'UPSTREAM_JOB_NAME')
+		string (defaultValue: "N/A", description: 'Build number of upstream build, working with UPSTREAM_JOB_NAME, only set when choose SDK_RESOURCE as upstream', name: 'UPSTREAM_JOB_NUMBER')
 		}
 	environment {
                 JCL_VERSION='current'
@@ -31,8 +34,17 @@ pipeline {
                 				deleteDir()
                 			}
                 		}
+                		if (params.SDK_RESOURCE == 'upstream') {
+                			dir('openjdkbinary') {
+	                			step([$class: 'CopyArtifact',
+	                        		fingerprintArtifacts: true,
+	                        		projectName: "${params.UPSTREAM_JOB_NAME}",
+	                        		selector: [$class: 'SpecificBuildSelector',
+	                                buildNumber: "${params.UPSTREAM_JOB_NUMBER}"]])
+                            }
+            			}
                 	}
-                	sh "$OPENJDK_TEST/get.sh -s $WORKSPACE -t $OPENJDK_TEST -p ${params.PLATFORM} -v ${params.JVM_VERSION}"
+                	sh "$OPENJDK_TEST/get.sh -s $WORKSPACE -t $OPENJDK_TEST -p ${params.PLATFORM} -v ${params.JVM_VERSION} -r ${params.SDK_RESOURCE} "
 					}
                 }
         }

--- a/get.sh
+++ b/get.sh
@@ -16,6 +16,7 @@ SDKDIR=""
 TESTDIR=""
 PLATFORM=""
 JVMVERSION=""
+SDK_RESOURCE="nightly"
 SYSTEMTEST=false
 
 usage ()
@@ -23,8 +24,9 @@ usage ()
 	echo 'Usage : get.sh  --testdir|-t openjdktestdir'
 	echo '                --platform|-p x64_linux | x64_mac | s390x_linux | ppc64le_linux | aarch64_linux'
 	echo '                --jvmversion|-v openjdk9-openj9 | openjdk9 | openjdk8'
-	echo '                [--sdkdir|-s binarySDKDIR] : if donot have a local sdk available, specify preferred directory'
+	echo '                [--sdkdir|-s binarySDKDIR] : if do not have a local sdk available, specify preferred directory'
 	echo '                [--systemtest|-S ] : indicate need system test materials'
+	echo '                [--sdk_resource|-r ] : indicate where to get sdk - releases, nightly or upstream'
 }
 
 parseCommandLineArgs()
@@ -45,6 +47,9 @@ parseCommandLineArgs()
 			"--jvmversion" | "-v" )
 				JVMVERSION="$1"; shift;;
 
+			"--sdk_resource" | "-r" )
+				SDK_RESOURCE="$1"; shift;;
+
 			"--systemtest" | "-S" )
 				SYSTEMTEST=true;;
 
@@ -58,16 +63,18 @@ parseCommandLineArgs()
 
 getBinaryOpenjdk()
 {
-	echo 'Get binary openjdk...'
 	cd $SDKDIR
-	mkdir openjdkbinary
-	cd openjdkbinary
-	download_url="https://api.adoptopenjdk.net/$JVMVERSION/releases/$PLATFORM/latest/binary"
-	wget -q --no-check-certificate --header 'Cookie: allow-download=1' ${download_url}
-	if [ $? -ne 0 ]; then
-		echo "Failed to retrieve the jdk binary, exiting"
-		exit 1
+	if [ "$SDK_RESOURCE" != "upstream" ]; then
+		echo 'Get binary openjdk...'
+		mkdir openjdkbinary
+		download_url="https://api.adoptopenjdk.net/$JVMVERSION/$SDK_RESOURCE/$PLATFORM/latest/binary"
+		wget --no-check-certificate --header 'Cookie: allow-download=1' ${download_url} --directory-prefix=${SDKDIR}/openjdkbinary
+		if [ $? -ne 0 ]; then
+			echo "Failed to retrieve the jdk binary, exiting"
+			exit 1
+		fi
 	fi
+	cd openjdkbinary
 	jar_file_name=`ls`
 	tar -zxf $jar_file_name
 	jarDir=`ls -d */`


### PR DESCRIPTION
Support grab sdk from adoptOpenjdk API releases or nightly build.
Also support grab sdk from specific sdk build, which could also be used by upstream build to automatically trigger build.
 
Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>