### PR TITLE
Fix tools.jar missing issue in systemtest when run on openjdk8

### DIFF
--- a/buildenv/jenkins/Jenkinsfile
+++ b/buildenv/jenkins/Jenkinsfile
@@ -53,7 +53,8 @@ pipeline {
             steps {
 				timestamps{
                 	echo 'Building tests...'
-                	withEnv(["JAVA_BIN=$WORKSPACE/openjdkbinary/j2sdk-image/${(params.JAVA_VERSION == 'SE80') ? 'jre/' : ''}bin",
+                	withEnv(["JAVA_HOME=$WORKSPACE/openjdkbinary/j2sdk-image/${(params.JAVA_VERSION == 'SE80') ? 'jre/' : ''}",
+                	"JAVA_BIN=$WORKSPACE/openjdkbinary/j2sdk-image/${(params.JAVA_VERSION == 'SE80') ? 'jre/' : ''}bin",
                 	"JAVA_VERSION=${params.JAVA_VERSION}"]) {
                 		sh '$OPENJDK_TEST/maketest.sh $OPENJDK_TEST'
 					}
@@ -64,7 +65,8 @@ pipeline {
             steps {
 				timestamps{
                 	echo 'Running tests...'
-                	withEnv(["JAVA_BIN=$WORKSPACE/openjdkbinary/j2sdk-image/${(params.JAVA_VERSION == 'SE80') ? 'jre/' : ''}bin",
+                	withEnv(["JAVA_HOME=$WORKSPACE/openjdkbinary/j2sdk-image/${(params.JAVA_VERSION == 'SE80') ? 'jre/' : ''}",
+                	"JAVA_BIN=$WORKSPACE/openjdkbinary/j2sdk-image/${(params.JAVA_VERSION == 'SE80') ? 'jre/' : ''}bin",
                 	"JAVA_VERSION=${params.JAVA_VERSION}"]) {
                 		sh "$OPENJDK_TEST/maketest.sh $OPENJDK_TEST ${params.TARGET}"
 					}


### PR DESCRIPTION
openjdk.test.debugging is a systemtest project that requires tools.jar to be present in a certain location in the prereqs folder for it to compile, in case we are running on Java 8. There is some logic inside openjdk.build/include/top.xml where it figures out whether or not we are running on Java 8, and ensures that tools.jar gets copied over to the required location if we are. I added some debug messages to openjdk.build/include/top.xml and found out that, for some reasons, even when we are running on Java8, the Ant property on which the logic depends on to figure out java version, ${java.specification.version} prints "9", as opposed to "1.8". This is the reason why the top.xml thinks that we are on Java9, and does not copy over tools.jar to prereqs folder -- which causes the compilation failure in openjdk.test.debugging project.  

The reason why ${java.specification.version} prints "9" is Ant is still running on the default JRE on the machine, which happens to be a Java 9 SDK (confirmed by looking inside the box), so ${java.specification.version} is set to "9". 

As a temporary fix to unblock the build, this pull request is putting back the export of JAVA_HOME (to the SDK being tested) at the beginning of the run (in the Jenkins file) which will enforce Ant to start with the JRE under test.  