### PR TITLE
Refactor adoptopenjdk dependency

### DIFF
--- a/TestConfig/makefile
+++ b/TestConfig/makefile
@@ -207,7 +207,6 @@ endif
 # common dir and jars
 #######################################
 LIB_DIR=$(JVM_TEST_ROOT)$(D)TestConfig$(D)lib
-TESTNG=$(LIB_DIR)$(D)TestNG$(D)testng.jar$(P)$(LIB_DIR)$(D)TestNG$(D)jcommander.jar
 JUNIT=$(LIB_DIR)$(D)junit-4.10.jar
 RESOURCES_DIR=$(JVM_TEST_ROOT)$(D)TestConfig$(D)resources
 

--- a/example/build.xml
+++ b/example/build.xml
@@ -14,12 +14,20 @@
 	<property name="build" location="./bin" />
 	<property name="transformerListener" location="../utils/src"/>
 
+	<target name="getTestNG" depends="init">
+		<exec executable="wget" failonerror="false">
+			<arg line="wget -q --output-document=testng.jar http://central.maven.org/maven2/org/testng/testng/6.10/testng-6.10.jar" />
+		</exec>
+		<exec executable="wget" failonerror="false">
+			<arg line="wget -q --output-document=jcommander.jar http://central.maven.org/maven2/com/beust/jcommander/1.48/jcommander-1.48.jar" />
+		</exec>
+	</target>
 	<target name="init">
 		<mkdir dir="${dist}" />
 		<mkdir dir="${build}" />
 	</target>
 
-	<target name="compile" depends="init" description="Using ${JAVA_VERSION} java compile the source  ">
+	<target name="compile" depends="getTestNG" description="Using ${JAVA_VERSION} java compile the source  ">
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
 		<echo>===fork:				yes</echo>
@@ -30,8 +38,8 @@
 			<src path="${src}" />
 			<src path="${transformerListener}" />
 			<classpath>
-				<pathelement location="../TestConfig/lib/TestNG/testng.jar" />
-				<pathelement location="../TestConfig/lib/TestNG/jcommander.jar" />
+				<pathelement location="testng.jar" />
+				<pathelement location="jcommander.jar" />
 			</classpath>
 		</javac>
 	</target>
@@ -42,7 +50,7 @@
 			<fileset dir="${src}/../" includes="*.properties,*.xml" />
 		</jar>
 		<copy todir="${dist}">
-			<fileset dir="${src}/../" includes="*.xml" />
+			<fileset dir="${src}/../" includes="*.xml,*.jar" />
 		</copy>
 		<copy todir="${DEST}">
 			<fileset dir="${src}/../" includes="*.mk" />

--- a/example/playlist.xml
+++ b/example/playlist.xml
@@ -19,7 +19,7 @@
 			<variation>-Xint</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
-	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)example.jar$(Q) \
+	-cp $(Q)$(RESOURCES_DIR)$(P)$(TEST_RESROOT)$(D)testng.jar$(P)$(TEST_RESROOT)$(D)jcommander.jar$(P)$(TEST_RESROOT)$(D)example.jar$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames exampleTest \
 	-groups $(TEST_GROUP) \
 	-excludegroups $(DEFAULT_EXCLUDE); \
@@ -39,7 +39,7 @@
 			<variation>-Xint</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
-	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)example.jar$(Q) \
+	-cp $(Q)$(RESOURCES_DIR)$(P)$(TEST_RESROOT)$(D)testng.jar$(P)$(TEST_RESROOT)$(D)jcommander.jar$(P)$(TEST_RESROOT)$(D)example.jar$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames exampleTest \
 	-groups $(TEST_GROUP) \
 	-excludegroups $(DEFAULT_EXCLUDE); \

--- a/get.sh
+++ b/get.sh
@@ -96,42 +96,7 @@ getTestDependencies()
 	mkdir lib
 	cd lib
 	echo 'Get third party libs...'
-	wget -q --output-document=asm-all-5.0.1.jar http://download.forge.ow2.org/asm/asm-5.0.1.jar
 	wget -q https://downloads.sourceforge.net/project/junit/junit/4.10/junit-4.10.jar
