### PR TITLE
Enable sanity and extended level target

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -1,7 +1,7 @@
 #!groovy
 /* template jenkinsfile for adoptopenjdk test builds*/
 OPENJDK_TEST="$WORKSPACE/openjdk-tests"
-def TESTPROJECTS = [system:'systemtest', perf:'performance', jck:'jck', external:'thirdparty_containers', openjdk:'openjdk_regression', runtest:'' ]
+def TESTPROJECTS = [system:'systemtest', perf:'performance', jck:'jck', external:'thirdparty_containers', openjdk:'openjdk_regression', runtest:'', sanity:'', extended:'' ]
 TESTPROJECT=TESTPROJECTS["$TARGET"]
 def test() {
 	timeout(time: 6, unit: 'HOURS') {


### PR DESCRIPTION
Enable sanity and extended level target to run same level tests with
different groups

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>