### PR TITLE
Updates on JenkinsfileBase and Jenkinsfile_personal

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -67,8 +67,8 @@ def test() {
 			timestamps{
 				step([$class: "TapPublisher", testResults: "**/*.tap"])
 				archiveArtifacts artifacts: '**/*.tap', fingerprint: true, allowEmptyArchive: true
-				junit allowEmptyResults: true, keepLongStdio: true, testResults: '**/work/**/*.xml, **/junitreports/**/*.xml'
-				archiveArtifacts artifacts: '**/work/**/*.jtr.xml, **/junitreports/**/*.xml', fingerprint: true, allowEmptyArchive: true
+				junit allowEmptyResults: true, keepLongStdio: true, testResults: '**/work/**/*.jtr.xml, **/junitreports/**/*.xml'
+				archiveArtifacts artifacts: '**/work/**/*.jtr, **/junitreports/**/*.xml', fingerprint: true, allowEmptyArchive: true
 				if (params.TARGET == 'system') {
 		       	 		sh 'tar -zcf openjdk-systemtest-results.tar.gz $WORKSPACE/openjdk-tests/TestConfig/test_output_*'
 		       	 		archiveArtifacts artifacts: '**/openjdk-systemtest-results.tar.gz', fingerprint: true, allowEmptyArchive: true

--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -66,13 +66,15 @@ def test() {
 		stage('Post') {
 			timestamps{
 				step([$class: "TapPublisher", testResults: "**/*.tap"])
-				archiveArtifacts artifacts: '**/*.tap', fingerprint: true, allowEmptyArchive: true
 				junit allowEmptyResults: true, keepLongStdio: true, testResults: '**/work/**/*.jtr.xml, **/junitreports/**/*.xml'
-				archiveArtifacts artifacts: '**/work/**/*.jtr, **/junitreports/**/*.xml', fingerprint: true, allowEmptyArchive: true
 				if (params.TARGET == 'system') {
-		       	 		sh 'tar -zcf openjdk-systemtest-results.tar.gz $WORKSPACE/openjdk-tests/TestConfig/test_output_*'
-		       	 		archiveArtifacts artifacts: '**/openjdk-systemtest-results.tar.gz', fingerprint: true, allowEmptyArchive: true
-			    }
+					sh 'tar -zcf openjdk-systemtest-results.tar.gz $WORKSPACE/openjdk-tests/TestConfig/test_output_*'
+					archiveArtifacts artifacts: '**/openjdk-systemtest-results.tar.gz', fingerprint: true, allowEmptyArchive: true
+				}
+				if (currentBuild.result == 'UNSTABLE') {
+					archiveArtifacts artifacts: '**/*.tap', fingerprint: true, allowEmptyArchive: true
+					archiveArtifacts artifacts: '**/work/**/*.jtr, **/junitreports/**/*.xml', fingerprint: true, allowEmptyArchive: true
+				}
 			}
 		}
 	}

--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -22,7 +22,7 @@ def test() {
 					JAVA_IMPL = 'hotspot'
 				}
 				env.JAVA_IMPL= "${JAVA_IMPL}"
-				if (TARGET.contains('openjdk')) {
+				if (TARGET.contains('jdk')) {
 					env.DIAGNOSTICLEVEL ='noDetails'
 				}
 				sh 'printenv'

--- a/buildenv/jenkins/Jenkinsfile_personal
+++ b/buildenv/jenkins/Jenkinsfile_personal
@@ -1,12 +1,11 @@
 #!groovy
-def JAVA_IMPL='hotspot'
 pipeline {
     agent {label "${params.MACHINE_LABEL}"}
     parameters {
     	string (defaultValue: "AdoptOpenJDK", description: 'personal repo', name: 'personalRepo')
     	string (defaultValue: "master", description: 'personal branch', name: 'personalBranch')
 		choice (choices: 'x64_linux\nx64_mac\ns390x_linux\nppc64le_linux\naarch64_linux', description: 'PLATFORM?', name: 'PLATFORM')
-		choice (choices: 'linux_x86-64\nmac_x86-64\nlinux_390-64\nlinux_ppc-64_le\nlinux_arm', description: 'SPEC'?', name: 'SPEC')
+		choice (choices: 'linux_x86-64\nmac_x86-64\nlinux_390-64\nlinux_ppc-64_le\nlinux_arm', description: 'SPEC?', name: 'SPEC')
 		choice (choices: 'SE80\nSE90\nSE100', description: 'What is JAVA_VERSION?', name: 'JAVA_VERSION')
 		string (defaultValue: 'hotspot', description: 'JAVA_IMPL, e.g. hotspot, openj9, sap', name: 'JAVA_IMPL')
 		choice (choices: 'openjdk8\nopenjdk8-openj9\nopenjdk9\nopenjdk9-openj9\nopenjdk10\nopenjdk10-openj9\nopenjdk10-sap', description: 'What is JVM Version?', name: 'JVM_VERSION')
@@ -29,7 +28,7 @@ pipeline {
                 BUILD_LIST="$TESTPROJECT"
                 REPO_URL="https://github.com/$personalRepo/openjdk-tests.git"
                 JVM_VERSION="${JVM_VERSION}"
-                JAVA_IMPL="$JAVA_IMPL"
+                JAVA_IMPL="${JAVA_IMPL}"
 				DIAGNOSTICLEVEL ='failure'
     }
     
@@ -78,7 +77,7 @@ pipeline {
 				timestamps{
                 	echo 'Running tests...'
                 	script {
-						if (TARGET.contains('openjdk')) {
+						if (TARGET.contains('jdk')) {
 							DIAGNOSTICLEVEL ='noDetails'
 						}
 					}

--- a/buildenv/jenkins/Jenkinsfile_personal
+++ b/buildenv/jenkins/Jenkinsfile_personal
@@ -94,15 +94,17 @@ pipeline {
     post {
     	always {
 			step([$class: "TapPublisher", testResults: "**/*.tap"])
-			archiveArtifacts artifacts: '**/*.tap', fingerprint: true, allowEmptyArchive: true
-            junit allowEmptyResults: true, keepLongStdio: true, testResults: '**/work/**/*.jtr.xml, **/junitreports/**/*.xml'
-            archiveArtifacts artifacts: '**/work/**/*.jtr, **/junitreports/**/*.xml', fingerprint: true, allowEmptyArchive: true
-             script {
-            	if (params.TARGET == 'test_systemtest') {  
+			junit allowEmptyResults: true, keepLongStdio: true, testResults: '**/work/**/*.jtr.xml, **/junitreports/**/*.xml'
+            script {
+            	if (params.TARGET == 'systemtest') {  
 	       	 		sh 'tar -zcf openjdk-systemtest-results.tar.gz $WORKSPACE/openjdk-tests/TestConfig/test_output_*'
 	       	 		archiveArtifacts artifacts: '**/openjdk-systemtest-results.tar.gz', fingerprint: true, allowEmptyArchive: true
 		    	}
 	    	}
+		}
+		unstable {
+			archiveArtifacts artifacts: '**/*.tap', fingerprint: true, allowEmptyArchive: true
+			archiveArtifacts artifacts: '**/work/**/*.jtr, **/junitreports/**/*.xml', fingerprint: true, allowEmptyArchive: true
 		}
  	}
     

--- a/buildenv/jenkins/Jenkinsfile_personal
+++ b/buildenv/jenkins/Jenkinsfile_personal
@@ -7,7 +7,8 @@ pipeline {
     	string (defaultValue: "master", description: 'personal branch', name: 'personalBranch')
 		choice (choices: 'x64_linux\nx64_mac\ns390x_linux\nppc64le_linux\naarch64_linux', description: 'PLATFORM?', name: 'PLATFORM')
 		choice (choices: 'linux_x86-64\nmac_x86-64\nlinux_390-64\nlinux_ppc-64_le\nlinux_arm', description: 'SPEC'?', name: 'SPEC')
-		choice (choices: 'SE90\nSE80\nSE100', description: 'What is JAVA_VERSION?', name: 'JAVA_VERSION')
+		choice (choices: 'SE80\nSE90\nSE100', description: 'What is JAVA_VERSION?', name: 'JAVA_VERSION')
+		string (defaultValue: 'hotspot', description: 'JAVA_IMPL, e.g. hotspot, openj9, sap', name: 'JAVA_IMPL')
 		choice (choices: 'openjdk8\nopenjdk8-openj9\nopenjdk9\nopenjdk9-openj9\nopenjdk10\nopenjdk10-openj9\nopenjdk10-sap', description: 'What is JVM Version?', name: 'JVM_VERSION')
 		string (defaultValue: '', description: 'Specific test project, leave blank by default for all projects to be compiled, e.g. openjdk_regression systemtest performance jck thirdparty_containers', name: 'TESTPROJECT')
 		string (defaultValue: 'runtest', description: 'Test Target to execute, default is runtest which will run all tests. You can also select sub-targets such as:\ntop level: openjdk, sanity, extended, system, jck, functional, perf, etc\ndirectory level: prefix a directory with test (eg test_systemtest)\nindividual test: jdk_beans_0, etc', name: 'TARGET')
@@ -28,6 +29,7 @@ pipeline {
                 BUILD_LIST="$TESTPROJECT"
                 REPO_URL="https://github.com/$personalRepo/openjdk-tests.git"
                 JVM_VERSION="${JVM_VERSION}"
+                JAVA_IMPL="$JAVA_IMPL"
 				DIAGNOSTICLEVEL ='failure'
     }
     
@@ -63,17 +65,9 @@ pipeline {
             steps {
 				timestamps{
                 	echo 'Building tests...'
-	                script {
-		                if (JVM_VERSION.contains('openj9')) {
-							JAVA_IMPL = 'openj9'
-						} else if (JVM_VERSION.contains('sap')) {
-							JAVA_IMPL = 'sap'
-						}
-					}
                 	withEnv(["JAVA_HOME=$WORKSPACE/openjdkbinary/j2sdk-image/${(params.JAVA_VERSION == 'SE80') ? 'jre/' : ''}",
                 	"JAVA_BIN=$WORKSPACE/openjdkbinary/j2sdk-image/${(params.JAVA_VERSION == 'SE80') ? 'jre/' : ''}bin",
-                	"JAVA_VERSION=${params.JAVA_VERSION}",
-                	"JAVA_IMPL=${JAVA_IMPL}"]) {
+                	"JAVA_VERSION=${params.JAVA_VERSION}"]) {
                 		sh '$OPENJDK_TEST/maketest.sh $OPENJDK_TEST'
 					}
                 }

--- a/buildenv/jenkins/Jenkinsfile_personal
+++ b/buildenv/jenkins/Jenkinsfile_personal
@@ -6,6 +6,7 @@ pipeline {
     	string (defaultValue: "AdoptOpenJDK", description: 'personal repo', name: 'personalRepo')
     	string (defaultValue: "master", description: 'personal branch', name: 'personalBranch')
 		choice (choices: 'x64_linux\nx64_mac\ns390x_linux\nppc64le_linux\naarch64_linux', description: 'PLATFORM?', name: 'PLATFORM')
+		choice (choices: 'linux_x86-64\nmac_x86-64\nlinux_390-64\nlinux_ppc-64_le\nlinux_arm', description: 'SPEC'?', name: 'SPEC')
 		choice (choices: 'SE90\nSE80\nSE100', description: 'What is JAVA_VERSION?', name: 'JAVA_VERSION')
 		choice (choices: 'openjdk8\nopenjdk8-openj9\nopenjdk9\nopenjdk9-openj9\nopenjdk10\nopenjdk10-openj9\nopenjdk10-sap', description: 'What is JVM Version?', name: 'JVM_VERSION')
 		string (defaultValue: '', description: 'Specific test project, leave blank by default for all projects to be compiled, e.g. openjdk_regression systemtest performance jck thirdparty_containers', name: 'TESTPROJECT')
@@ -23,7 +24,7 @@ pipeline {
 	environment {
                 JCL_VERSION='current'
                 OPENJDK_TEST="$WORKSPACE/openjdk-tests"
-                SPEC='linux_x86-64'
+                SPEC="${SPEC}"
                 BUILD_LIST="$TESTPROJECT"
                 REPO_URL="https://github.com/$personalRepo/openjdk-tests.git"
                 JVM_VERSION="${JVM_VERSION}"

--- a/buildenv/jenkins/Jenkinsfile_personal
+++ b/buildenv/jenkins/Jenkinsfile_personal
@@ -102,13 +102,13 @@ pipeline {
 			step([$class: "TapPublisher", testResults: "**/*.tap"])
 			archiveArtifacts artifacts: '**/*.tap', fingerprint: true, allowEmptyArchive: true
             junit allowEmptyResults: true, keepLongStdio: true, testResults: '**/work/**/*.jtr.xml, **/junitreports/**/*.xml'
-            archiveArtifacts artifacts: '**/work/**/*.jtr.xml, **/junitreports/**/*.xml', fingerprint: true, allowEmptyArchive: true
+            archiveArtifacts artifacts: '**/work/**/*.jtr, **/junitreports/**/*.xml', fingerprint: true, allowEmptyArchive: true
              script {
             	if (params.TARGET == 'test_systemtest') {  
 	       	 		sh 'tar -zcf openjdk-systemtest-results.tar.gz $WORKSPACE/openjdk-tests/TestConfig/test_output_*'
 	       	 		archiveArtifacts artifacts: '**/openjdk-systemtest-results.tar.gz', fingerprint: true, allowEmptyArchive: true
-		    	}     
-	    	}  
+		    	}
+	    	}
 		}
  	}
     


### PR DESCRIPTION
A couple of minor updates on JenkinsfileBase and Jenkinsfile_personal:

1. Archive *.jtr instead of *.jtr.xml, which contains full error logs
2. Enable SPEC parameter instead of hard coded in personal build
3. Set JAVA_IMPL as a  global environment variable, which is consistent with Testkitgen MK story
4. Set DIAGNOSTICLEVEL ='noDetails' for all jdk test
