### PR TITLE
adding more jck test targets into jck playlist

### DIFF
--- a/jck/README.md
+++ b/jck/README.md
@@ -23,9 +23,9 @@
 1. Put unarchived jck test materials (jck8b or jck9) into an empty folder, for example:
 * `/jck/jck8b/` and `/jck/jck9`
 
-2. Export `JCK_ROOT=/jck` as an environment variable or pass it in makefile when run make commands
+2. Export `JCK_ROOT=/jck` as an environment variable or pass it in when run as a make command
 
-3. Export `JCK_VERSION=<your_jck_version>` as an environment variable or pass it in makefile when run make commands. For example `export JCK_VERSION=jck8b` 
+3. Export `JCK_VERSION=<your_jck_version>` as an environment variable or pass it in when run as a make command. For example `export JCK_VERSION=jck8b` 
 
 4. Export `JAVA_HOME=<your_JDK_root>` as an environment variable
 
@@ -43,8 +43,10 @@ There are three custom JCK test targets `jck-runtime-custom`, `jck-compiler-cust
 
 1. Follow the Steps 1 - 4 mentioned above. 
 
-2. Export `JCK_TEST_TARGET=<jck_test_subset>` as an environment variable or pass it in makefile when run make commands. For example `export JCK_TEST_TARGET=api/java_math`
+2. Export `JCK_TEST_TARGET=<jck_test_subset>` as an environment variable or pass it in when run as a make command. For example `export JCK_TEST_TARGET=api/java_math`
 
 3. Make sure the JCK test subset is available in JCK test material folder, a.k.a. `$(JCK_ROOT)/$(JCK_VERSION)/`.
 
-4. Follow the steps remaining in `openjdk-tests/README.md`
+4. If you need to add extra Java options to JCK tests, you could export `JCK_JAVA_ARGS="<java_options>"`. Then extra added Java options would be added to JCK test during execution.
+
+5. Follow the steps remaining in `openjdk-tests/README.md`

--- a/jck/README.md
+++ b/jck/README.md
@@ -1,3 +1,16 @@
+<!--
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+-->
 
 # How-to Run JCK Tests
 
@@ -10,13 +23,28 @@
 1. Put unarchived jck test materials (jck8b or jck9) into an empty folder, for example:
 * `/jck/jck8b/` and `/jck/jck9`
 
-2. Export `JCK_ROOT=/jck` as an environment variable or pass it in makefile when run make command
+2. Export `JCK_ROOT=/jck` as an environment variable or pass it in makefile when run make commands
 
-3. Export `JAVA_HOME=<your_JDK_root>` as an environment variable
+3. Export `JCK_VERSION=<your_jck_version>` as an environment variable or pass it in makefile when run make commands. For example `export JCK_VERSION=jck8b` 
 
-4. The other steps will stay the same as instructed in `openj9/test/README.md`
+4. Export `JAVA_HOME=<your_JDK_root>` as an environment variable
+
+5. The other steps will stay the same as instructed in `openjdk-tests/README.md`
 
 
 This test directory contains:
   * build.xml file - that clones AdoptOpenJDK/stf repo to pick up a test framework
   * playlist.xml - to allow easy inclusion of JCK tests into automated builds
+
+
+# How-to Run customized JCK test targets
+
+There are three custom JCK test targets `jck-runtime-custom`, `jck-compiler-custom` and `jck-devtools-custom`. With these three test targets, you can run custom JCK subsets.
+
+1. Follow the Steps 1 - 4 mentioned above. 
+
+2. Export `JCK_TEST_TARGET=<jck_test_subset>` as an environment variable or pass it in makefile when run make commands. For example `export JCK_TEST_TARGET=api/java_math`
+
+3. Make sure the JCK test subset is available in JCK test material folder, a.k.a. `$(JCK_ROOT)/$(JCK_VERSION)/`.
+
+4. Follow the steps remaining in `openjdk-tests/README.md`

--- a/jck/build.xml
+++ b/jck/build.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0"?>
+
+<!--
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+-->
+
 <project name="jck" default="build" basedir=".">
 	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>Build STF based JCK Tests </description>
@@ -72,12 +87,18 @@
 	</target>
 
 	<target name="configure_stf" depends="check_systemtest">
-		<ant antfile="${SYSTEMTEST_ROOT}/stf/stf.build/build.xml" dir="${SYSTEMTEST_ROOT}/stf/stf.build/" target="configure" inheritAll="false" />
-		<ant antfile="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build/build.xml" dir="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build/" target="configure" inheritAll="false" />
+		<ant antfile="${SYSTEMTEST_ROOT}/stf/stf.build/build.xml" dir="${SYSTEMTEST_ROOT}/stf/stf.build/" target="configure" inheritAll="false" >
+			<property name="java.home" value="${JAVA_BIN}/.."/>
+		</ant>
+		<ant antfile="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build/build.xml" dir="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build/" target="configure" inheritAll="false" >
+			<property name="java.home" value="${JAVA_BIN}/.."/>
+		</ant>
 	</target>
 
 	<target name="compile_stf" depends="configure_stf">
-		<ant antfile="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build/build.xml" dir="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build" inheritAll="false" />
+		<ant antfile="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build/build.xml" dir="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build" inheritAll="false" >
+			<property name="java.home" value="${JAVA_BIN}/.."/>
+		</ant>
 	</target>
 
 	<target name="dist" depends="compile_stf" description="generate the distribution">
@@ -124,11 +145,18 @@
 					</then>
 				</if>
 			</then>
+			<else>
+				<echo message="JCK_ROOT is not set, skip building jck" />
+			</else>
 		</if>
 	</target>
 
 	<target name="clean">
-		<ant antfile="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build/build.xml" dir="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build" inheritAll="false" target="clean" />
-		<ant antfile="${SYSTEMTEST_ROOT}/stf/stf.build/build.xml" dir="${SYSTEMTEST_ROOT}/stf/stf.build" inheritAll="false" target="clean" />
+		<ant antfile="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build/build.xml" dir="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build" inheritAll="false" target="clean" >
+			<property name="java.home" value="${JAVA_BIN}/.."/>
+		</ant>
+		<ant antfile="${SYSTEMTEST_ROOT}/stf/stf.build/build.xml" dir="${SYSTEMTEST_ROOT}/stf/stf.build" inheritAll="false" target="clean" >
+			<property name="java.home" value="${JAVA_BIN}/.."/>
+		</ant>
 	</target>
 </project>

--- a/jck/playlist.xml
+++ b/jck/playlist.xml
@@ -21,6 +21,7 @@
 		</variations>
 		<command>export JAVA_HOME=$(JDK_HOME)$(D)  && \
 	perl $(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)$(JAVA_VERSION)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
+	-java-args-setup=$(JCK_JAVA_ARGS) \
 	-test-root=$(Q)$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)stf;$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)openjdk-systemtest$(Q) \
 	-systemtest-prereqs=$(Q)$(JCK_ROOT)$(Q)  \
 	-results-root=$(REPORTDIR)  \
@@ -41,6 +42,7 @@
 		</variations>
 		<command>export JAVA_HOME=$(JDK_HOME)$(D)  && \
 	perl $(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)$(JAVA_VERSION)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
+	-java-args-setup=$(JCK_JAVA_ARGS) \
 	-test-root=$(Q)$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)stf;$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)openjdk-systemtest$(Q) \
 	-systemtest-prereqs=$(Q)$(JCK_ROOT)$(Q)  \
 	-results-root=$(REPORTDIR)  \
@@ -61,6 +63,7 @@
 		</variations>
 		<command>export JAVA_HOME=$(JDK_HOME)$(D)  && \
 	perl $(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)$(JAVA_VERSION)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
+	-java-args-setup=$(JCK_JAVA_ARGS) \
 	-test-root=$(Q)$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)stf;$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)openjdk-systemtest$(Q) \
 	-systemtest-prereqs=$(Q)$(JCK_ROOT)$(Q)  \
 	-results-root=$(REPORTDIR)  \

--- a/jck/playlist.xml
+++ b/jck/playlist.xml
@@ -1,8 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+-->
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
 
 	<test>
-		<testCaseName>jck_runtime-api-java_math_SE80</testCaseName>
+		<testCaseName>jck-runtime-custom</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -11,17 +24,18 @@
 	-test-root=$(Q)$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)stf;$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)openjdk-systemtest$(Q) \
 	-systemtest-prereqs=$(Q)$(JCK_ROOT)$(Q)  \
 	-results-root=$(REPORTDIR)  \
-	-test=Jck -test-args=$(Q)tests=api/java_math,jckversion=jck8b,testsuite=RUNTIME$(Q); \
+	-test=Jck -test-args=$(Q)tests=$(JCK_TEST_TARGET),jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
 	$(TEST_STATUS)</command>
 		<tags>
 			<tag>jck</tag>
 		</tags>
 		<subsets>
 			<subset>SE80</subset>
+			<subset>SE90</subset>
 		</subsets>
 	</test>
 	<test>
-		<testCaseName>jck_runtime-api-java_math_SE90</testCaseName>
+		<testCaseName>jck-compiler-custom</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -30,14 +44,430 @@
 	-test-root=$(Q)$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)stf;$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)openjdk-systemtest$(Q) \
 	-systemtest-prereqs=$(Q)$(JCK_ROOT)$(Q)  \
 	-results-root=$(REPORTDIR)  \
-	-test=Jck -test-args=$(Q)tests=api/java_math,jckversion=jck9,testsuite=RUNTIME$(Q); \
+	-test=Jck -test-args=$(Q)tests=$(JCK_TEST_TARGET),jckversion=$(JCK_VERSION),testsuite=COMPILER$(Q); \
 	$(TEST_STATUS)</command>
 		<tags>
 			<tag>jck</tag>
 		</tags>
 		<subsets>
+			<subset>SE80</subset>
+			<subset>SE90</subset>
+		</subsets>
+	</test>
+	<test>
+		<testCaseName>jck-devtools-custom</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>export JAVA_HOME=$(JDK_HOME)$(D)  && \
+	perl $(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)$(JAVA_VERSION)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
+	-test-root=$(Q)$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)stf;$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)openjdk-systemtest$(Q) \
+	-systemtest-prereqs=$(Q)$(JCK_ROOT)$(Q)  \
+	-results-root=$(REPORTDIR)  \
+	-test=Jck -test-args=$(Q)tests=$(JCK_TEST_TARGET),jckversion=$(JCK_VERSION),testsuite=DEVTOOLS$(Q); \
+	$(TEST_STATUS)</command>
+		<tags>
+			<tag>jck</tag>
+		</tags>
+		<subsets>
+			<subset>SE80</subset>
+			<subset>SE90</subset>
+		</subsets>
+	</test>
+
+	<test>
+		<testCaseName>jck-runtime-api-java_math</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>export JAVA_HOME=$(JDK_HOME)$(D)  && \
+	perl $(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)$(JAVA_VERSION)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
+	-test-root=$(Q)$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)stf;$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)openjdk-systemtest$(Q) \
+	-systemtest-prereqs=$(Q)$(JCK_ROOT)$(Q)  \
+	-results-root=$(REPORTDIR)  \
+	-test=Jck -test-args=$(Q)tests=api/java_math,jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
+	$(TEST_STATUS)</command>
+		<tags>
+			<tag>jck</tag>
+		</tags>
+		<subsets>
+			<subset>SE80</subset>
+			<subset>SE90</subset>
+		</subsets>
+	</test>
+	<test>
+		<testCaseName>jck-runtime-api-java_lang-instrument</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>export JAVA_HOME=$(JDK_HOME)$(D)  && \
+	perl $(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)$(JAVA_VERSION)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
+	-test-root=$(Q)$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)stf;$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)openjdk-systemtest$(Q) \
+	-systemtest-prereqs=$(Q)$(JCK_ROOT)$(Q)  \
+	-results-root=$(REPORTDIR)  \
+	-test=Jck -test-args=$(Q)tests=api/java_lang/instrument,jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
+	$(TEST_STATUS)</command>
+		<tags>
+			<tag>jck</tag>
+			<tag>daily</tag>
+		</tags>
+		<subsets>
+			<subset>SE80</subset>
+			<subset>SE90</subset>
+		</subsets>
+	</test>
+
+	<test>
+		<testCaseName>jck-runtime-api-java_lang-invoke</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>export JAVA_HOME=$(JDK_HOME)$(D)  && \
+	perl $(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)$(JAVA_VERSION)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
+	-test-root=$(Q)$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)stf;$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)openjdk-systemtest$(Q) \
+	-systemtest-prereqs=$(Q)$(JCK_ROOT)$(Q)  \
+	-results-root=$(REPORTDIR)  \
+	-test=Jck -test-args=$(Q)tests=api/java_lang/invoke,jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
+	$(TEST_STATUS)</command>
+		<tags>
+			<tag>jck</tag>
+			<tag>daily</tag>
+		</tags>
+		<subsets>
+			<subset>SE80</subset>
+			<subset>SE90</subset>
+		</subsets>
+	</test>
+	<test>
+		<testCaseName>jck-runtime-api-java_lang-reflect</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>export JAVA_HOME=$(JDK_HOME)$(D)  && \
+	perl $(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)$(JAVA_VERSION)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
+	-test-root=$(Q)$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)stf;$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)openjdk-systemtest$(Q) \
+	-systemtest-prereqs=$(Q)$(JCK_ROOT)$(Q)  \
+	-results-root=$(REPORTDIR)  \
+	-test=Jck -test-args=$(Q)tests=api/java_lang/reflect,jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
+	$(TEST_STATUS)</command>
+		<tags>
+			<tag>jck</tag>
+			<tag>daily</tag>
+		</tags>
+		<subsets>
+			<subset>SE80</subset>
+			<subset>SE90</subset>
+		</subsets>
+	</test>
+	<test>
+		<testCaseName>jck-runtime-api-java_lang-Package</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>export JAVA_HOME=$(JDK_HOME)$(D)  && \
+	perl $(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)$(JAVA_VERSION)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
+	-test-root=$(Q)$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)stf;$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)openjdk-systemtest$(Q) \
+	-systemtest-prereqs=$(Q)$(JCK_ROOT)$(Q)  \
+	-results-root=$(REPORTDIR)  \
+	-test=Jck -test-args=$(Q)tests=api/java_lang/Package,jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
+	$(TEST_STATUS)</command>
+		<tags>
+			<tag>jck</tag>
+			<tag>daily</tag>
+		</tags>
+		<subsets>
+			<subset>SE80</subset>
+			<subset>SE90</subset>
+		</subsets>
+	</test>
+	<test>
+		<testCaseName>jck-runtime-api-java_lang-String</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>export JAVA_HOME=$(JDK_HOME)$(D)  && \
+	perl $(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)$(JAVA_VERSION)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
+	-test-root=$(Q)$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)stf;$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)openjdk-systemtest$(Q) \
+	-systemtest-prereqs=$(Q)$(JCK_ROOT)$(Q)  \
+	-results-root=$(REPORTDIR)  \
+	-test=Jck -test-args=$(Q)tests=api/java_lang/String,jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
+	$(TEST_STATUS)</command>
+		<tags>
+			<tag>jck</tag>
+			<tag>daily</tag>
+		</tags>
+		<subsets>
+			<subset>SE80</subset>
+			<subset>SE90</subset>
+		</subsets>
+	</test>
+	<test>
+		<testCaseName>jck-runtime-api-java_lang-StringBuilder</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>export JAVA_HOME=$(JDK_HOME)$(D)  && \
+	perl $(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)$(JAVA_VERSION)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
+	-test-root=$(Q)$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)stf;$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)openjdk-systemtest$(Q) \
+	-systemtest-prereqs=$(Q)$(JCK_ROOT)$(Q)  \
+	-results-root=$(REPORTDIR)  \
+	-test=Jck -test-args=$(Q)tests=api/java_lang/StringBuilder,jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
+	$(TEST_STATUS)</command>
+		<tags>
+			<tag>jck</tag>
+			<tag>daily</tag>
+		</tags>
+		<subsets>
+			<subset>SE80</subset>
+			<subset>SE90</subset>
+		</subsets>
+	</test>
+	<test>
+		<testCaseName>jck-runtime-api-java_lang-StringBuffer</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>export JAVA_HOME=$(JDK_HOME)$(D)  && \
+	perl $(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)$(JAVA_VERSION)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
+	-test-root=$(Q)$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)stf;$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)openjdk-systemtest$(Q) \
+	-systemtest-prereqs=$(Q)$(JCK_ROOT)$(Q)  \
+	-results-root=$(REPORTDIR)  \
+	-test=Jck -test-args=$(Q)tests=api/java_lang/StringBuffer,jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
+	$(TEST_STATUS)</command>
+		<tags>
+			<tag>jck</tag>
+			<tag>daily</tag>
+		</tags>
+		<subsets>
+			<subset>SE80</subset>
+			<subset>SE90</subset>
+		</subsets>
+	</test>
+	<test>
+		<testCaseName>jck-runtime-api-java_lang-ClassLoader</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>export JAVA_HOME=$(JDK_HOME)$(D)  && \
+	perl $(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)$(JAVA_VERSION)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
+	-test-root=$(Q)$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)stf;$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)openjdk-systemtest$(Q) \
+	-systemtest-prereqs=$(Q)$(JCK_ROOT)$(Q)  \
+	-results-root=$(REPORTDIR)  \
+	-test=Jck -test-args=$(Q)tests=api/java_lang/ClassLoader,jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
+	$(TEST_STATUS)</command>
+		<tags>
+			<tag>jck</tag>
+			<tag>daily</tag>
+		</tags>
+		<subsets>
+			<subset>SE80</subset>
+			<subset>SE90</subset>
+		</subsets>
+	</test>
+	<test>
+		<testCaseName>jck-runtime-vm-constantpool</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>export JAVA_HOME=$(JDK_HOME)$(D)  && \
+	perl $(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)$(JAVA_VERSION)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
+	-test-root=$(Q)$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)stf;$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)openjdk-systemtest$(Q) \
+	-systemtest-prereqs=$(Q)$(JCK_ROOT)$(Q)  \
+	-results-root=$(REPORTDIR)  \
+	-test=Jck -test-args=$(Q)tests=vm/constantpool,jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
+	$(TEST_STATUS)</command>
+		<tags>
+			<tag>jck</tag>
+			<tag>daily</tag>
+		</tags>
+		<subsets>
+			<subset>SE80</subset>
+			<subset>SE90</subset>
+		</subsets>
+	</test>
+	<test>
+		<testCaseName>jck-runtime-vm-jvmti</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>export JAVA_HOME=$(JDK_HOME)$(D)  && \
+	perl $(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)$(JAVA_VERSION)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
+	-test-root=$(Q)$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)stf;$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)openjdk-systemtest$(Q) \
+	-systemtest-prereqs=$(Q)$(JCK_ROOT)$(Q)  \
+	-results-root=$(REPORTDIR)  \
+	-test=Jck -test-args=$(Q)tests=vm/jvmti,jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
+	$(TEST_STATUS)</command>
+		<tags>
+			<tag>jck</tag>
+			<tag>daily</tag>
+		</tags>
+		<subsets>
+			<subset>SE80</subset>
+			<subset>SE90</subset>
+		</subsets>
+	</test>
+	<test>
+		<testCaseName>jck-runtime-vm-overview</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>export JAVA_HOME=$(JDK_HOME)$(D)  && \
+	perl $(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)$(JAVA_VERSION)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
+	-test-root=$(Q)$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)stf;$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)openjdk-systemtest$(Q) \
+	-systemtest-prereqs=$(Q)$(JCK_ROOT)$(Q)  \
+	-results-root=$(REPORTDIR)  \
+	-test=Jck -test-args=$(Q)tests=vm/overview,jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
+	$(TEST_STATUS)</command>
+		<tags>
+			<tag>jck</tag>
+			<tag>daily</tag>
+		</tags>
+		<subsets>
+			<subset>SE80</subset>
+			<subset>SE90</subset>
+		</subsets>
+	</test>
+	<test>
+		<testCaseName>jck-runtime-vm-classfmt-clf</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>export JAVA_HOME=$(JDK_HOME)$(D)  && \
+	perl $(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)$(JAVA_VERSION)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
+	-test-root=$(Q)$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)stf;$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)openjdk-systemtest$(Q) \
+	-systemtest-prereqs=$(Q)$(JCK_ROOT)$(Q)  \
+	-results-root=$(REPORTDIR)  \
+	-test=Jck -test-args=$(Q)tests=vm/classfmt/clf,jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
+	$(TEST_STATUS)</command>
+		<tags>
+			<tag>jck</tag>
+			<tag>daily</tag>
+		</tags>
+		<subsets>
+			<subset>SE80</subset>
 			<subset>SE90</subset>
 		</subsets>
 	</test>
 	
+	<test>
+		<testCaseName>jck-runtime-api-java_lang-ModuleLayer</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>export JAVA_HOME=$(JDK_HOME)$(D)  && \
+	perl $(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)$(JAVA_VERSION)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
+	-test-root=$(Q)$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)stf;$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)openjdk-systemtest$(Q) \
+	-systemtest-prereqs=$(Q)$(JCK_ROOT)$(Q)  \
+	-results-root=$(REPORTDIR)  \
+	-test=Jck -test-args=$(Q)tests=api/java_lang/ModuleLayer,jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
+	$(TEST_STATUS)</command>
+		<tags>
+			<tag>jck</tag>
+			<tag>daily</tag>
+		</tags>
+		<subsets>
+			<subset>SE90</subset>
+		</subsets>
+	</test>
+	<test>
+		<testCaseName>jck-runtime-api-java_lang-module</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>export JAVA_HOME=$(JDK_HOME)$(D)  && \
+	perl $(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)$(JAVA_VERSION)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
+	-test-root=$(Q)$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)stf;$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)openjdk-systemtest$(Q) \
+	-systemtest-prereqs=$(Q)$(JCK_ROOT)$(Q)  \
+	-results-root=$(REPORTDIR)  \
+	-test=Jck -test-args=$(Q)tests=api/java_lang/module,jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
+	$(TEST_STATUS)</command>
+		<tags>
+			<tag>jck</tag>
+			<tag>daily</tag>
+		</tags>
+		<subsets>
+			<subset>SE90</subset>
+		</subsets>
+	</test>
+	<test>
+		<testCaseName>jck-runtime-api-java_lang-StackWalker</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>export JAVA_HOME=$(JDK_HOME)$(D)  && \
+	perl $(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)$(JAVA_VERSION)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
+	-test-root=$(Q)$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)stf;$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)openjdk-systemtest$(Q) \
+	-systemtest-prereqs=$(Q)$(JCK_ROOT)$(Q)  \
+	-results-root=$(REPORTDIR)  \
+	-test=Jck -test-args=$(Q)tests=api/java_lang/StackWalker,jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
+	$(TEST_STATUS)</command>
+		<tags>
+			<tag>jck</tag>
+			<tag>daily</tag>
+		</tags>
+		<subsets>
+			<subset>SE90</subset>
+		</subsets>
+	</test>
+	<test>
+		<testCaseName>jck-runtime-api-modulegraph</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>export JAVA_HOME=$(JDK_HOME)$(D)  && \
+	perl $(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)$(JAVA_VERSION)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
+	-test-root=$(Q)$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)stf;$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)openjdk-systemtest$(Q) \
+	-systemtest-prereqs=$(Q)$(JCK_ROOT)$(Q)  \
+	-results-root=$(REPORTDIR)  \
+	-test=Jck -test-args=$(Q)tests=api/modulegraph,jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
+	$(TEST_STATUS)</command>
+		<tags>
+			<tag>jck</tag>
+			<tag>daily</tag>
+		</tags>
+		<subsets>
+			<subset>SE90</subset>
+		</subsets>
+	</test>
+	<test>
+		<testCaseName>jck-runtime-vm-module</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>export JAVA_HOME=$(JDK_HOME)$(D)  && \
+	perl $(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)$(JAVA_VERSION)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
+	-test-root=$(Q)$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)stf;$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)openjdk-systemtest$(Q) \
+	-systemtest-prereqs=$(Q)$(JCK_ROOT)$(Q)  \
+	-results-root=$(REPORTDIR)  \
+	-test=Jck -test-args=$(Q)tests=vm/module,jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
+	$(TEST_STATUS)</command>
+		<tags>
+			<tag>jck</tag>
+			<tag>daily</tag>
+		</tags>
+		<subsets>
+			<subset>SE90</subset>
+		</subsets>
+	</test>
+	<test>
+		<testCaseName>jck-runtime-vm-verifier</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>export JAVA_HOME=$(JDK_HOME)$(D)  && \
+	perl $(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)$(JAVA_VERSION)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
+	-test-root=$(Q)$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)stf;$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)openjdk-systemtest$(Q) \
+	-systemtest-prereqs=$(Q)$(JCK_ROOT)$(Q)  \
+	-results-root=$(REPORTDIR)  \
+	-test=Jck -test-args=$(Q)tests=vm/verifier,jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
+	$(TEST_STATUS)</command>
+		<tags>
+			<tag>jck</tag>
+			<tag>daily</tag>
+		</tags>
+		<subsets>
+			<subset>SE90</subset>
+		</subsets>
+	</test>
+
 </playlist>


### PR DESCRIPTION
* update jck build.xml to ensure it uses the same javac in JAVA_BIN 
* add JCK_VERSION to use same test target on all JCK versions
* and JCK custom test targets and JCK_TEST_TARGET variable
* user can run JCK test subset with new added JCK custom test targets
* export JCK_TEST_TARGET to define which JCK test subset to run 
* add daily and weekly JCK test tags and test targets

Signed-off-by: Tianyu Zuo <tianyu@ca.ibm.com>