### PR TITLE
Re-enable jre tests related with jar missing

### DIFF
--- a/openjdk_regression/ProblemList_openjdk8.txt
+++ b/openjdk_regression/ProblemList_openjdk8.txt
@@ -93,10 +93,6 @@ runtime/Metaspace/FragmentMetaspaceSimple.java 120	generic-all
 runtime/ErrorHandling/TestCrashOnOutOfMemoryError.java	121	generic-all
 runtime/ErrorHandling/TestExitOnOutOfMemoryError.java	121	generic-all
 runtime/ErrorHandling/TestOnOutOfMemoryError.java	122	generic-all
-runtime/Final/PutfieldError.java	123	generic-all
-runtime/classFileParserBug/BadNameAndType.java	123	generic-all
-runtime/handlerInTry/LoadHandlerInTry.java	123	generic-all
-runtime/stackMapCheck/StackMapCheck.java	123	generic-all
 runtime/NMT/NMTWithCDS.java	124	generic-all
 runtime/memory/ReserveMemory.java	124	generic-all
 serviceability/jvmti/TestRedefineWithUnresolvedClass.java	124	generic-all


### PR DESCRIPTION
jtreg-4.2.0-tip.tar.gz updated.  https://ci.adoptopenjdk.net/job/jtreg/. 
Re-enable tests.

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>
  