### PR TITLE
Exclude HCRLateAttachWorkload test due to openjdk-systemtest issue 7

### DIFF
--- a/systemtest/exclude_playlist.xml
+++ b/systemtest/exclude_playlist.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
+	<test>
+		<testCaseName>HCRLateAttachWorkload</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>export JAVA_HOME=$(JDK_HOME)$(D)  && \
+	perl $(TEST_RESROOT)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
+	-test-root=$(Q)$(TEST_RESROOT)$(D)stf;$(TEST_RESROOT)$(D)openjdk-systemtest$(Q) \
+	-systemtest-prereqs=$(Q)$(TEST_RESROOT)$(D)systemtest_prereqs$(Q)  \
+	-results-root=$(REPORTDIR)  \
+	-test=HCRLateAttachWorkload; \
+	$(TEST_STATUS)</command>	
+		<tags>
+			<tag>system</tag>
+		</tags>
+		<subsets>
+			<subset>SE80</subset>
+			<subset>SE90</subset>
+		</subsets>
+	</test>
+</playlist>

--- a/systemtest/playlist.xml
+++ b/systemtest/playlist.xml
@@ -318,25 +318,4 @@
 		</subsets>
 	</test>
 	
-	<test>
-		<testCaseName>HCRLateAttachWorkload</testCaseName>
-		<variations>
-			<variation>NoOptions</variation>
-		</variations>
-		<command>export JAVA_HOME=$(JDK_HOME)$(D)  && \
-	perl $(TEST_RESROOT)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
-	-test-root=$(Q)$(TEST_RESROOT)$(D)stf;$(TEST_RESROOT)$(D)openjdk-systemtest$(Q) \
-	-systemtest-prereqs=$(Q)$(TEST_RESROOT)$(D)systemtest_prereqs$(Q)  \
-	-results-root=$(REPORTDIR)  \
-	-test=HCRLateAttachWorkload; \
-	$(TEST_STATUS)</command>	
-		<tags>
-			<tag>system</tag>
-		</tags>
-		<subsets>
-			<subset>SE80</subset>
-			<subset>SE90</subset>
-		</subsets>
-	</test>
-	
 </playlist>


### PR DESCRIPTION
Exclude HCRLateAttachWorkload test due to  https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/7