### PR TITLE
Remove "rm extraSettings.mk"

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -101,7 +101,6 @@ getTestKitGen()
 	cd openj9
 	git filter-branch --subdirectory-filter test/TestConfig
 
-	rm extraSettings.mk
 	cd $TESTDIR
 	mv openj9 TestConfig
 }


### PR DESCRIPTION
- extraSettings.mk no longer exists after latest testKitGen update.

Signed-off-by: Renfei Wang <renfeiw@ca.ibm.com>