### PR TITLE
WIP: Exclude more regression tests for openj9 implementation

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -67,7 +67,7 @@ def test() {
 				step([$class: "TapPublisher", testResults: "**/*.tap"])
 				archiveArtifacts artifacts: '**/*.tap', fingerprint: true, allowEmptyArchive: true
 				junit allowEmptyResults: true, keepLongStdio: true, testResults: '**/work/**/*.xml, **/junitreports/**/*.xml'
-				archiveArtifacts artifacts: '**/work/**/*.jtr.xml, **/junitreports/**/*.xml', fingerprint: true, allowEmptyArchive: true
+				archiveArtifacts artifacts: '**/work/**/*.jtr.xml, **/work/**/*.jtr, **/junitreports/**/*.xml', fingerprint: true, allowEmptyArchive: true
 				if (params.TARGET == 'system') {
 		       	 		sh 'tar -zcf openjdk-systemtest-results.tar.gz $WORKSPACE/openjdk-tests/TestConfig/test_output_*'
 		       	 		archiveArtifacts artifacts: '**/openjdk-systemtest-results.tar.gz', fingerprint: true, allowEmptyArchive: true

--- a/buildenv/jenkins/Jenkinsfile_personal
+++ b/buildenv/jenkins/Jenkinsfile_personal
@@ -102,7 +102,7 @@ pipeline {
 			step([$class: "TapPublisher", testResults: "**/*.tap"])
 			archiveArtifacts artifacts: '**/*.tap', fingerprint: true, allowEmptyArchive: true
             junit allowEmptyResults: true, keepLongStdio: true, testResults: '**/work/**/*.jtr.xml, **/junitreports/**/*.xml'
-            archiveArtifacts artifacts: '**/work/**/*.jtr.xml, **/junitreports/**/*.xml', fingerprint: true, allowEmptyArchive: true
+            archiveArtifacts artifacts: '**/work/**/*.jtr.xml, **/work/**/*.jtr, **/junitreports/**/*.xml', fingerprint: true, allowEmptyArchive: true
              script {
             	if (params.TARGET == 'test_systemtest') {  
 	       	 		sh 'tar -zcf openjdk-systemtest-results.tar.gz $WORKSPACE/openjdk-tests/TestConfig/test_output_*'

--- a/buildenv/jenkins/Jenkinsfile_x86-64_windows
+++ b/buildenv/jenkins/Jenkinsfile_x86-64_windows
@@ -55,7 +55,7 @@ pipeline {
  			step([$class: "TapPublisher", testResults: "**/*.tap"])
             archiveArtifacts artifacts: '**/*.tap', fingerprint: true, allowEmptyArchive: true
             junit allowEmptyResults: true, keepLongStdio: true, testResults: '**/work/**/*.xml, **/junitreports/**/*.xml'
-            archiveArtifacts artifacts: '**/work/**/*.jtr.xml, **/junitreports/**/*.xml', fingerprint: true, allowEmptyArchive: true 
+            archiveArtifacts artifacts: '**/work/**/*.jtr.xml, **/work/**/*.jtr, **/junitreports/**/*.xml', fingerprint: true, allowEmptyArchive: true 
  		}
  	}
     

--- a/openjdk_regression/ProblemList_openjdk8-openj9.txt
+++ b/openjdk_regression/ProblemList_openjdk8-openj9.txt
@@ -68,10 +68,42 @@ com/sun/management/HotspotRuntimeMBean/GetSafepointSyncTime.java	000 generic-all
 com/sun/management/HotspotRuntimeMBean/GetTotalSafepointTime.java	000 generic-all
 com/sun/management/HotspotThreadMBean/GetInternalThreads.java   000 generic-all
 com/sun/management/HotSpotDiagnosticMXBean/DumpHeap.sh  000 generic-all
+com/sun/management/HotSpotDiagnosticMXBean/DumpHeap.java  000 generic-all
 com/sun/management/HotSpotDiagnosticMXBean/GetDiagnosticOptions.java  000 generic-all
 com/sun/management/HotSpotDiagnosticMXBean/GetVMOption.java   000 generic-all
 com/sun/management/HotSpotDiagnosticMXBean/SetAllVMOptions.java   000 generic-all
 com/sun/management/HotSpotDiagnosticMXBean/SetVMOption.java   000 generic-all
+com/sun/management/HotSpotDiagnosticMXBean/CheckOrigin.java  000 generic-all
+com/sun/management/HotSpotDiagnosticMXBean/GetDoubleVMOption.java 000 generic-all
+com/sun/management/OperatingSystemMXBean/TestTotalSwap.java  000 generic-all
+com/sun/management/CheckSomeMXBeanImplPackage.java  000 generic-all
+java/lang/management/RuntimeMXBean/TestInputArgument.sh  000 generic-all
+jdk/internal/agent/AgentCMETest.java 000 generic-all
+jdk/internal/agent/AgentCheckTest.java 000 generic-all
+sun/management/LoggingTest/LoggingWithJULTest.java 000 generic-all
+sun/management/LoggingTest/LoggingWithLoggerFinderTest.java 000 generic-all
+sun/management/PlatformMBeanProviderConstructorCheck.java	 000 generic-all
+sun/management/StackTraceElementCompositeData/CompatibilityTest.java	 000 generic-all
+sun/management/jdp/JdpDefaultsTest.java	 000 generic-all
+sun/management/jdp/JdpJmxRemoteDynamicPortTest.java 000 generic-all
+sun/management/jdp/JdpOffTest.java	 000 generic-all
+sun/management/jdp/JdpSpecificAddressTest.java 000 generic-all
+sun/management/jmxremote/bootstrap/JMXInterfaceBindingTest.java	 000 generic-all
+sun/management/jmxremote/bootstrap/PasswordFilePermissionTest.java  000 generic-all
+sun/management/jmxremote/bootstrap/RmiRegistrySslTest.java  000 generic-all
+sun/management/jmxremote/bootstrap/SSLConfigFilePermissionTest.java  000 generic-all
+sun/management/jmxremote/startstop/JMXStatusPerfCountersTest.java  000 generic-all
+sun/management/jmxremote/startstop/JMXStatusTest.java  000 generic-all
+com/sun/management/GarbageCollectorMXBean/GarbageCollectionNotificationContentTest.java  000 generic-all
+com/sun/management/GarbageCollectorMXBean/GarbageCollectionNotificationTest.java  000 generic-all
+java/lang/management/CompositeData/ThreadInfoCompositeData.java 000 generic-all
+sun/management/jmxremote/bootstrap/CustomLauncherTest.java 000 generic-all
+sun/management/jmxremote/bootstrap/JvmstatCountersTest.java 000 generic-all
+sun/management/jmxremote/bootstrap/LocalManagementTest.java 000 generic-all
+sun/management/jmxremote/bootstrap/RmiBootstrapTest.sh 000 generic-all
+sun/management/jmxremote/bootstrap/RmiSslBootstrapTest.sh 000 generic-all
+sun/management/jmxremote/bootstrap/RmiSslNoKeyStoreTest.sh 000 generic-all
+sun/management/jmxremote/startstop/JMXStartStopTest.java 000 generic-all
 
 ############################################################################
 

--- a/openjdk_regression/ProblemList_openjdk8-openj9.txt
+++ b/openjdk_regression/ProblemList_openjdk8-openj9.txt
@@ -85,7 +85,7 @@ sun/management/LoggingTest/LoggingWithLoggerFinderTest.java 000 generic-all
 sun/management/PlatformMBeanProviderConstructorCheck.java	 000 generic-all
 sun/management/StackTraceElementCompositeData/CompatibilityTest.java	 000 generic-all
 sun/management/jdp/JdpDefaultsTest.java	 000 generic-all
-sun/management/jdp/JdpJmxRemoteDynamicPortTest.java 000 generic-all
+sun/management/jdp/JdpJmxRemoteDynamicPortTest.java    000 generic-all
 sun/management/jdp/JdpOffTest.java	 000 generic-all
 sun/management/jdp/JdpSpecificAddressTest.java 000 generic-all
 sun/management/jmxremote/bootstrap/JMXInterfaceBindingTest.java	 000 generic-all
@@ -103,7 +103,7 @@ sun/management/jmxremote/bootstrap/LocalManagementTest.java 000 generic-all
 sun/management/jmxremote/bootstrap/RmiBootstrapTest.sh 000 generic-all
 sun/management/jmxremote/bootstrap/RmiSslBootstrapTest.sh 000 generic-all
 sun/management/jmxremote/bootstrap/RmiSslNoKeyStoreTest.sh 000 generic-all
-sun/management/jmxremote/startstop/JMXStartStopTest.java 000 generic-all
+sun/management/jmxremote/startstop/JMXStartStopTest.java   000 generic-all
 
 ############################################################################
 

--- a/openjdk_regression/playlist.xml
+++ b/openjdk_regression/playlist.xml
@@ -474,7 +474,7 @@
 			<subset>SE100</subset>
 		</subsets>
 		<levels>
-			<level>sanity</level>
+			<level>extended</level>
 		</levels>
 		<groups>
 			<group>openjdk</group>

--- a/openjdk_regression/playlist.xml
+++ b/openjdk_regression/playlist.xml
@@ -528,7 +528,7 @@
 			<subset>SE100</subset>
 		</subsets>
 		<levels>
-			<level>extended</level>
+			<level>sanity</level>
 		</levels>
 		<groups>
 			<group>openjdk</group>


### PR DESCRIPTION
jdk_management group has a set of tests that are not applicable to openj9
