### PR TITLE
Add BUILD_LIST to compile based on TARGET

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -1,31 +1,36 @@
 #!groovy
 /* template jenkinsfile for adoptopenjdk test builds*/
-JCL_VERSION='current'
 OPENJDK_TEST="$WORKSPACE/openjdk-tests"
+def TESTPROJECTS = [system:'systemtest', perf:'performance', jck:'jck', external:'thirdparty_containers', openjdk:'openjdk_regression', extended:'openjdk_regression', runtest:'' ]
+TESTPROJECT=TESTPROJECTS["$TARGET"]
 def test() {
 	stage('Setup') {
 		timestamps{
+			env.JCL_VERSION = "current"
+			env.JAVA_BIN = "$WORKSPACE/openjdkbinary/j2sdk-image/${(JAVA_VERSION == 'SE80') ? 'jre/' : ''}bin"
+			env.JAVA_HOME = "${JAVA_BIN}/.."
+			env.JAVA_VERSION = "${JAVA_VERSION}"
+			env.SPEC = "${SPEC}"
+			env.BUILD_LIST= "${TESTPROJECT}"
 			sh 'printenv'
 			sh "chmod 755 ${OPENJDK_TEST}/maketest.sh"
 			sh "chmod 755 ${OPENJDK_TEST}/get.sh"
-			script {
-				if (fileExists('openjdkbinary')) {
-					dir('openjdkbinary') {
-						deleteDir()
-					}
+			if (fileExists('openjdkbinary')) {
+				dir('openjdkbinary') {
+					deleteDir()
 				}
-				if (fileExists('jvmtest')) {
-					dir('jvmtest') {
-						deleteDir()
-					}
+			}
+			if (fileExists('jvmtest')) {
+				dir('jvmtest') {
+					deleteDir()
 				}
-				if (SDK_RESOURCE == 'upstream') {
-					dir('openjdkbinary') {
-						step([$class: 'CopyArtifact',
-							fingerprintArtifacts: true,
-							projectName: "$UPSTREAM_JOB_NAME",
-							selector: upstream(allowUpstreamDependencies: false, fallbackToLastSuccessful: false, upstreamFilterStrategy: 'UseGlobalSetting')])
-					}
+			}
+			if (SDK_RESOURCE == 'upstream') {
+				dir('openjdkbinary') {
+					step([$class: 'CopyArtifact',
+						fingerprintArtifacts: true,
+						projectName: "$UPSTREAM_JOB_NAME",
+						selector: upstream(allowUpstreamDependencies: false, fallbackToLastSuccessful: false, upstreamFilterStrategy: 'UseGlobalSetting')])
 				}
 			}
 			sh "$OPENJDK_TEST/get.sh -s $WORKSPACE -t $OPENJDK_TEST -p $PLATFORM -v $JVM_VERSION -r $SDK_RESOURCE -c $CUSTOMIZED_SDK_URL"
@@ -35,26 +40,13 @@ def test() {
 	stage('Build') {
 		timestamps{
 			echo 'Building tests...'
-			withEnv(["JAVA_HOME=$WORKSPACE/openjdkbinary/j2sdk-image/${(JAVA_VERSION == 'SE80') ? 'jre/' : ''}",
-			"JAVA_BIN=$WORKSPACE/openjdkbinary/j2sdk-image/${(JAVA_VERSION == 'SE80') ? 'jre/' : ''}bin",
-			"JAVA_VERSION=${JAVA_VERSION}",
-			"SPEC=${SPEC}",
-			"JCL_VERSION=${JCL_VERSION}",
-			"BUILD_LIST=${TESTPROJECT}"]) {
-				sh "$OPENJDK_TEST/maketest.sh $OPENJDK_TEST"
-			}
+			sh "$OPENJDK_TEST/maketest.sh $OPENJDK_TEST"
 		}
 	}
 	stage('Test') {
 		timestamps{
 			echo 'Running tests...'
-			withEnv(["JAVA_HOME=$WORKSPACE/openjdkbinary/j2sdk-image/${(JAVA_VERSION == 'SE80') ? 'jre/' : ''}",
-			"JAVA_BIN=$WORKSPACE/openjdkbinary/j2sdk-image/${(JAVA_VERSION == 'SE80') ? 'jre/' : ''}bin",
-			"JAVA_VERSION=${JAVA_VERSION}",
-			"SPEC=${SPEC}",
-			"JCL_VERSION=${JCL_VERSION}"]) {
-				sh "$OPENJDK_TEST/maketest.sh $OPENJDK_TEST $TARGET"
-			}
+			sh "$OPENJDK_TEST/maketest.sh $OPENJDK_TEST $TARGET"
 		}
 	}
 	stage('Post') {

--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -39,7 +39,8 @@ def test() {
 			"JAVA_BIN=$WORKSPACE/openjdkbinary/j2sdk-image/${(JAVA_VERSION == 'SE80') ? 'jre/' : ''}bin",
 			"JAVA_VERSION=${JAVA_VERSION}",
 			"SPEC=${SPEC}",
-			"JCL_VERSION=${JCL_VERSION}"]) {
+			"JCL_VERSION=${JCL_VERSION}",
+			"BUILD_LIST=${TESTPROJECT}"]) {
 				sh "$OPENJDK_TEST/maketest.sh $OPENJDK_TEST"
 			}
 		}

--- a/buildenv/jenkins/openjdk10_aarch64_linux
+++ b/buildenv/jenkins/openjdk10_aarch64_linux
@@ -3,7 +3,6 @@
 	Set parameter TARGET(openjdk, system, external, perf, jck etc.).
 	Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_x86-64_linux)
 	Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
-/* TODO: Relate TARGET with BUILD_LIST to generate makefile and compile correspondingly */
 node('linux&&arm64&&test') {
     PLATFORM = 'aarch64_linux'
     JAVA_VERSION = 'SE100'

--- a/buildenv/jenkins/openjdk10_ppc64_aix
+++ b/buildenv/jenkins/openjdk10_ppc64_aix
@@ -3,7 +3,6 @@
 	Set parameter TARGET(openjdk, system, external, perf, jck etc.).
 	Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_x86-64_linux)
 	Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
-/* TODO: Relate TARGET with BUILD_LIST to generate makefile and compile correspondingly */
 node('aix&&ppc64&&test') {
     PLATFORM = 'ppc64_aix'
     JAVA_VERSION = 'SE100'

--- a/buildenv/jenkins/openjdk10_ppc64le_linux
+++ b/buildenv/jenkins/openjdk10_ppc64le_linux
@@ -3,7 +3,6 @@
 	Set parameter TARGET(openjdk, system, external, perf, jck etc.).
 	Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_x86-64_linux)
 	Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
-/* TODO: Relate TARGET with BUILD_LIST to generate makefile and compile correspondingly */
 node('linux&&ppc64le&&test') { //ppc64le build use "fedora" too, for now leave as is
     PLATFORM = 'ppc64le_linux'
     JAVA_VERSION = 'SE100'

--- a/buildenv/jenkins/openjdk10_s390x_linux
+++ b/buildenv/jenkins/openjdk10_s390x_linux
@@ -3,7 +3,6 @@
 	Set parameter TARGET(openjdk, system, external, perf, jck etc.).
 	Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_x86-64_linux)
 	Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
-/* TODO: Relate TARGET with BUILD_LIST to generate makefile and compile correspondingly */
 node('linux&&s390x&&test') {
     PLATFORM = 's390x_linux'
     JAVA_VERSION = 'SE100'

--- a/buildenv/jenkins/openjdk10_x86-64_linux
+++ b/buildenv/jenkins/openjdk10_x86-64_linux
@@ -3,7 +3,6 @@
 	Set parameter TARGET(openjdk, system, external, perf, jck etc.).
 	Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_x86-64_linux)
 	Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
-/* TODO: Relate TARGET with BUILD_LIST to generate makefile and compile correspondingly */
 node('linux&&x64&&test') {
     PLATFORM = 'x64_linux'
     JAVA_VERSION = 'SE100'

--- a/buildenv/jenkins/openjdk10_x86-64_macos
+++ b/buildenv/jenkins/openjdk10_x86-64_macos
@@ -3,7 +3,6 @@
 	Set parameter TARGET(openjdk, system, external, perf, jck etc.).
 	Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_x86-64_linux)
 	Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
-/* TODO: Relate TARGET with BUILD_LIST to generate makefile and compile correspondingly */
 node('mac&&x64&&test') {
     PLATFORM = 'x64_mac'
     JAVA_VERSION = 'SE100'

--- a/buildenv/jenkins/openjdk8_aarch64_linux
+++ b/buildenv/jenkins/openjdk8_aarch64_linux
@@ -3,7 +3,6 @@
 	Set parameter TARGET(openjdk, system, external, perf, jck etc.).
 	Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_x86-64_linux)
 	Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
-/* TODO: Relate TARGET with BUILD_LIST to generate makefile and compile correspondingly */
 node('linux&&arm64&&test') {
     PLATFORM = 'aarch64_linux'
     JAVA_VERSION = 'SE80'

--- a/buildenv/jenkins/openjdk8_ppc64_aix
+++ b/buildenv/jenkins/openjdk8_ppc64_aix
@@ -3,7 +3,6 @@
 	Set parameter TARGET(openjdk, system, external, perf, jck etc.).
 	Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_x86-64_linux)
 	Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
-/* TODO: Relate TARGET with BUILD_LIST to generate makefile and compile correspondingly */
 node('aix&&ppc64&&test') {
     PLATFORM = 'ppc64_aix'
     JAVA_VERSION = 'SE80'

--- a/buildenv/jenkins/openjdk8_ppc64le_linux
+++ b/buildenv/jenkins/openjdk8_ppc64le_linux
@@ -3,7 +3,6 @@
 	Set parameter TARGET(openjdk, system, external, perf, jck etc.).
 	Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_x86-64_linux)
 	Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
-/* TODO: Relate TARGET with BUILD_LIST to generate makefile and compile correspondingly */
 node('linux&&ppc64le&&test') { //ppc64le build use "fedora" too, for now leave as is
     PLATFORM = 'ppc64le_linux'
     JAVA_VERSION = 'SE80'

--- a/buildenv/jenkins/openjdk8_s390x_linux
+++ b/buildenv/jenkins/openjdk8_s390x_linux
@@ -3,7 +3,6 @@
 	Set parameter TARGET(openjdk, system, external, perf, jck etc.).
 	Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_x86-64_linux)
 	Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
-/* TODO: Relate TARGET with BUILD_LIST to generate makefile and compile correspondingly */
 node('linux&&s390x&&test') {
     PLATFORM = 's390x_linux'
     JAVA_VERSION = 'SE80'

--- a/buildenv/jenkins/openjdk8_x86-64_linux
+++ b/buildenv/jenkins/openjdk8_x86-64_linux
@@ -3,7 +3,6 @@
 	Set parameter TARGET(openjdk, system, external, perf, jck etc.).
 	Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_x86-64_linux)
 	Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
-/* TODO: Relate TARGET with BUILD_LIST to generate makefile and compile correspondingly */
 node('linux&&x64&&test') {
     PLATFORM = 'x64_linux'
     JAVA_VERSION = 'SE80'

--- a/buildenv/jenkins/openjdk8_x86-64_macos
+++ b/buildenv/jenkins/openjdk8_x86-64_macos
@@ -3,7 +3,6 @@
 	Set parameter TARGET(openjdk, system, external, perf, jck etc.).
 	Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_x86-64_linux)
 	Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
-/* TODO: Relate TARGET with BUILD_LIST to generate makefile and compile correspondingly */
 node('mac&&x64&&test') {
     PLATFORM = 'x64_mac'
     JAVA_VERSION = 'SE80'

--- a/buildenv/jenkins/openjdk9_aarch64_linux
+++ b/buildenv/jenkins/openjdk9_aarch64_linux
@@ -3,7 +3,6 @@
 	Set parameter TARGET(openjdk, system, external, perf, jck etc.).
 	Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_x86-64_linux)
 	Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
-/* TODO: Relate TARGET with BUILD_LIST to generate makefile and compile correspondingly */
 node('linux&&arm64&&test') {
     PLATFORM = 'aarch64_linux'
     JAVA_VERSION = 'SE90'

--- a/buildenv/jenkins/openjdk9_ppc64_aix
+++ b/buildenv/jenkins/openjdk9_ppc64_aix
@@ -3,7 +3,6 @@
 	Set parameter TARGET(openjdk, system, external, perf, jck etc.).
 	Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_x86-64_linux)
 	Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
-/* TODO: Relate TARGET with BUILD_LIST to generate makefile and compile correspondingly */
 node('aix&&ppc64&&test') {
     PLATFORM = 'ppc64_aix'
     JAVA_VERSION = 'SE90'

--- a/buildenv/jenkins/openjdk9_ppc64le_linux
+++ b/buildenv/jenkins/openjdk9_ppc64le_linux
@@ -3,7 +3,6 @@
 	Set parameter TARGET(openjdk, system, external, perf, jck etc.).
 	Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_x86-64_linux)
 	Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
-/* TODO: Relate TARGET with BUILD_LIST to generate makefile and compile correspondingly */
 node('linux&&ppc64le&&test') { //ppc64le build use "fedora" too, for now leave as is
     PLATFORM = 'ppc64le_linux'
     JAVA_VERSION = 'SE90'

--- a/buildenv/jenkins/openjdk9_s390x_linux
+++ b/buildenv/jenkins/openjdk9_s390x_linux
@@ -3,7 +3,6 @@
 	Set parameter TARGET(openjdk, system, external, perf, jck etc.).
 	Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_x86-64_linux)
 	Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
-/* TODO: Relate TARGET with BUILD_LIST to generate makefile and compile correspondingly */
 node('linux&&s390x&&test') {
     PLATFORM = 's390x_linux'
     JAVA_VERSION = 'SE90'

--- a/buildenv/jenkins/openjdk9_x86-64_linux
+++ b/buildenv/jenkins/openjdk9_x86-64_linux
@@ -3,7 +3,6 @@
 	Set parameter TARGET(openjdk, system, external, perf, jck etc.).
 	Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_x86-64_linux)
 	Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
-/* TODO: Relate TARGET with BUILD_LIST to generate makefile and compile correspondingly */
 node('linux&&x64&&test') {
     PLATFORM = 'x64_linux'
     JAVA_VERSION = 'SE90'

--- a/buildenv/jenkins/openjdk9_x86-64_macos
+++ b/buildenv/jenkins/openjdk9_x86-64_macos
@@ -3,7 +3,6 @@
 	Set parameter TARGET(openjdk, system, external, perf, jck etc.).
 	Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_x86-64_linux)
 	Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
-/* TODO: Relate TARGET with BUILD_LIST to generate makefile and compile correspondingly */
 node('mac&&x64&&test') {
     PLATFORM = 'x64_mac'
     JAVA_VERSION = 'SE90'


### PR DESCRIPTION
Only TARGET related folder will be compiled. No other folders will be compiled. In this way openjdk8_hs_openjdktest_x86-64_linux wont' compile systemtest and won't be affected by systemtest compile failures.