### PR TITLE
Add stage GetBuildList for template jobs

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -1,9 +1,17 @@
 #!groovy
 /* template jenkinsfile for adoptopenjdk test builds*/
 OPENJDK_TEST="$WORKSPACE/openjdk-tests"
-def TESTPROJECTS = [system:'systemtest', perf:'performance', jck:'jck', external:'thirdparty_containers', openjdk:'openjdk_regression', runtest:'', sanity:'', extended:'' ]
-TESTPROJECT=TESTPROJECTS["$TARGET"]
+def getBuildList() {
+	stage('GetBuildList') {
+		def TESTPROJECTS = [system:'systemtest', perf:'performance', jck:'jck', external:'thirdparty_containers', openjdk:'openjdk_regression', runtest:'', sanity:'', extended:'']
+		String fullTarget="${TARGET}"
+		String[] levelTargets = fullTarget.split('\\.')
+		String simpleTarget = levelTargets[-1]
+		TESTPROJECT = TESTPROJECTS[simpleTarget]
+	}
+}
 def test() {
+	getBuildList()
 	timeout(time: 6, unit: 'HOURS') {
 		stage('Setup') {
 			timestamps{


### PR DESCRIPTION
Support mapping level.group target to group BuildList

Target for template job can be group (e.g. openjdk, openj9, system, etc.) or level.group(e.g. sanity.openjdk, sanity.system, etc.)

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>