-
-	echo 'get jtreg...'
-	wget -q --no-check-certificate https://ci.adoptopenjdk.net/job/jtreg/lastSuccessfulBuild/artifact/jtreg-4.2.0-tip.tar.gz
-	if [ $? -ne 0 ]; then
-		echo "Failed to retrieve the jtreg binary, exiting"
-		exit 1
-	fi
-	tar xf jtreg-4.2.0-tip.tar.gz
-
-	mkdir TestNG
-	cd TestNG
-	wget -q --output-document=testng.jar http://central.maven.org/maven2/org/testng/testng/6.10/testng-6.10.jar
-	wget -q --output-document=jcommander.jar http://central.maven.org/maven2/com/beust/jcommander/1.48/jcommander-1.48.jar
-}
-
-getOpenjdk()
-{
-	cd $TESTDIR/openjdk_regression
-	echo 'Get openjdk...'
-
-	openjdkGit="openjdk-jdk8u"
-	if [[ $JVMVERSION =~ "openjdk9" ]]; then
-		openjdkGit="openjdk-jdk9"
-	fi
-
-	git clone -b dev -q https://github.com/AdoptOpenJDK/$openjdkGit.git
-	if [ $? -ne 0 ]; then
-		echo "Failed to retrieve the openjdk, exiting"
-		exit 1
-	fi
-
-	openjdkDir=`ls -d */`
-	openjdkDirName=${openjdkDir%?}
-	mv $openjdkDirName openjdk-jdk
 }
 
 parseCommandLineArgs "$@"
@@ -139,4 +104,3 @@ if [[ "$SDKDIR" != "" ]]; then
 	getBinaryOpenjdk
 fi
 getTestDependencies
-getOpenjdk

--- a/openjdk_regression/build.xml
+++ b/openjdk_regression/build.xml
@@ -9,12 +9,31 @@
 	<property name="DEST" value="${BUILD_ROOT}/openjdk_regression" />
 	<property name="dist" location="${DEST}/${JAVA_VERSION}" />
 	<property name="src" location="." />
-
-	<target name="init">
+	<condition property="openjdkGit" value="openjdk-jdk8u" else="openjdk-jdk9">
+		<equals arg1="${JAVA_VERSION}" arg2="SE80"/>
+	</condition>
+	<condition property="openjdkDir" value="openjdk-jdk8u" else="openjdk-jdk9">
+		<equals arg1="${JAVA_VERSION}" arg2="SE80"/>
+	</condition>
+	
+	<target name="getJtreg">
 		<mkdir dir="${dist}"/>
+		<exec executable="wget" failonerror="false">
+			<arg line="-q --no-check-certificate https://ci.adoptopenjdk.net/job/jtreg/lastSuccessfulBuild/artifact/jtreg-4.2.0-tip.tar.gz" />
+		</exec>
+		<exec executable="tar" failonerror="false">
+			<arg line="xf jtreg-4.2.0-tip.tar.gz -C ${dist}" />
+		</exec>
 	</target>
-
-	<target name="dist" depends="init" description="generate the distribution">
+	
+	<target name="getOpenjdk">
+		<exec executable="git" failonerror="false">
+			<arg line="clone -b dev -q https://github.com/AdoptOpenJDK/${openjdkGit}.git" />
+		</exec>
+		<move file="${openjdkDir}" tofile="openjdk-jdk"/>
+	</target>
+	
+	<target name="dist" depends="getJtreg, getOpenjdk" description="generate the distribution">
 		<copy todir="${dist}">
 			<fileset dir="${src}" includes="*.xml, ProblemList*.txt"/>
 		</copy>

--- a/openjdk_regression/playlist.xml
+++ b/openjdk_regression/playlist.xml
@@ -15,7 +15,7 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
 	<test>
 		<testCaseName>hotspot_all</testCaseName>
