### PR TITLE
Add openjdk8-openj9 as a valid release to run tests against

### DIFF
--- a/buildenv/jenkins/Jenkinsfile
+++ b/buildenv/jenkins/Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
     parameters {
 		choice (choices: 'x64_linux\nx64_mac\ns390x_linux\nppc64le_linux\naarch64_linux', description: 'PLATFORM?', name: 'PLATFORM')
 		choice (choices: 'SE90\nSE80', description: 'What is JAVA_VERSION?', name: 'JAVA_VERSION')
-		choice (choices: 'openjdk9-openj9\nopenjdk9\nopenjdk8', description: 'What is JVM Version?', name: 'JVM_VERSION')
+		choice (choices: 'openjdk9-openj9\nopenjdk8-openj9\nopenjdk9\nopenjdk8', description: 'What is JVM Version?', name: 'JVM_VERSION')
 		choice (choices: 'openjdk\nsanity\nextended\nruntest', description: 'What is test level?', name: 'TARGET')
 		choice (choices: 'linux\nmac', description: 'What is machine label?', name: 'MACHINE_LABEL')
 		choice (choices: 'releases\nnightly\nupstream', description: 'Where is sdk?', name: 'SDK_RESOURCE')

--- a/buildenv/jenkins/Jenkinsfile_openjdk-systemtest
+++ b/buildenv/jenkins/Jenkinsfile_openjdk-systemtest
@@ -3,7 +3,7 @@ pipeline {
     agent {label "linux&&x64&&test"}
     parameters {
 		choice (choices: 'SE90\nSE80', description: 'What is JAVA_VERSION?', name: 'JAVA_VERSION')
-		choice (choices: 'openjdk9-openj9\nopenjdk9\nopenjdk8', description: 'What is JVM Version?', name: 'JVM_VERSION')
+		choice (choices: 'openjdk9-openj9\nopenjdk8-openj9\nopenjdk9\nopenjdk8', description: 'What is JVM Version?', name: 'JVM_VERSION')
 		string(defaultValue: "", description: '(Optional) To run tests individually, please provide a comma separated list of test targets from the list : {' + 
 			'ClassLoadingTest, ConcurrentLoadTest, DirectByteBufferLoadTest, ' + 
 				'LangLoadTest, LockingLoadTest, MathLoadTest_all, MathLoadTest_autosimd, ' + 


### PR DESCRIPTION
This gets validated by jenkinsfile (modified), and passed to go.sh, which uses it for a check that should be compatible with this new value.

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>