### PR TITLE
Add JCK signaturetest to playlist and fix dir rename issue

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -87,13 +87,17 @@ getBinaryOpenjdk()
 	fi
 	jarDir=`ls -d */`
 	dirName=${jarDir%?}
-	mv $dirName j2sdk-image
+	if [ "$dirName" != "j2sdk-image" ]; then
+		mv $dirName j2sdk-image
+	else
+		echo "dirName is equal to j2sdk-image, skip moving"
+	fi
 }
 
 getTestKitGen()
 {
 	cd $TESTDIR
-	git clone https://github.com/eclipse/openj9.git
+	git clone --depth 1 https://github.com/eclipse/openj9.git
 	cd openj9
 	git filter-branch --subdirectory-filter test/TestConfig
 
@@ -112,7 +116,10 @@ wgetSDK()
 }
 
 parseCommandLineArgs "$@"
-getTestKitGen
+if [ ! -d "$TESTDIR/TestConfig" ]; then
+	getTestKitGen
+fi
+
 if [[ "$SDKDIR" != "" ]]; then
 	getBinaryOpenjdk
 fi

--- a/jck/playlist.xml
+++ b/jck/playlist.xml
@@ -199,6 +199,30 @@
 		</subsets>
 	</test>
 	<test>
+		<testCaseName>jck-runtime-api-signaturetest</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>export JAVA_HOME=$(JDK_HOME)$(D)  && \
+	perl $(TEST_RESROOT)$(D)..$(D)systemtest$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
+	-test-root=$(Q)$(TEST_RESROOT)$(D)..$(D)systemtest$(D)stf;$(TEST_RESROOT)$(D)..$(D)systemtest$(D)openjdk-systemtest$(Q) \
+	-systemtest-prereqs=$(Q)$(JCK_ROOT)$(Q)  \
+	-results-root=$(REPORTDIR)  \
+	-test=Jck -test-args=$(Q)tests=api/signaturetest,jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
+	$(TEST_STATUS)</command>
+		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements><!-- Temporarily for linux_x86-64 Jenkins machines only. -->
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>jck</group>
+		</groups>
+		<subsets>
+			<subset>SE80</subset>
+			<subset>SE90</subset>
+		</subsets>
+	</test>	
+	<test>
 		<testCaseName>jck-runtime-vm-constantpool</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>


### PR DESCRIPTION
* add JCK signaturetest to jck playlist and limited it to linux_x86
  machines since only linux_x86 machines have Svfb installed
* add dir name check before rename it to j2sdk-image
* clone openj9 with only main branch and history 2 to shrink clone time
  which also shrink filter-branch time.

fixed:#262

Signed-off-by: Tianyu Zuo <tianyu@ca.ibm.com>