### PR TITLE
change daily tagged jck tests to sanity

### DIFF
--- a/jck/playlist.xml
+++ b/jck/playlist.xml
@@ -111,8 +111,8 @@
 	-test=Jck -test-args=$(Q)tests=api/java_lang/instrument,jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
 	$(TEST_STATUS)</command>
 		<tags>
+			<tag>sanity</tag>
 			<tag>jck</tag>
-			<tag>daily</tag>
 		</tags>
 		<subsets>
 			<subset>SE80</subset>
@@ -133,8 +133,8 @@
 	-test=Jck -test-args=$(Q)tests=api/java_lang/invoke,jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
 	$(TEST_STATUS)</command>
 		<tags>
+			<tag>sanity</tag>
 			<tag>jck</tag>
-			<tag>daily</tag>
 		</tags>
 		<subsets>
 			<subset>SE80</subset>
@@ -154,8 +154,8 @@
 	-test=Jck -test-args=$(Q)tests=api/java_lang/reflect,jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
 	$(TEST_STATUS)</command>
 		<tags>
+			<tag>sanity</tag>
 			<tag>jck</tag>
-			<tag>daily</tag>
 		</tags>
 		<subsets>
 			<subset>SE80</subset>
@@ -175,8 +175,8 @@
 	-test=Jck -test-args=$(Q)tests=api/java_lang/Package,jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
 	$(TEST_STATUS)</command>
 		<tags>
+			<tag>sanity</tag>
 			<tag>jck</tag>
-			<tag>daily</tag>
 		</tags>
 		<subsets>
 			<subset>SE80</subset>
@@ -196,8 +196,8 @@
 	-test=Jck -test-args=$(Q)tests=api/java_lang/String,jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
 	$(TEST_STATUS)</command>
 		<tags>
+			<tag>sanity</tag>
 			<tag>jck</tag>
-			<tag>daily</tag>
 		</tags>
 		<subsets>
 			<subset>SE80</subset>
@@ -217,8 +217,8 @@
 	-test=Jck -test-args=$(Q)tests=api/java_lang/StringBuilder,jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
 	$(TEST_STATUS)</command>
 		<tags>
+			<tag>sanity</tag>
 			<tag>jck</tag>
-			<tag>daily</tag>
 		</tags>
 		<subsets>
 			<subset>SE80</subset>
@@ -238,8 +238,8 @@
 	-test=Jck -test-args=$(Q)tests=api/java_lang/StringBuffer,jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
 	$(TEST_STATUS)</command>
 		<tags>
+			<tag>sanity</tag>
 			<tag>jck</tag>
-			<tag>daily</tag>
 		</tags>
 		<subsets>
 			<subset>SE80</subset>
@@ -259,8 +259,8 @@
 	-test=Jck -test-args=$(Q)tests=api/java_lang/ClassLoader,jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
 	$(TEST_STATUS)</command>
 		<tags>
+			<tag>sanity</tag>
 			<tag>jck</tag>
-			<tag>daily</tag>
 		</tags>
 		<subsets>
 			<subset>SE80</subset>
@@ -280,8 +280,8 @@
 	-test=Jck -test-args=$(Q)tests=vm/constantpool,jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
 	$(TEST_STATUS)</command>
 		<tags>
+			<tag>sanity</tag>
 			<tag>jck</tag>
-			<tag>daily</tag>
 		</tags>
 		<subsets>
 			<subset>SE80</subset>
@@ -301,8 +301,8 @@
 	-test=Jck -test-args=$(Q)tests=vm/jvmti,jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
 	$(TEST_STATUS)</command>
 		<tags>
+			<tag>sanity</tag>
 			<tag>jck</tag>
-			<tag>daily</tag>
 		</tags>
 		<subsets>
 			<subset>SE80</subset>
@@ -322,8 +322,8 @@
 	-test=Jck -test-args=$(Q)tests=vm/overview,jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
 	$(TEST_STATUS)</command>
 		<tags>
+			<tag>sanity</tag>
 			<tag>jck</tag>
-			<tag>daily</tag>
 		</tags>
 		<subsets>
 			<subset>SE80</subset>
@@ -343,8 +343,8 @@
 	-test=Jck -test-args=$(Q)tests=vm/classfmt/clf,jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
 	$(TEST_STATUS)</command>
 		<tags>
+			<tag>sanity</tag>
 			<tag>jck</tag>
-			<tag>daily</tag>
 		</tags>
 		<subsets>
 			<subset>SE80</subset>
@@ -365,8 +365,8 @@
 	-test=Jck -test-args=$(Q)tests=api/java_lang/ModuleLayer,jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
 	$(TEST_STATUS)</command>
 		<tags>
+			<tag>sanity</tag>
 			<tag>jck</tag>
-			<tag>daily</tag>
 		</tags>
 		<subsets>
 			<subset>SE90</subset>
@@ -385,8 +385,8 @@
 	-test=Jck -test-args=$(Q)tests=api/java_lang/module,jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
 	$(TEST_STATUS)</command>
 		<tags>
+			<tag>sanity</tag>
 			<tag>jck</tag>
-			<tag>daily</tag>
 		</tags>
 		<subsets>
 			<subset>SE90</subset>
@@ -405,8 +405,8 @@
 	-test=Jck -test-args=$(Q)tests=api/java_lang/StackWalker,jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
 	$(TEST_STATUS)</command>
 		<tags>
+			<tag>sanity</tag>
 			<tag>jck</tag>
-			<tag>daily</tag>
 		</tags>
 		<subsets>
 			<subset>SE90</subset>
@@ -425,8 +425,8 @@
 	-test=Jck -test-args=$(Q)tests=api/modulegraph,jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
 	$(TEST_STATUS)</command>
 		<tags>
+			<tag>sanity</tag>
 			<tag>jck</tag>
-			<tag>daily</tag>
 		</tags>
 		<subsets>
 			<subset>SE90</subset>
@@ -445,8 +445,8 @@
 	-test=Jck -test-args=$(Q)tests=vm/module,jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
 	$(TEST_STATUS)</command>
 		<tags>
+			<tag>sanity</tag>
 			<tag>jck</tag>
-			<tag>daily</tag>
 		</tags>
 		<subsets>
 			<subset>SE90</subset>
@@ -465,8 +465,8 @@
 	-test=Jck -test-args=$(Q)tests=vm/verifier,jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
 	$(TEST_STATUS)</command>
 		<tags>
+			<tag>sanity</tag>
 			<tag>jck</tag>
-			<tag>daily</tag>
 		</tags>
 		<subsets>
 			<subset>SE90</subset>


### PR DESCRIPTION
* we are not going to have daily or weekly level
* we are going to use sanity and extended as daily and weekly
* change all daily tagged jck tests to sanity level 

Signed-off-by: Tianyu Zuo <tianyu@ca.ibm.com>