### PR TITLE
Enable parallelism for test execution and remove jck dependent functions in Jenkinsfile

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -11,101 +11,82 @@ def getBuildList() {
 	return TESTPROJECT
 }
 
-def getJCK(){
-	dir("$WORKSPACE/jck/"){
-		def jck_suite = "runtime"
-		def jck_version = "0"
-		if (env.JCK_VERSION == "jck8b") {
-			jck_version = "8b"
-		} else if (env.JCK_VERSION == "jck9") {
-			jck_version = "9"
-		} else if (env.JCK_VERSION == "jck10") {
-			jck_version = "10"
-		} else {
-			error_message =  "FAILED: JCK version ${env.JCK_VERSION} are not correctly defined \n"
-			echo error_message
-			currentBuild.result = 'FAILURE'
-			error(error_message)
+def archiveTestBinaries() {
+	dir("$WORKSPACE") {
+		sh "tar -zcf test-binaries.tar.gz ./openjdk-tests ./jvmtest ./openjdkbinary"
+	}
+	archiveArtifacts artifacts: '**/test-binaries.tar.gz', fingerprint: true, allowEmptyArchive: false
+}
+
+def stageTestBinaries() {
+	sh "wget -q --no-check-certificate --header 'Cookie: allow-download=1' ${env.BUILD_URL}artifact/test-binaries.tar.gz " 
+	sh "tar -xzf test-binaries.tar.gz"
+	echo pwd()
+	sh "ls"
+}
+
+def setupEnv() {
+	env.JCL_VERSION = "current"
+	env.JAVA_BIN = "$WORKSPACE/openjdkbinary/j2sdk-image/${(JAVA_VERSION == 'SE80') ? 'jre/' : ''}bin"
+	env.JAVA_HOME = "${JAVA_BIN}/.."
+	env.JAVA_VERSION = "${JAVA_VERSION}"
+	env.JVM_VERSION = "${JVM_VERSION}"
+	env.SPEC = "${SPEC}"
+	env.BUILD_LIST = "${getBuildList()}"
+	
+	if (env.BUILD_LIST == "jck") {
+		if ( JAVA_VERSION == "SE80" ) {
+			env.JCK_VERSION = "jck8b"
+		} else if ( JAVA_VERSION == "SE90" ) {
+			env.JCK_VERSION = "jck9"
+		} else if ( JAVA_VERSION == "SE100" ) {
+			env.JCK_VERSION = "jck10"
 		}
-		def server = Artifactory.server 'na.artifactory.swg-devops'
-		def downloadSpec_JCK = """{
-		"files": [
-			{
-			"pattern": "${JCK_MATERIAL_SERVER_ID}/jck-test/jck-src/${env.JCK_VERSION}/JCK-${jck_suite}-${jck_version}.zip",
-			"target": "./"
-			},
-			{
-			"pattern": "${JCK_MATERIAL_SERVER_ID}/jck-test/jck-src/${env.JCK_VERSION}/${env.JCK_VERSION}_configs.zip",
-			"target": "./"
-			}
-		]
-		}"""
-		server.download(downloadSpec_JCK)
-		sh """
-			df -h
-			mv ./jck-test/jck-src/${env.JCK_VERSION}/* ./
-			ls ./
-			echo "unzipping jck materials"
-			unzip -o -q ./${env.JCK_VERSION}_configs.zip  -d ./${env.JCK_VERSION}/
-			unzip -o -q ./JCK-${jck_suite}-${jck_version}.zip -d ./${env.JCK_VERSION}/
-			echo "unzipping jck materials successfully"
-			ls ./${env.JCK_VERSION}/JCK-${jck_suite}-${jck_version}/
-			ls ./${env.JCK_VERSION}/
-		"""
+		env.JCK_ROOT = "$WORKSPACE/../jck_root"
+		echo "env.JCK_ROOT is: ${env.JCK_ROOT}, env.JCK_VERSION is: ${env.JCK_VERSION}"
+		if( params.JCK_GIT_REPO ) {
+			env.JCK_GIT_REPO = params.JCK_GIT_REPO
+			echo "env.JCK_GIT_REPO is ${env.JCK_GIT_REPO}"
+		} else {
+			echo "params.JCK_GIT_REPO was not defined"
+		}
+	}
+	
+	if (JVM_VERSION.contains('openj9')) {
+		JAVA_IMPL = 'openj9'
+	} else if (JVM_VERSION.contains('sap')) {
+		JAVA_IMPL = 'sap'
+	} else {
+		JAVA_IMPL = 'hotspot'
+	}
+	env.JAVA_IMPL= "${JAVA_IMPL}"
+	if (env.BUILD_LIST == 'openjdk_regression' ||  env.BUILD_LIST == 'thirdparty_containers') {
+		env.DIAGNOSTICLEVEL ='noDetails'
+	}
+	sh 'printenv'
+}
+
+def setupParallelEnv() {
+	stage('setupParallelEnv') {
+		timestamps{
+			cleanWs()
+			setupEnv()
+		}
 	}
 }
 
 def setup() {
 	stage('Setup') {
 		timestamps{
-			env.JCL_VERSION = "current"
-			env.JAVA_BIN = "$WORKSPACE/openjdkbinary/j2sdk-image/${(JAVA_VERSION == 'SE80') ? 'jre/' : ''}bin"
-			env.JAVA_HOME = "${JAVA_BIN}/.."
-			env.JAVA_VERSION = "${JAVA_VERSION}"
-			env.JVM_VERSION = "${JVM_VERSION}"
-			env.SPEC = "${SPEC}"
-			env.BUILD_LIST = "${getBuildList()}"
+			setupEnv()
+			// get TestKitGen and test JDK for test
 			try{
 				CUSTOMIZED_SDK_URL = "${CUSTOMIZED_SDK_URL}"
 			} catch (MissingPropertyException e) {
 				CUSTOMIZED_SDK_URL = ''
 			}
-			//download JCK test materials if BUILD_LIST is jck
-			if (env.BUILD_LIST == "jck") {
-				if ( fileExists ("$WORKSPACE/jck/") ) {
-					dir("$WORKSPACE/jck/") {
-						deleteDir()
-					}
-				}
-				
-				if ( JAVA_VERSION == "SE80" ) {
-					env.JCK_VERSION = "jck8b"
-				} else if ( JAVA_VERSION == "SE90" ) {
-					env.JCK_VERSION = "jck9"
-				} else if ( JAVA_VERSION == "SE100" ) {
-					env.JCK_VERSION = "jck10"
-				}
-				echo "env.BUILD_LIST is jck, starting preparing JCK test materials."
-				getJCK()
-				env.JCK_ROOT = "$WORKSPACE/jck/"
-				
-			}
-			
-			if (JVM_VERSION.contains('openj9')) {
-				JAVA_IMPL = 'openj9'
-			} else if (JVM_VERSION.contains('sap')) {
-				JAVA_IMPL = 'sap'
-			} else {
-				JAVA_IMPL = 'hotspot'
-			}
-			env.JAVA_IMPL= "${JAVA_IMPL}"
-			if (env.BUILD_LIST == 'openjdk_regression' ||  env.BUILD_LIST == 'thirdparty_containers') {
-				env.DIAGNOSTICLEVEL ='noDetails'
-			}
-			sh 'printenv'
-			
-			sh "chmod 755 ${WORKSPACE}/openjdk-tests/maketest.sh"
-			sh "chmod 755 ${WORKSPACE}/openjdk-tests/get.sh"
+			sh "chmod 755 $WORKSPACE/openjdk-tests/maketest.sh"
+			sh "chmod 755 $WORKSPACE/openjdk-tests/get.sh"
 			if (fileExists('openjdkbinary')) {
 				dir('openjdkbinary') {
 					deleteDir()
@@ -125,7 +106,6 @@ def setup() {
 				}
 			}
 			sh "$WORKSPACE/openjdk-tests/get.sh -s $WORKSPACE -t $WORKSPACE/openjdk-tests -p $PLATFORM -v $JVM_VERSION -r $SDK_RESOURCE -c $CUSTOMIZED_SDK_URL"
-			env.JCK_ROOT = "$WORKSPACE/jck/"
 		}
 	}
 }
@@ -133,14 +113,19 @@ def setup() {
 def buildTest() {
 	stage('Build') {
 		timestamps{
-			sh 'printenv'
 			echo 'Building tests...'
 			if (JAVA_VERSION == 'SE80') {
 				sh "chmod 755 ${JAVA_BIN}/java"
 				sh "chmod 755 ${JAVA_BIN}/../../bin/javac"
 				sh "chmod 755 ${JAVA_BIN}/../../bin/java"
 			}
-			sh "$WORKSPACE/openjdk-tests/maketest.sh $WORKSPACE/openjdk-tests"
+			if( params.JCK_GIT_REPO ) {
+				sshagent (credentials: ["$params.SSH_AGENT_CREDENTIAL"]) {
+					sh "$WORKSPACE/openjdk-tests/maketest.sh $WORKSPACE/openjdk-tests"
+				}
+			} else {
+				sh "$WORKSPACE/openjdk-tests/maketest.sh $WORKSPACE/openjdk-tests"
+			}
 		}
 	}
 }
@@ -157,93 +142,71 @@ def runTest(subDir) {
 					env.DISPLAY = "${DISPLAY}"
 					echo "env.DISPLAY is ${env.DISPLAY}"
 					echo 'Running tests...'
-					sh "$WORKSPACE/openjdk-tests/maketest.sh $WORKSPACE/openjdk-tests/$subDir _$TARGET"
+					sh "$WORKSPACE/openjdk-tests/maketest.sh $WORKSPACE/openjdk-tests/${subDir} _$TARGET"
 				}
 			} else {
 				echo 'Running tests...'
-				sh "$WORKSPACE/openjdk-tests/maketest.sh $WORKSPACE/openjdk-tests/$subDir _$TARGET"
+				sh "$WORKSPACE/openjdk-tests/maketest.sh $WORKSPACE/openjdk-tests/${subDir} _$TARGET"
 			}
 		}
 	}
 }
 
-def post() {
+def post(test_target) {
 	stage('Post') {
 		timestamps{
 			step([$class: "TapPublisher", testResults: "**/*.tap"])
 			junit allowEmptyResults: true, keepLongStdio: true, testResults: '**/work/**/*.jtr.xml, **/junitreports/**/*.xml'
 			if (currentBuild.result == 'UNSTABLE') {
-				archiveArtifacts artifacts: '**/*.tap', fingerprint: true, allowEmptyArchive: true
 				archiveArtifacts artifacts: '**/work/**/*.jtr, **/junitreports/**/*.xml', fingerprint: true, allowEmptyArchive: true
-				if (params.TARGET == 'system') {
-					sh 'tar -zcf openjdk-systemtest-results.tar.gz $WORKSPACE/openjdk-tests/TestConfig/test_output_*'
-					archiveArtifacts artifacts: '**/openjdk-systemtest-results.tar.gz', fingerprint: true, allowEmptyArchive: true
-				}
-				if (env.BUILD_LIST == 'jck') {
-					sh 'tar -zcf jck-test-results.tar.gz $WORKSPACE/openjdk-tests/TestConfig/test_output_*'
-					archiveArtifacts artifacts: '**/jck-test-results.tar.gz', fingerprint: true, allowEmptyArchive: true
-				}
+				sh "tar -zcf ${test_target}_test_output.tar.gz $WORKSPACE/openjdk-tests/TestConfig/test_output_*"
+				archiveArtifacts artifacts: "**/${test_target}_test_output.tar.gz", fingerprint: true, allowEmptyArchive: true
 			}
 			cleanWs cleanWhenFailure: false
+			
 		}
 	}
 }
+
 def testBuild() {
 	timeout(time: 6, unit: 'HOURS') {
-		def isParallel = false;
-		try {
-			isParallel = IS_PARALLEL;
-		} catch (MissingPropertyException e) {
-			echo "IS_PARALLEL is not defined, set isParallel to false"
-			isParallel = false
-		}
-		def BUILD_LIST = getBuildList()
-		if ( isParallel == "true" ) {
+		// prepare environment and compile test projects
+		setup()
+		buildTest()
+		if( params.IS_PARALLEL ){
+			// archive compiled test binaries for parallel jobs
+			archiveTestBinaries()
 			def testSubDirs = []
 			def testSubDirSize = 0
-			dir("$WORKSPACE/openjdk-tests/$BUILD_LIST") {
+			dir("$WORKSPACE/openjdk-tests/${env.BUILD_LIST}") {
 				testSubDirs = sh(returnStdout: true, script: "ls -d */").trim().split()
 				testSubDirSize = testSubDirs.size()
 			}
-			echo "isParallel is $isParallel, testSubDirSize is $testSubDirSize, testSubDirs is $testSubDirs"
+			echo "testSubDirSize is ${testSubDirSize}, testSubDirs is ${testSubDirs}, running test in parallel mode"
 			def parallel_tests = [:]
 			for (int i = 0; i < testSubDirSize; i++) {
 				def testSubDir = testSubDirs[i].trim();
 				parallel_tests[testSubDir] = {
 					node ("$LABEL") {
-						if ( fileExists ("$WORKSPACE/openjdk-tests") ) {
-							dir("$WORKSPACE/openjdk-tests") {
-								deleteDir()
-							}
+						setupParallelEnv()
+						stageTestBinaries()
+						if( env.BUILD_LIST == "jck") {
+							buildTest()
 						}
-						def git_url = "https://github.com/AdoptOpenJDK/openjdk-tests.git"
-						def git_branch = "master"
-						try {
-							git_url = GIT_URL;
-						} catch (MissingPropertyException e) {
-							echo "GIT_URL is not defined, use default git_url"
-						}
-						try {
-							git_branch = GIT_BRANCH;
-						} catch (MissingPropertyException e) {
-							echo "GIT_BRANCH is not defined, use default git_branch"
-						}
-						sh "git clone -b $git_branch --depth 1 $git_url"
-						setup()
-						buildTest()
-						runTest("$BUILD_LIST/$testSubDir")
-						post()
+						def test_name = testSubDir.replace("/","")
+						runTest("${env.BUILD_LIST}/${testSubDir}")
+						post("${env.BUILD_LIST}-${test_name}")
 					}
 				}
 			}
 			parallel parallel_tests
+			cleanWs()
 		} else {
-			echo "isParallel is $isParallel, running test in default mode"
-			setup()
-			buildTest()
-			runTest("$BUILD_LIST")
-			post()
+			echo "running test in default mode"
+			runTest("${env.BUILD_LIST}")
+			post("${env.BUILD_LIST}")
 		}
+		
 	}
 }
 return this

--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -1,6 +1,5 @@
 #!groovy
 /* template jenkinsfile for adoptopenjdk test builds*/
-OPENJDK_TEST="$WORKSPACE/openjdk-tests"
 def getBuildList() {
 	def TESTPROJECTS = [system:'systemtest', perf:'performance', jck:'jck', external:'thirdparty_containers', functional: 'functional', openjdk:'openjdk_regression', jdk:'openjdk_regression', runtest:'', sanity:'', extended:'']
 	String fullTarget="${TARGET}"
@@ -105,8 +104,8 @@ def setup() {
 			}
 			sh 'printenv'
 			
-			sh "chmod 755 ${OPENJDK_TEST}/maketest.sh"
-			sh "chmod 755 ${OPENJDK_TEST}/get.sh"
+			sh "chmod 755 ${WORKSPACE}/openjdk-tests/maketest.sh"
+			sh "chmod 755 ${WORKSPACE}/openjdk-tests/get.sh"
 			if (fileExists('openjdkbinary')) {
 				dir('openjdkbinary') {
 					deleteDir()
@@ -125,7 +124,7 @@ def setup() {
 						selector: [$class: 'SpecificBuildSelector', buildNumber: "${params.UPSTREAM_JOB_NUMBER}"]])
 				}
 			}
-			sh "$OPENJDK_TEST/get.sh -s $WORKSPACE -t $OPENJDK_TEST -p $PLATFORM -v $JVM_VERSION -r $SDK_RESOURCE -c $CUSTOMIZED_SDK_URL"
+			sh "$WORKSPACE/openjdk-tests/get.sh -s $WORKSPACE -t $WORKSPACE/openjdk-tests -p $PLATFORM -v $JVM_VERSION -r $SDK_RESOURCE -c $CUSTOMIZED_SDK_URL"
 			env.JCK_ROOT = "$WORKSPACE/jck/"
 		}
 	}
@@ -141,12 +140,12 @@ def buildTest() {
 				sh "chmod 755 ${JAVA_BIN}/../../bin/javac"
 				sh "chmod 755 ${JAVA_BIN}/../../bin/java"
 			}
-			sh "$OPENJDK_TEST/maketest.sh $OPENJDK_TEST"
+			sh "$WORKSPACE/openjdk-tests/maketest.sh $WORKSPACE/openjdk-tests"
 		}
 	}
 }
 