-		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(JTREG_DIR)$(D)lib$(D)jtreg.jar$(Q) \
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
 	$(JTREG_BASIC_OPTIONS) -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
 	-w $(Q)$(TEST_RESROOT)$(D)work$(Q) \
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
@@ -32,7 +32,7 @@
 	</test>
 	<test>
 		<testCaseName>hotspot_jre</testCaseName>
-		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(JTREG_DIR)$(D)lib$(D)jtreg.jar$(Q) \
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
 	$(JTREG_BASIC_OPTIONS) -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
 	-w $(Q)$(TEST_RESROOT)$(D)work$(Q) \
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
@@ -50,7 +50,7 @@
 	</test>
 	<test>
 		<testCaseName>jdk_beans</testCaseName>
-		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(JTREG_DIR)$(D)lib$(D)jtreg.jar$(Q) \
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
 	$(JTREG_BASIC_OPTIONS) -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
 	-w $(Q)$(TEST_RESROOT)$(D)work$(Q) \
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
@@ -69,7 +69,7 @@
 	</test>
 	<test>
 		<testCaseName>jdk_io</testCaseName>
-		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(JTREG_DIR)$(D)lib$(D)jtreg.jar$(Q) \
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
 	$(JTREG_BASIC_OPTIONS)  -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
 	-w $(Q)$(TEST_RESROOT)$(D)work$(Q) \
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
@@ -88,7 +88,7 @@
 	</test>
 	<test>
 		<testCaseName>jdk_lang</testCaseName>
-		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(JTREG_DIR)$(D)lib$(D)jtreg.jar$(Q) \
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
 	$(JTREG_BASIC_OPTIONS)  -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
 	-w $(Q)$(TEST_RESROOT)$(D)work$(Q) \
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
@@ -107,7 +107,7 @@
 	</test>
 	<test>
 		<testCaseName>jdk_math</testCaseName>
-		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(JTREG_DIR)$(D)lib$(D)jtreg.jar$(Q) \
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
 	$(JTREG_BASIC_OPTIONS)  -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
 	-w $(Q)$(TEST_RESROOT)$(D)work$(Q) \
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
@@ -126,7 +126,7 @@
 	</test>
 	<test>
 		<testCaseName>jdk_other</testCaseName>
-		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(JTREG_DIR)$(D)lib$(D)jtreg.jar$(Q) \
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
 	$(JTREG_BASIC_OPTIONS)  -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
 	-w $(Q)$(TEST_RESROOT)$(D)work$(Q) \
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
@@ -145,7 +145,7 @@
 	</test>
 	<test>
 		<testCaseName>jdk_net</testCaseName>
-		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(JTREG_DIR)$(D)lib$(D)jtreg.jar$(Q) \
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
 	$(JTREG_BASIC_OPTIONS)  -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
 	-w $(Q)$(TEST_RESROOT)$(D)work$(Q) \
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
@@ -164,7 +164,7 @@
 	</test>
 	<test>
 		<testCaseName>jdk_nio</testCaseName>
-		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(JTREG_DIR)$(D)lib$(D)jtreg.jar$(Q) \
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
 	$(JTREG_BASIC_OPTIONS)  -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
 	-w $(Q)$(TEST_RESROOT)$(D)work$(Q) \
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
@@ -183,7 +183,7 @@
 	</test>
 	<test>
 		<testCaseName>jdk_security1</testCaseName>
-		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(JTREG_DIR)$(D)lib$(D)jtreg.jar$(Q) \
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
 	$(JTREG_BASIC_OPTIONS)  -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
 	-w $(Q)$(TEST_RESROOT)$(D)work$(Q) \
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
@@ -202,7 +202,7 @@
 	</test>
 	<test>
 		<testCaseName>jdk_security2</testCaseName>
-		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(JTREG_DIR)$(D)lib$(D)jtreg.jar$(Q) \
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
 	$(JTREG_BASIC_OPTIONS)  -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
 	-w $(Q)$(TEST_RESROOT)$(D)work$(Q) \
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
@@ -221,7 +221,7 @@
 	</test>
 		<test>
 		<testCaseName>jdk_security3</testCaseName>
