### PR TITLE
enabling testKitGen to run STF based JCK test

### DIFF
--- a/TestConfig/makefile
+++ b/TestConfig/makefile
@@ -285,7 +285,7 @@ endif
 $(info set JAVA_VERSION to $(JAVA_VERSION))
 # compile all tests under $(SRC_ROOT)
 compile:
-	ant -f $(SRC_ROOT)$(D)TestConfig$(D)scripts$(D)build_test.xml -DSRC_ROOT=$(SRC_ROOT) -DBUILD_ROOT=$(BUILD_ROOT) -DJAVA_BIN=$(JAVA_BIN) -DJAVA_VERSION=$(JAVA_VERSION) -DJCL_VERSION=$(JCL_VERSION) -DBUILD_LIST=${BUILD_LIST}
+	ant -f $(SRC_ROOT)$(D)TestConfig$(D)scripts$(D)build_test.xml -DSRC_ROOT=$(SRC_ROOT) -DBUILD_ROOT=$(BUILD_ROOT) -DJAVA_BIN=$(JAVA_BIN) -DJAVA_VERSION=$(JAVA_VERSION) -DJCL_VERSION=$(JCL_VERSION) -DBUILD_LIST=${BUILD_LIST} -DJCK_ROOT=${JCK_ROOT}
 
 #######################################
 # failed target

--- a/TestConfig/scripts/testKitGen/makeGenTool/mkgen.pl
+++ b/TestConfig/scripts/testKitGen/makeGenTool/mkgen.pl
@@ -17,7 +17,7 @@ use feature 'say';
 
 use constant DEBUG => 0;
 
-my @allGroups = ( "sanity", "extended", "promotion", "openjdk", "system" );
+my @allGroups = ( "sanity", "extended", "promotion", "openjdk", "system", "jck" );
 
 my $headerComments =
 	"########################################################\n"

--- a/jck/README.md
+++ b/jck/README.md
@@ -1,0 +1,22 @@
+
+# How-to Run JCK Tests
+
+* Prerequisites:
+  * JCK test materials (JCK test source): jck8b or jck9
+  * ant 1.10.1 or above with ant-contrib.jar
+
+
+
+1. Put unarchived jck test materials (jck8b or jck9) into an empty folder, for example:
+* `/jck/jck8b/` and `/jck/jck9`
+
+2. Export `JCK_ROOT=/jck` as an environment variable or pass it in makefile when run make command
+
+3. Export `JAVA_HOME=<your_JDK_root>` as an environment variable
+
+4. The other steps will stay the same as instructed in `openj9/test/README.md`
+
+
+This test directory contains:
+  * build.xml file - that clones AdoptOpenJDK/stf repo to pick up a test framework
+  * playlist.xml - to allow easy inclusion of JCK tests into automated builds

