### PR TITLE
add jck custom test target back

### DIFF
--- a/jck/README.md
+++ b/jck/README.md
@@ -29,17 +29,18 @@
 
 4. Export `JAVA_HOME=<your_JDK_root>` as an environment variable
 
-5. The other steps will stay the same as instructed in `openjdk-tests/README.md`
+5. If you want to compile jck test only, export `BUILD_LIST=jck`. The other steps will stay the same as instructed in `openjdk-tests/README.md`.
 
 
 This test directory contains:
   * build.xml file - that clones AdoptOpenJDK/stf repo to pick up a test framework
   * playlist.xml - to allow easy inclusion of JCK tests into automated builds
+  * jck.mk - define extra settings for JCK tests.
 
 
 # How-to Run customized JCK test targets
 
-There are three custom JCK test targets `jck-runtime-custom`, `jck-compiler-custom` and `jck-devtools-custom`. With these three test targets, you can run custom JCK subsets.
+There is one custom JCK test targets `jck-runtime-custom`. This test target is used as an example to run custom JCK test target in JCK runtime suite.
 
 1. Follow the Steps 1 - 4 mentioned above. 
 

--- a/jck/jck.mk
+++ b/jck/jck.mk
@@ -1,0 +1,24 @@
+##############################################################################
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##############################################################################
+ifndef JCK_TEST_TARGET
+JCK_TEST_TARGET=api/math
+endif
+
+ifndef JCK_VERSION
+JCK_VERSION=jck8b
+endif
+
+ifndef JCK_ROOT
+JCK_ROOT=$(TEST_ROOT)/jck/jck_root
+endif

--- a/jck/playlist.xml
+++ b/jck/playlist.xml
@@ -13,6 +13,31 @@
 # limitations under the License.
 -->
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
+	<include>jck.mk</include>
+	<test>
+		<testCaseName>jck-runtime-custom</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>export JAVA_HOME=$(JDK_HOME)$(D)  && \
+	perl $(TEST_RESROOT)$(D)..$(D)systemtest$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
+	-java-args-setup=$(Q)$(EXTRA_OPTIONS)$(Q) \
+	-test-root=$(Q)$(TEST_RESROOT)$(D)..$(D)systemtest$(D)stf;$(TEST_RESROOT)$(D)..$(D)systemtest$(D)openjdk-systemtest$(Q) \
+	-systemtest-prereqs=$(Q)$(JCK_ROOT)$(Q)  \
+	-results-root=$(REPORTDIR)  \
+	-test=Jck -test-args=$(Q)tests=$(JCK_TEST_TARGET),jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>jck</group>
+		</groups>
+		<subsets>
+			<subset>SE80</subset>
+			<subset>SE90</subset>
+		</subsets>
+	</test>
 	<test>
 		<testCaseName>jck-runtime-api-java_lang-instrument</testCaseName>
 		<variations>


### PR DESCRIPTION
* add jck runtime custom test target
* add default JCK_TEST_TARGET value into jck.mk, in this case if
  JCK_TEST_TARGET is not define by user, it will have a default value
  to run the jck test
* add default JCK_VERSION and JCK_ROOT in jck.mk
* add jck-runtime test target as an example since we only need runtime
  for now, if extra test suites are needed, will update the playlist 
  upon request.

Signed-off-by: Tianyu Zuo <tianyu@ca.ibm.com>