### PR TITLE
Update jtreg generate xml reports to *.jtr.xml

### DIFF
--- a/buildenv/jenkins/Jenkinsfile
+++ b/buildenv/jenkins/Jenkinsfile
@@ -84,8 +84,8 @@ pipeline {
     	always {
  			step([$class: "TapPublisher", testResults: "**/*.tap"])
             archiveArtifacts artifacts: '**/*.tap', fingerprint: true
-            junit allowEmptyResults: true, keepLongStdio: true, testResults: '**/work/**/*.xml, **/junitreports/**/*.xml'
-            archiveArtifacts artifacts: '**/work/**/*.xml, **/junitreports/**/*.xml', fingerprint: true
+            junit allowEmptyResults: true, keepLongStdio: true, testResults: '**/work/**/*.jtr.xml, **/junitreports/**/*.xml'
+            archiveArtifacts artifacts: '**/work/**/*.jtr.xml, **/junitreports/**/*.xml', fingerprint: true
              script {
             	if (params.TARGET == 'test_systemtest') {  
 	       	 		sh 'tar -zcvf openjdk-systemtest-results.tar.gz $WORKSPACE/openjdk-test/TestConfig/test_output_*'

--- a/openjdk_regression/ProblemList_openjdk8.txt
+++ b/openjdk_regression/ProblemList_openjdk8.txt
@@ -55,7 +55,6 @@ compiler/jsr292/RedefineMethodUsedByMultipleMethodHandles.java	116	generic-all
 compiler/loopopts/UseCountedLoopSafepoints.java	116	generic-all
 compiler/loopopts/TestImpossibleIV.java	116	generic-all
 compiler/types/correctness/OffTest.java	116	generic-all
-compiler/unsafe/TestRawAliasing.java	116	linux-all
 gc/TestVerifySilently.java	116	generic-all
 gc/TestVerifySubSet.java	116	generic-all
 gc/arguments/TestG1HeapRegionSize.java	116	generic-all
@@ -103,7 +102,6 @@ runtime/memory/ReserveMemory.java	124	generic-all
 serviceability/jvmti/TestRedefineWithUnresolvedClass.java	124	generic-all
 serviceability/jvmti/GetObjectSizeOverflow.java	124	linux-all
 serviceability/sa/jmap-hashcode/Test8028623.java	124	linux-all
-compiler/unsafe/TestRawAliasing.java	131	generic-all
 ############################################################################
 
 # jdk_awt
@@ -154,7 +152,6 @@ java/beans/XMLEncoder/sun_swing_PrintColorUIResource.java	125	macosx-all
 # jdk_lang
 jdk/lambda/vm/InterfaceAccessFlagsTest.java	126	linux-all
 java/lang/Math/HypotTests.java	128	linux-all
-java/lang/System/finalization/FinInterrupt.java	141	generic-all
 java/lang/invoke/LFCaching/LFMultiThreadCachingTest.java	128	generic-all
 java/lang/invoke/LFCaching/LFSingleThreadCachingTest.java	128	generic-all
 java/lang/invoke/MethodHandlesTest.java	128 generic-all
@@ -195,7 +192,6 @@ com/sun/jdi/DoubleAgentTest.java	155	macosx-all
 
 # jdk_nio
 java/nio/Buffer/Basic.java 118	linux-all
-java/nio/Buffer/Chars.java	150	generic-all
 sun/nio/ch/TestMaxCachedBufferSize.java 118	linux-all
 sun/nio/cs/FindDecoderBugs.java 118	linux-all
 sun/nio/cs/FindEncoderBugs.java 118	linux-all


### PR DESCRIPTION
1. Update jtreg generate xml reports to *.jtr.xml instead of *.xml
2. Re-enable compiler/unsafe/TestRawAliasing.java,
java/lang/System/finalization/FinInterrupt.java,
java/nio/Buffer/Chars.java

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>