-def runTest() {
+def runTest(subDir) {
 	stage('Test') {
 		timestamps{
 			if (env.BUILD_LIST == "jck"){
@@ -158,11 +157,11 @@ def runTest() {
 					env.DISPLAY = "${DISPLAY}"
 					echo "env.DISPLAY is ${env.DISPLAY}"
 					echo 'Running tests...'
-					sh "$OPENJDK_TEST/maketest.sh $OPENJDK_TEST _$TARGET"
+					sh "$WORKSPACE/openjdk-tests/maketest.sh $WORKSPACE/openjdk-tests/$subDir _$TARGET"
 				}
 			} else {
 				echo 'Running tests...'
-				sh "$OPENJDK_TEST/maketest.sh $OPENJDK_TEST _$TARGET"
+				sh "$WORKSPACE/openjdk-tests/maketest.sh $WORKSPACE/openjdk-tests/$subDir _$TARGET"
 			}
 		}
 	}
@@ -191,10 +190,60 @@ def post() {
 }
 def testBuild() {
 	timeout(time: 6, unit: 'HOURS') {
-		setup()
-		buildTest()
-		runTest()
-		post()
+		def isParallel = false;
+		try {
+			isParallel = IS_PARALLEL;
+		} catch (MissingPropertyException e) {
+			echo "IS_PARALLEL is not defined, set isParallel to false"
+			isParallel = false
+		}
+		def BUILD_LIST = getBuildList()
+		if ( isParallel == "true" ) {
+			def testSubDirs = []
+			def testSubDirSize = 0
+			dir("$WORKSPACE/openjdk-tests/$BUILD_LIST") {
+				testSubDirs = sh(returnStdout: true, script: "ls -d */").trim().split()
+				testSubDirSize = testSubDirs.size()
+			}
+			echo "isParallel is $isParallel, testSubDirSize is $testSubDirSize, testSubDirs is $testSubDirs"
+			def parallel_tests = [:]
+			for (int i = 0; i < testSubDirSize; i++) {
+				def testSubDir = testSubDirs[i].trim();
+				parallel_tests[testSubDir] = {
+					node ("$LABEL") {
+						if ( fileExists ("$WORKSPACE/openjdk-tests") ) {
+							dir("$WORKSPACE/openjdk-tests") {
+								deleteDir()
+							}
+						}
+						def git_url = "https://github.com/AdoptOpenJDK/openjdk-tests.git"
+						def git_branch = "master"
+						try {
+							git_url = GIT_URL;
+						} catch (MissingPropertyException e) {
+							echo "GIT_URL is not defined, use default git_url"
+						}
+						try {
+							git_branch = GIT_BRANCH;
+						} catch (MissingPropertyException e) {
+							echo "GIT_BRANCH is not defined, use default git_branch"
+						}
+						sh "git clone -b $git_branch --depth 1 $git_url"
+						setup()
+						buildTest()
+						runTest("$BUILD_LIST/$testSubDir")
+						post()
+					}
+				}
+			}
+			parallel parallel_tests
+		} else {
+			echo "isParallel is $isParallel, running test in default mode"
+			setup()
+			buildTest()
+			runTest("$BUILD_LIST")
+			post()
+		}
 	}
 }
 return this

--- a/buildenv/jenkins/openjdk10_aarch64_linux
+++ b/buildenv/jenkins/openjdk10_aarch64_linux
@@ -3,7 +3,8 @@
 	Set parameter TARGET(openjdk, system, external, perf, jck etc.).
 	Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_x86-64_linux)
 	Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
-node('linux&&arm64&&test') {
+LABEL='linux&&arm64&&test'
+node("$LABEL") {
     PLATFORM = 'aarch64_linux'
     JAVA_VERSION = 'SE100'
     SDK_RESOURCE = 'upstream'

--- a/buildenv/jenkins/openjdk10_ppc64_aix
+++ b/buildenv/jenkins/openjdk10_ppc64_aix
@@ -3,7 +3,8 @@
 	Set parameter TARGET(openjdk, system, external, perf, jck etc.).
 	Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_x86-64_linux)
 	Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
-node('aix&&ppc64&&test') {
+LABEL='aix&&ppc64&&test'
+node("$LABEL") {
     PLATFORM = 'ppc64_aix'
     JAVA_VERSION = 'SE100'
     SDK_RESOURCE = 'upstream'

--- a/buildenv/jenkins/openjdk10_ppc64le_linux
+++ b/buildenv/jenkins/openjdk10_ppc64le_linux
@@ -3,7 +3,8 @@
 	Set parameter TARGET(openjdk, system, external, perf, jck etc.).
 	Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_x86-64_linux)
 	Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
-node('linux&&ppc64le&&test') { //ppc64le build use "fedora" too, for now leave as is
+LABEL='linux&&ppc64le&&test'
+node("$LABEL") { //ppc64le build use "fedora" too, for now leave as is
     PLATFORM = 'ppc64le_linux'
     JAVA_VERSION = 'SE100'
     SDK_RESOURCE = 'upstream'

--- a/buildenv/jenkins/openjdk10_s390x_linux
+++ b/buildenv/jenkins/openjdk10_s390x_linux
@@ -3,7 +3,8 @@
 	Set parameter TARGET(openjdk, system, external, perf, jck etc.).
 	Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_x86-64_linux)
 	Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
-node('linux&&s390x&&test') {
+LABEL='linux&&s390x&&test'
+node("$LABEL") {
     PLATFORM = 's390x_linux'
     JAVA_VERSION = 'SE100'
     SDK_RESOURCE = 'upstream'

--- a/buildenv/jenkins/openjdk10_x86-64_linux
+++ b/buildenv/jenkins/openjdk10_x86-64_linux
@@ -3,7 +3,8 @@
 	Set parameter TARGET(openjdk, system, external, perf, jck etc.).
 	Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_x86-64_linux)
 	Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
-node('linux&&x64&&test') {
+LABEL='linux&&x64&&test'
+node("$LABEL") {
     PLATFORM = 'x64_linux'
     JAVA_VERSION = 'SE100'
     SDK_RESOURCE = 'upstream'

--- a/buildenv/jenkins/openjdk10_x86-64_macos
+++ b/buildenv/jenkins/openjdk10_x86-64_macos
@@ -3,7 +3,8 @@
 	Set parameter TARGET(openjdk, system, external, perf, jck etc.).
 	Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_x86-64_linux)
 	Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
-node('mac&&x64&&test') {
+LABEL='mac&&x64&&test'
+node("$LABEL") {
     PLATFORM = 'x64_mac'
     JAVA_VERSION = 'SE100'
     SDK_RESOURCE = 'upstream'

--- a/buildenv/jenkins/openjdk8_aarch64_linux
+++ b/buildenv/jenkins/openjdk8_aarch64_linux
@@ -3,7 +3,8 @@
 	Set parameter TARGET(openjdk, system, external, perf, jck etc.).
 	Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_x86-64_linux)
 	Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
-node('linux&&arm64&&test') {
+LABEL='linux&&arm64&&test'
+node("$LABEL") {
     PLATFORM = 'aarch64_linux'
     JAVA_VERSION = 'SE80'
     SDK_RESOURCE = 'upstream'

--- a/buildenv/jenkins/openjdk8_ppc64_aix
+++ b/buildenv/jenkins/openjdk8_ppc64_aix
@@ -3,7 +3,8 @@
 	Set parameter TARGET(openjdk, system, external, perf, jck etc.).
 	Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_x86-64_linux)
 	Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
-node('aix&&ppc64&&test||ci.project.openj9&&hw.arch.ppc&&sw.os.aix7.1') {
+LABEL='aix&&ppc64&&test||ci.project.openj9&&hw.arch.ppc&&sw.os.aix7.1'
+node("$LABEL") {
     PLATFORM = 'ppc64_aix'
     JAVA_VERSION = 'SE80'
     SDK_RESOURCE = 'upstream'

--- a/buildenv/jenkins/openjdk8_ppc64le_linux
+++ b/buildenv/jenkins/openjdk8_ppc64le_linux
@@ -3,7 +3,8 @@
 	Set parameter TARGET(openjdk, system, external, perf, jck etc.).
 	Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_x86-64_linux)
 	Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
-node('linux&&ppc64le&&test||ci.project.openj9&&sw.os.linux&&hw.arch.ppc') { //ppc64le build use "fedora" too, for now leave as is
+LABEL='linux&&ppc64le&&test||ci.project.openj9&&sw.os.linux&&hw.arch.ppc'
+node("$LABEL") { //ppc64le build use "fedora" too, for now leave as is
     PLATFORM = 'ppc64le_linux'
     JAVA_VERSION = 'SE80'
     SDK_RESOURCE = 'upstream'

--- a/buildenv/jenkins/openjdk8_s390x_linux
+++ b/buildenv/jenkins/openjdk8_s390x_linux
@@ -3,7 +3,8 @@
 	Set parameter TARGET(openjdk, system, external, perf, jck etc.).
 	Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_x86-64_linux)
 	Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
-node('linux&&s390x&&test||ci.project.openj9&&sw.os.linux&&hw.arch.s390') {
+LABEL='linux&&s390x&&test||ci.project.openj9&&sw.os.linux&&hw.arch.s390'
+node("$LABEL") {
     PLATFORM = 's390x_linux'
     JAVA_VERSION = 'SE80'
     SDK_RESOURCE = 'upstream'

--- a/buildenv/jenkins/openjdk8_x86-64_linux
+++ b/buildenv/jenkins/openjdk8_x86-64_linux
@@ -3,7 +3,8 @@
 	Set parameter TARGET(openjdk, system, external, perf, jck etc.).
 	Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_x86-64_linux)
 	Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
-node('linux&&x64&&test||ci.project.openj9&&sw.os.linux&&hw.arch.x86') {
+LABEL='linux&&x64&&test||ci.project.openj9&&sw.os.linux&&hw.arch.x86'
+node("$LABEL") {
     PLATFORM = 'x64_linux'
     JAVA_VERSION = 'SE80'
     SDK_RESOURCE = 'upstream'

--- a/buildenv/jenkins/openjdk8_x86-64_macos
+++ b/buildenv/jenkins/openjdk8_x86-64_macos
@@ -3,7 +3,8 @@
 	Set parameter TARGET(openjdk, system, external, perf, jck etc.).
 	Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_x86-64_linux)
 	Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
-node('mac&&x64&&test') {
+LABEL='mac&&x64&&test'
+node("$LABEL") {
     PLATFORM = 'x64_mac'
     JAVA_VERSION = 'SE80'
     SDK_RESOURCE = 'upstream'

--- a/buildenv/jenkins/openjdk9_aarch64_linux
+++ b/buildenv/jenkins/openjdk9_aarch64_linux
@@ -3,7 +3,8 @@
 	Set parameter TARGET(openjdk, system, external, perf, jck etc.).
 	Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_x86-64_linux)
 	Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
-node('linux&&arm64&&test') {
+LABEL='linux&&arm64&&test'
+node("$LABEL") {
     PLATFORM = 'aarch64_linux'
     JAVA_VERSION = 'SE90'
     SDK_RESOURCE = 'upstream'

--- a/buildenv/jenkins/openjdk9_ppc64_aix
+++ b/buildenv/jenkins/openjdk9_ppc64_aix
@@ -3,7 +3,8 @@
 	Set parameter TARGET(openjdk, system, external, perf, jck etc.).
 	Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_x86-64_linux)
 	Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
-node('aix&&ppc64&&test') {
+LABEL='aix&&ppc64&&test'
+node("$LABEL") {
     PLATFORM = 'ppc64_aix'
     JAVA_VERSION = 'SE90'
     SDK_RESOURCE = 'upstream'

--- a/buildenv/jenkins/openjdk9_ppc64le_linux
+++ b/buildenv/jenkins/openjdk9_ppc64le_linux
@@ -3,7 +3,8 @@
 	Set parameter TARGET(openjdk, system, external, perf, jck etc.).
 	Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_x86-64_linux)
 	Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
-node('linux&&ppc64le&&test') { //ppc64le build use "fedora" too, for now leave as is
+LABEL='linux&&ppc64le&&test'
+node("$LABEL") { //ppc64le build use "fedora" too, for now leave as is
     PLATFORM = 'ppc64le_linux'
     JAVA_VERSION = 'SE90'
     SDK_RESOURCE = 'upstream'

--- a/buildenv/jenkins/openjdk9_s390x_linux
+++ b/buildenv/jenkins/openjdk9_s390x_linux
@@ -3,7 +3,8 @@
 	Set parameter TARGET(openjdk, system, external, perf, jck etc.).
 	Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_x86-64_linux)
 	Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
-node('linux&&s390x&&test') {
+LABEL='linux&&s390x&&test'
+node("$LABEL") {
     PLATFORM = 's390x_linux'
     JAVA_VERSION = 'SE90'
     SDK_RESOURCE = 'upstream'

--- a/buildenv/jenkins/openjdk9_x86-64_linux
+++ b/buildenv/jenkins/openjdk9_x86-64_linux
@@ -3,7 +3,8 @@
 	Set parameter TARGET(openjdk, system, external, perf, jck etc.).
 	Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_x86-64_linux)
 	Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
-node('linux&&x64&&test') {
+LABEL='linux&&x64&&test'
+node("$LABEL") {
     PLATFORM = 'x64_linux'
     JAVA_VERSION = 'SE90'
     SDK_RESOURCE = 'upstream'

--- a/buildenv/jenkins/openjdk9_x86-64_macos
+++ b/buildenv/jenkins/openjdk9_x86-64_macos
@@ -3,7 +3,8 @@
 	Set parameter TARGET(openjdk, system, external, perf, jck etc.).
 	Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_x86-64_linux)
 	Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
-node('mac&&x64&&test') {
+LABEL='mac&&x64&&test'
+node("$LABEL") {
     PLATFORM = 'x64_mac'
     JAVA_VERSION = 'SE90'
     SDK_RESOURCE = 'upstream'

--- a/get.sh
+++ b/get.sh
@@ -107,7 +107,7 @@ getTestKitGen()
 
 wgetSDK()
 {
-	wget --no-check-certificate --header 'Cookie: allow-download=1' ${download_url} --directory-prefix=${SDKDIR}/openjdkbinary
+	wget -q --no-check-certificate --header 'Cookie: allow-download=1' ${download_url} --directory-prefix=${SDKDIR}/openjdkbinary
 	if [ $? -ne 0 ]; then
 		echo "Failed to retrieve the jdk binary, exiting"
 		exit 1

--- a/maketest.sh
+++ b/maketest.sh
@@ -11,14 +11,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ######
-cd $1/TestConfig
 if [ "$#" -eq 1 ];then
+	cd $1/TestConfig
 	make -f run_configure.mk
 	if [ $? -ne 0 ]; then
 		exit 1
 	fi
 	make compile
 else
-	make $2
+	make -C $1 -f autoGen.mk $2
 fi
 


### PR DESCRIPTION
* update base file to enable parallelism
* use single LABEL to define Jenkins nodes
* reuse LABEL to parallel test jobs
* remove jck dependent functions in Jenkinsfile
  since JCK materials are staging in ant build.xml
* archive test output dir if test was unstable

Signed-off-by: Tianyu Zuo <tianyu@ca.ibm.com>