-		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(JTREG_DIR)$(D)lib$(D)jtreg.jar$(Q) \
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
 	$(JTREG_BASIC_OPTIONS)  -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
 	-w $(Q)$(TEST_RESROOT)$(D)work$(Q) \
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
@@ -240,7 +240,7 @@
 	</test>
 	<test>
 		<testCaseName>jdk_text</testCaseName>
-		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(JTREG_DIR)$(D)lib$(D)jtreg.jar$(Q) \
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
 	$(JTREG_BASIC_OPTIONS)  -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
 	-w $(Q)$(TEST_RESROOT)$(D)work$(Q) \
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
@@ -259,7 +259,7 @@
 	</test>
 	<test>
 		<testCaseName>jdk_util</testCaseName>
-		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(JTREG_DIR)$(D)lib$(D)jtreg.jar$(Q) \
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
 	$(JTREG_BASIC_OPTIONS)  -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
 	-w $(Q)$(TEST_RESROOT)$(D)work$(Q) \
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
@@ -278,7 +278,7 @@
 	</test>
 	<test>
 		<testCaseName>jdk_time</testCaseName>
-		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(JTREG_DIR)$(D)lib$(D)jtreg.jar$(Q) \
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
 	$(JTREG_BASIC_OPTIONS)  -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
 	-w $(Q)$(TEST_RESROOT)$(D)work$(Q) \
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
@@ -297,7 +297,7 @@
 	</test>
 	<test>
 		<testCaseName>jdk_management</testCaseName>
-		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(JTREG_DIR)$(D)lib$(D)jtreg.jar$(Q) \
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
 	$(JTREG_BASIC_OPTIONS)  -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
 	-w $(Q)$(TEST_RESROOT)$(D)work$(Q) \
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
@@ -316,7 +316,7 @@
 	</test>
 	<test>
 		<testCaseName>jdk_jmx</testCaseName>
-		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(JTREG_DIR)$(D)lib$(D)jtreg.jar$(Q) \
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
 	$(JTREG_BASIC_OPTIONS)  -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
 	-w $(Q)$(TEST_RESROOT)$(D)work$(Q) \
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
@@ -335,7 +335,7 @@
 	</test>
 	<test>
 		<testCaseName>jdk_rmi</testCaseName>
-		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(JTREG_DIR)$(D)lib$(D)jtreg.jar$(Q) \
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
 	$(JTREG_BASIC_OPTIONS)  -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
 	-w $(Q)$(TEST_RESROOT)$(D)work$(Q) \
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
@@ -354,7 +354,7 @@
 	</test>
 	<test>
 		<testCaseName>jdk_sound</testCaseName>
-		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(JTREG_DIR)$(D)lib$(D)jtreg.jar$(Q) \
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
 	$(JTREG_BASIC_OPTIONS)  -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
 	-w $(Q)$(TEST_RESROOT)$(D)work$(Q) \
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
@@ -373,7 +373,7 @@
 	</test>
 	<test>
 		<testCaseName>jdk_tools</testCaseName>
-		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(JTREG_DIR)$(D)lib$(D)jtreg.jar$(Q) \
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
 	$(JTREG_BASIC_OPTIONS)  -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
 	-w $(Q)$(TEST_RESROOT)$(D)work$(Q) \
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
@@ -392,7 +392,7 @@
 	</test>
 	<test>
 		<testCaseName>jdk_jdi</testCaseName>
-		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(JTREG_DIR)$(D)lib$(D)jtreg.jar$(Q) \
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
 	$(JTREG_BASIC_OPTIONS)  -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
 	-w $(Q)$(TEST_RESROOT)$(D)work$(Q) \
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
@@ -411,7 +411,7 @@
 	</test>
 	<test>
 		<testCaseName>jdk_jfr</testCaseName>
-		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(JTREG_DIR)$(D)lib$(D)jtreg.jar$(Q) \
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
 	$(JTREG_BASIC_OPTIONS)  -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
 	-w $(Q)$(TEST_RESROOT)$(D)work$(Q) \
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \


### PR DESCRIPTION
Move category based tests dependency to each own folder
Keep repo level get.sh focous on repo dependency

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>