### PR TITLE
Re-disable java/rmi/Naming/legalRegistryNames/LegalRegistryNames.java

### DIFF
--- a/openjdk_regression/ProblemList.txt
+++ b/openjdk_regression/ProblemList.txt
@@ -203,6 +203,7 @@ java/nio/channels/SocketChannel/Connect.java	156	macosx-all
 ############################################################################
 
 # jdk_rmi
+java/rmi/Naming/legalRegistryNames/LegalRegistryNames.java 61	linux-all
 java/rmi/registry/serialFilter/RegistryFilterTest.java	61 macosx-all
 java/rmi/activation/rmidViaInheritedChannel/InheritedChannelNotServerSocket.java 154 macosx-all
 


### PR DESCRIPTION
Re-disabel java/rmi/Naming/legalRegistryNames/LegalRegistryNames.java on
linux, which failed 50% in recent test builds

https://ci.adoptopenjdk.net/view/OpenJDK%20tests/job/openjdk8_test_x86-64_linux/76/

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>