### PR TITLE
Update params.TARGET value to 'system' in JenkinsfileBase

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -55,7 +55,7 @@ def test() {
 			archiveArtifacts artifacts: '**/*.tap', fingerprint: true, allowEmptyArchive: true
 			junit allowEmptyResults: true, keepLongStdio: true, testResults: '**/work/**/*.xml, **/junitreports/**/*.xml'
 			archiveArtifacts artifacts: '**/work/**/*.jtr.xml, **/junitreports/**/*.xml', fingerprint: true, allowEmptyArchive: true
-			if (params.TARGET == 'test_systemtest') {  
+			if (params.TARGET == 'system') {  
 	       	 		sh 'tar -zcf openjdk-systemtest-results.tar.gz $WORKSPACE/openjdk-tests/TestConfig/test_output_*'
 	       	 		archiveArtifacts artifacts: '**/openjdk-systemtest-results.tar.gz', fingerprint: true, allowEmptyArchive: true
 		    }


### PR DESCRIPTION
We need to update the params.TARGET value to 'system' for system tests as we have introduced the system tag now. Otherwise test results will not get zipped up. 