### PR TITLE
Change example test tag to "example"

### DIFF
--- a/TestConfig/scripts/testKitGen/makeGenTool/mkgen.pl
+++ b/TestConfig/scripts/testKitGen/makeGenTool/mkgen.pl
@@ -17,7 +17,7 @@ use feature 'say';
 
 use constant DEBUG => 0;
 
-my @allGroups = ( "sanity", "extended", "promotion", "openjdk", "system", "jck", "perf", "external", "hotspot", "openj9" );
+my @allGroups = ( "sanity", "extended", "promotion", "openjdk", "system", "jck", "perf", "external", "hotspot", "openj9", "example");
 
 my $headerComments =
 	"########################################################\n"

--- a/example/playlist.xml
+++ b/example/playlist.xml
@@ -26,7 +26,7 @@
 	$(TEST_STATUS)</command>
 		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
 		<tags>
-			<tag>sanity</tag>
+			<tag>example</tag>
 		</tags>
 		<subsets>
 			<subset>SE80</subset>
@@ -46,7 +46,7 @@
 	$(TEST_STATUS)</command>
 		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
 		<tags>
-			<tag>extended</tag>
+			<tag>example</tag>
 		</tags>
 		<subsets>
 			<subset>SE80</subset>


### PR DESCRIPTION
This change is a hack solution. The tag "example" will do nothing here.
Change it when testkitgen supports multi-tags

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>