### PR TITLE
Exclude jdi test and mauve multi thread load test from systemtest builds

### DIFF
--- a/TestConfig/makefile
+++ b/TestConfig/makefile
@@ -318,7 +318,23 @@ openjdk: rmResultFile openjdk_$(JAVA_VERSION) resultsSummary
 perf: JVM_TEST_ROOT := $(BUILD_ROOT)
 perf: rmResultFile perf_$(JAVA_VERSION) resultsSummary
 
-runtest: rmResultFile sanity_$(JAVA_VERSION) extended_$(JAVA_VERSION) openjdk_$(JAVA_VERSION) perf_$(JAVA_VERSION) resultsSummary
+system: JVM_TEST_ROOT := $(BUILD_ROOT)
+system: rmResultFile system_$(JAVA_VERSION) resultsSummary
+
+jck: JVM_TEST_ROOT := $(BUILD_ROOT)
+jck: rmResultFile jck_$(JAVA_VERSION) resultsSummary
+
+external: JVM_TEST_ROOT := $(BUILD_ROOT)
+external: rmResultFile external_$(JAVA_VERSION) resultsSummary
+
+hotspot: JVM_TEST_ROOT := $(BUILD_ROOT)
+hotspot: rmResultFile hotspot_$(JAVA_VERSION) resultsSummary
+
+openj9: JVM_TEST_ROOT := $(BUILD_ROOT)
+openj9: rmResultFile openj9_$(JAVA_VERSION) resultsSummary
+
+
+runtest: rmResultFile sanity_$(JAVA_VERSION) extended_$(JAVA_VERSION) openjdk_$(JAVA_VERSION) perf_$(JAVA_VERSION) system_$(JAVA_VERSION) jck_$(JAVA_VERSION) external_$(JAVA_VERSION) resultsSummary
 .NOTPARALLEL: extended sanity openjdk runtest rmResultFile resultsSummary
 
 # cleanup

--- a/TestConfig/scripts/testKitGen/makeGenTool/mkgen.pl
+++ b/TestConfig/scripts/testKitGen/makeGenTool/mkgen.pl
@@ -17,7 +17,7 @@ use feature 'say';
 
 use constant DEBUG => 0;
 
-my @allGroups = ( "sanity", "extended", "promotion", "openjdk", "system", "jck", "perf" );
+my @allGroups = ( "sanity", "extended", "promotion", "openjdk", "system", "jck", "perf", "external", "hotspot", "openj9" );
 
 my $headerComments =
 	"########################################################\n"

--- a/systemtest/exclude_playlist.xml
+++ b/systemtest/exclude_playlist.xml
@@ -20,4 +20,48 @@
 			<subset>SE90</subset>
 		</subsets>
 	</test>
+	
+	<test>
+		<testCaseName>JdiTest</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>export JAVA_HOME=$(JDK_HOME)$(D)  && \
+	perl $(TEST_RESROOT)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
+	-test-root=$(Q)$(TEST_RESROOT)$(D)stf;$(TEST_RESROOT)$(D)openjdk-systemtest$(Q) \
+	-systemtest-prereqs=$(Q)$(TEST_RESROOT)$(D)systemtest_prereqs$(Q)  \
+	-results-root=$(REPORTDIR)  \
+	-test=JdiTest; \
+	$(TEST_STATUS)</command>	
+		<tags>
+			<tag>system</tag>
+		</tags>
+		<subsets>
+			<subset>SE80</subset>
+			<subset>SE90</subset>
+		</subsets>
+	</test>
+	
+		
+	<test>
+		<testCaseName>MauveMultiThreadLoadTest</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>export JAVA_HOME=$(JDK_HOME)$(D)  && \
+	perl $(TEST_RESROOT)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
+	-test-root=$(Q)$(TEST_RESROOT)$(D)stf;$(TEST_RESROOT)$(D)openjdk-systemtest$(Q) \
+	-systemtest-prereqs=$(Q)$(TEST_RESROOT)$(D)systemtest_prereqs$(Q)  \
+	-results-root=$(REPORTDIR)  \
+	-test=MauveMultiThreadLoadTest; \
+	$(TEST_STATUS)</command>	
+		<tags>
+			<tag>system</tag>
+		</tags>
+		<subsets>
+			<subset>SE80</subset>
+			<subset>SE90</subset>
+		</subsets>
+	</test>
+	
 </playlist>

--- a/systemtest/playlist.xml
+++ b/systemtest/playlist.xml
@@ -214,27 +214,6 @@
 	</test>
 	
 	<test>
-		<testCaseName>MauveMultiThreadLoadTest</testCaseName>
-		<variations>
-			<variation>NoOptions</variation>
-		</variations>
-		<command>export JAVA_HOME=$(JDK_HOME)$(D)  && \
-	perl $(TEST_RESROOT)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
-	-test-root=$(Q)$(TEST_RESROOT)$(D)stf;$(TEST_RESROOT)$(D)openjdk-systemtest$(Q) \
-	-systemtest-prereqs=$(Q)$(TEST_RESROOT)$(D)systemtest_prereqs$(Q)  \
-	-results-root=$(REPORTDIR)  \
-	-test=MauveMultiThreadLoadTest; \
-	$(TEST_STATUS)</command>	
-		<tags>
-			<tag>system</tag>
-		</tags>
-		<subsets>
-			<subset>SE80</subset>
-			<subset>SE90</subset>
-		</subsets>
-	</test>
-	
-	<test>
 		<testCaseName>NioLoadTest</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
@@ -297,25 +276,6 @@
 		</subsets>
 	</test>
 	
-	<test>
-		<testCaseName>JdiTest</testCaseName>
-		<variations>
-			<variation>NoOptions</variation>
-		</variations>
-		<command>export JAVA_HOME=$(JDK_HOME)$(D)  && \
-	perl $(TEST_RESROOT)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
-	-test-root=$(Q)$(TEST_RESROOT)$(D)stf;$(TEST_RESROOT)$(D)openjdk-systemtest$(Q) \
-	-systemtest-prereqs=$(Q)$(TEST_RESROOT)$(D)systemtest_prereqs$(Q)  \
-	-results-root=$(REPORTDIR)  \
-	-test=JdiTest; \
-	$(TEST_STATUS)</command>	
-		<tags>
-			<tag>system</tag>
-		</tags>
-		<subsets>
-			<subset>SE80</subset>
-			<subset>SE90</subset>
-		</subsets>
-	</test>
+	
 	
 </playlist>

--- a/thirdparty_containers/scala/playlist.xml
+++ b/thirdparty_containers/scala/playlist.xml
@@ -21,7 +21,7 @@
 			<subset>SE90</subset>
 		</subsets>
 		<tags>
-			<tag>extended</tag>
+			<tag>external</tag>
 		</tags>
 	</test>
 </playlist>


### PR DESCRIPTION
Exclude failing tests. 

Related PR : https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/64

Related PR : https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/63