### PR TITLE
Changes to ProblemList.txt

### DIFF
--- a/openjdk_regression/ProblemList.txt
+++ b/openjdk_regression/ProblemList.txt
@@ -203,8 +203,7 @@ java/nio/channels/SocketChannel/Connect.java	156	macosx-all
 ############################################################################
 
 # jdk_rmi
-java/rmi/Naming/legalRegistryNames/LegalRegistryNames.java 61	linux-all
-java/rmi/registry/serialFilter/RegistryFilterTest.java	61 generic-all
+java/rmi/registry/serialFilter/RegistryFilterTest.java	61 macosx-all
 java/rmi/activation/rmidViaInheritedChannel/InheritedChannelNotServerSocket.java 154 macosx-all
 
 ############################################################################


### PR DESCRIPTION
- Removing java/rmi/Naming/legalRegistryNames/LegalRegistryNames.java from the problem list file as the test is working fine on Linux x86-64
- Marking java/rmi/registry/serialFilter/RegistryFilterTest as failure only on Mac as per comments in issue #61

Signed-off-by: sabkrish <sabkrish@in.ibm.com>