--- a/jck/build.xml
+++ b/jck/build.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0"?>
+<project name="jck" default="build" basedir=".">
+	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+	<description>Build STF based JCK Tests </description>
+
+	<!-- set global properties for this build -->
+	<property name="SYSTEMTEST_ROOT" value="${basedir}/../systemtest" />
+	<property name="DEST" value="${BUILD_ROOT}/jck" />
+	<property name="dist" location="${DEST}/${JAVA_VERSION}" />
+	<property name="SYSTEMTEST_BUILD_ROOT" value="${BUILD_ROOT}/systemtest/${JAVA_VERSION}" />
+	<property environment="env" />
+
+	<target name="init">
+		<mkdir dir="${dist}" />
+		<if>
+			<not>
+				<available file="${SYSTEMTEST_BUILD_ROOT}" type="dir" />
+			</not>
+			<then>
+				<mkdir dir="${SYSTEMTEST_BUILD_ROOT}" />
+			</then>
+		</if>
+	</target>
+
+	<target name="clone_stf">
+		<exec executable="git" failonerror="false">
+			<arg value="clone" />
+			<arg value="--depth" />
+			<arg value="1" />
+			<arg value="--single-branch" />
+			<arg value="https://github.com/AdoptOpenJDK/stf.git" />
+			<arg value="${SYSTEMTEST_ROOT}/stf" />
+		</exec>
+	</target>
+
+	<target name="clone_systemtest">
+		<exec executable="git" failonerror="false">
+			<arg value="clone" />
+			<arg value="--depth" />
+			<arg value="1" />
+			<arg value="--single-branch" />
+			<arg value="https://github.com/AdoptOpenJDK/openjdk-systemtest.git" />
+			<arg value="${SYSTEMTEST_ROOT}/openjdk-systemtest" />
+		</exec>
+	</target>
+
+	<target name="check_systemtest" depends="init">
+		<if>
+			<not>
+				<available file="${SYSTEMTEST_ROOT}/stf" type="dir" />
+			</not>
+			<then>
+				<echo message="${SYSTEMTEST_ROOT}/stf does not exist, clone from GitHub" />
+				<antcall target="clone_stf" inheritall="true" />
+			</then>
+			<else>
+				<echo message="${SYSTEMTEST_ROOT}/stf exists, skip cloning" />
+			</else>
+		</if>
+		<if>
+			<not>
+				<available file="${SYSTEMTEST_ROOT}/openjdk-systemtest" type="dir" />
+			</not>
+			<then>
+				<echo message="${SYSTEMTEST_ROOT}/openjdk-systemtest does not exist, clone from GitHub" />
+				<antcall target="clone_systemtest" inheritall="true" />
+			</then>
+			<else>
+				<echo message="${SYSTEMTEST_ROOT}/openjdk-systemtest exists, skip cloning" />
+			</else>
+		</if>
+	</target>
+
+	<target name="configure_stf" depends="check_systemtest">
+		<ant antfile="${SYSTEMTEST_ROOT}/stf/stf.build/build.xml" dir="${SYSTEMTEST_ROOT}/stf/stf.build/" target="configure" inheritAll="false" />
+		<ant antfile="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build/build.xml" dir="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build/" target="configure" inheritAll="false" />
+	</target>
+
+	<target name="compile_stf" depends="configure_stf">
+		<ant antfile="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build/build.xml" dir="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build" inheritAll="false" />
+	</target>
+
+	<target name="dist" depends="compile_stf" description="generate the distribution">
+		<if>
+			<not>
+				<available file="${SYSTEMTEST_BUILD_ROOT}/openjdk-systemtest" type="dir" />
+			</not>
+			<then>
+				<copy todir="${SYSTEMTEST_BUILD_ROOT}/stf">
+					<fileset dir="${SYSTEMTEST_ROOT}/stf" includes="**" />
+				</copy>
+				<copy todir="${SYSTEMTEST_BUILD_ROOT}/openjdk-systemtest">
+					<fileset dir="${SYSTEMTEST_ROOT}/openjdk-systemtest" includes="**" />
+				</copy>
+				<copy todir="${SYSTEMTEST_BUILD_ROOT}/systemtest_prereqs/">
+					<fileset dir="${basedir}/../systemtest_prereqs/" includes="**" />
+				</copy>
+			</then>
+		</if>
+		<copy todir="${DEST}">
+			<fileset dir="${basedir}" includes="*.mk" />
+		</copy>
+		<copy todir="${dist}">
+			<fileset dir="${basedir}" includes="*.xml"/>
+		</copy>
+		<copy todir="${JCK_ROOT}/">
+			<fileset dir="${basedir}/../systemtest_prereqs/" includes="**" />
+		</copy>
+	</target>
+
+	<target name="build">
+		<echo>JCK_ROOT is set to: ${JCK_ROOT}</echo>
+		<if>
+			<isset property="JCK_ROOT" />
+			<then>
+				<if>
+					<not>
+						<equals arg1="${JCK_ROOT}" arg2="" />
+					</not>
+					<then>
+						<echo>=== JCK_ROOT is set to ${JCK_ROOT} ===</echo>
+						<echo>start building jck project</echo>
+						<antcall target="dist" inheritall="true" />
+					</then>
+				</if>
+			</then>
+		</if>
+	</target>
+
+	<target name="clean">
+		<ant antfile="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build/build.xml" dir="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build" inheritAll="false" target="clean" />
+		<ant antfile="${SYSTEMTEST_ROOT}/stf/stf.build/build.xml" dir="${SYSTEMTEST_ROOT}/stf/stf.build" inheritAll="false" target="clean" />
+	</target>
+</project>

--- a/jck/playlist.xml
+++ b/jck/playlist.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
+
+	<test>
+		<testCaseName>jck_runtime-api-java_math_SE80</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>export JAVA_HOME=$(JDK_HOME)$(D)  && \
+	perl $(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)$(JAVA_VERSION)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
+	-test-root=$(Q)$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)stf;$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)openjdk-systemtest$(Q) \
+	-systemtest-prereqs=$(Q)$(JCK_ROOT)$(Q)  \
+	-results-root=$(REPORTDIR)  \
+	-test=Jck -test-args=$(Q)tests=api/java_math,jckversion=jck8b,testsuite=RUNTIME$(Q); \
+	$(TEST_STATUS)</command>
+		<tags>
+			<tag>jck</tag>
+		</tags>
+		<subsets>
+			<subset>SE80</subset>
+		</subsets>
+	</test>
+	<test>
+		<testCaseName>jck_runtime-api-java_math_SE90</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>export JAVA_HOME=$(JDK_HOME)$(D)  && \
+	perl $(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)$(JAVA_VERSION)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
+	-test-root=$(Q)$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)stf;$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)openjdk-systemtest$(Q) \
+	-systemtest-prereqs=$(Q)$(JCK_ROOT)$(Q)  \
+	-results-root=$(REPORTDIR)  \
+	-test=Jck -test-args=$(Q)tests=api/java_math,jckversion=jck9,testsuite=RUNTIME$(Q); \
+	$(TEST_STATUS)</command>
+		<tags>
+			<tag>jck</tag>
+		</tags>
+		<subsets>
+			<subset>SE90</subset>
+		</subsets>
+	</test>
+	
+</playlist>


### PR DESCRIPTION
* jck and systemtest are using the same src of stf & openjdk-systemtest
* require JCK_ROOT to be exported before compiling and running JCK tests
* add api-java_math as an example to run STF JCK tests
* add jck subset
* works with target jck_${JAVA_VERSION}

Signed-off-by: Tianyu Zuo <tianyu@ca.ibm.com>