### PR TITLE
Update jdk and hotspot test dir to work with restructuring of openjdk10 test

### DIFF
--- a/openjdk_regression/openjdk_regression.mk
+++ b/openjdk_regression/openjdk_regression.mk
@@ -47,16 +47,17 @@ JTREG_BASIC_OPTIONS += $(JTREG_XML_OPTION)
 # Add any extra options
 JTREG_BASIC_OPTIONS += $(EXTRA_JTREG_OPTIONS)
 
-ifdef JTREG_TEST_DIR
+ifdef OPENJDK_DIR 
 # removing "
-JTREG_TEST_DIR := $(subst ",,$(JTREG_TEST_DIR))
+OPENJDK_DIR := $(subst ",,$(OPENJDK_DIR))
 else
-JTREG_TEST_DIR := $(TEST_ROOT)$(D)openjdk_regression$(D)openjdk-jdk$(D)jdk$(D)test
+OPENJDK_DIR := $(TEST_ROOT)$(D)openjdk_regression$(D)openjdk-jdk
 endif
 
-ifdef JTREG_HOTSPOT_TEST_DIR
-# removing "
-JTREG_HOTSPOT_TEST_DIR := $(subst ",,$(JTREG_TEST_DIR))
+ifneq (,$(findstring $(JAVA_VERSION),SE80-SE90))
+	JTREG_TEST_DIR := $(OPENJDK_DIR)$(D)jdk$(D)test
+	JTREG_HOTSPOT_TEST_DIR := $(OPENJDK_DIR)$(D)hotspot$(D)test
 else
-JTREG_HOTSPOT_TEST_DIR := $(TEST_ROOT)$(D)openjdk_regression$(D)openjdk-jdk$(D)hotspot$(D)test
+	JTREG_TEST_DIR := $(OPENJDK_DIR)$(D)test$(D)jdk
+	JTREG_HOTSPOT_TEST_DIR := $(OPENJDK_DIR)$(D)test$(D)hotspot
 endif

--- a/openjdk_regression/playlist.xml
+++ b/openjdk_regression/playlist.xml
@@ -58,6 +58,7 @@
 		<impls>
 			<impl>hotspot</impl>
 		</impls>
+		<disabled>https://github.com/AdoptOpenJDK/openjdk-tests/issues/228</disabled>
 	</test>
 	<test>
 		<testCaseName>hotspot_jre</testCaseName>
@@ -105,6 +106,7 @@
 		<impls>
 			<impl>hotspot</impl>
 		</impls>
+		<disabled>https://github.com/AdoptOpenJDK/openjdk-tests/issues/228</disabled>
 	</test>
 	<test>
 		<testCaseName>jdk_awt</testCaseName>


### PR DESCRIPTION
In openjdk jdk/hotspot test has been moved from {openjdk source top directory}/jdk(hotspot)/test in jdk8/9 to {openjdk source top directory}/test/jdk(hotspot).  

This change update jdk/hotspot test dir to work for both jdk8/9 and jdk10.

Also disable hotspot test, which need extra command option -nativepath:{location of the hotspot test native library}.

Close #284 

Signed-off-by: Sophia Guo sophiag@ca.ibm.com