### PR TITLE
change JCK_JAVA_ARGS to EXTRA_OPTIONS to reuse tkg options

### DIFF
--- a/jck/README.md
+++ b/jck/README.md
@@ -47,6 +47,6 @@ There are three custom JCK test targets `jck-runtime-custom`, `jck-compiler-cust
 
 3. Make sure the JCK test subset is available in JCK test material folder, a.k.a. `$(JCK_ROOT)/$(JCK_VERSION)/`.
 
-4. If you need to add extra Java options to JCK tests, you could export `JCK_JAVA_ARGS="<java_options>"`. Then extra added Java options would be added to JCK test during execution.
+4. If you need to add extra Java options to JCK tests, you could export `EXTRA_OPTIONS="<java_options>"`. Then extra added Java options would be added to JCK test during execution.
 
 5. Follow the steps remaining in `openjdk-tests/README.md`

--- a/jck/playlist.xml
+++ b/jck/playlist.xml
@@ -21,7 +21,7 @@
 		</variations>
 		<command>export JAVA_HOME=$(JDK_HOME)$(D)  && \
 	perl $(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)$(JAVA_VERSION)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
-	-java-args-setup=$(JCK_JAVA_ARGS) \
+	-java-args-setup=$(EXTRA_OPTIONS) \
 	-test-root=$(Q)$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)stf;$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)openjdk-systemtest$(Q) \
 	-systemtest-prereqs=$(Q)$(JCK_ROOT)$(Q)  \
 	-results-root=$(REPORTDIR)  \
@@ -42,7 +42,7 @@
 		</variations>
 		<command>export JAVA_HOME=$(JDK_HOME)$(D)  && \
 	perl $(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)$(JAVA_VERSION)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
-	-java-args-setup=$(JCK_JAVA_ARGS) \
+	-java-args-setup=$(EXTRA_OPTIONS) \
 	-test-root=$(Q)$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)stf;$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)openjdk-systemtest$(Q) \
 	-systemtest-prereqs=$(Q)$(JCK_ROOT)$(Q)  \
 	-results-root=$(REPORTDIR)  \
@@ -63,7 +63,7 @@
 		</variations>
 		<command>export JAVA_HOME=$(JDK_HOME)$(D)  && \
 	perl $(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)$(JAVA_VERSION)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
-	-java-args-setup=$(JCK_JAVA_ARGS) \
+	-java-args-setup=$(EXTRA_OPTIONS) \
 	-test-root=$(Q)$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)stf;$(TEST_RESROOT)$(D)..$(D)..$(D)systemtest$(D)${JAVA_VERSION}$(D)openjdk-systemtest$(Q) \
 	-systemtest-prereqs=$(Q)$(JCK_ROOT)$(Q)  \
 	-results-root=$(REPORTDIR)  \


### PR DESCRIPTION
* use can export EXTRA_OPTIONS instead of JCK_JAVA_ARGS
* reuse EXTRA_OPTIONS to avoid introducing new macro

Signed-off-by: Tianyu Zuo <tianyu@ca.ibm.com>