### PR TITLE
Remove impls tag for testcases working with all exsiting impls

### DIFF
--- a/openjdk_regression/ProblemList_openjdk10-sap.txt
+++ b/openjdk_regression/ProblemList_openjdk10-sap.txt
@@ -1,0 +1,132 @@
+# List of tests that should not be run by adoptOpenjdk playlist:
+#   1. Does not run with jtreg -samevm mode
+#   2. Causes problems in jtreg -samevm mode for jtreg or tests that follow it
+#   3. The test is too slow or consumes too many system resources
+#   4. The test fails when run on any official build systems
+
+# More than one label is allowed but must be on the same line.
+#
+#############################################################################
+#
+# Fixing the tests:
+#
+# Some tests just may need to be run with "othervm", and that can easily be
+#   done my adding a @run line (or modifying any existing @run):
+#      @run main/othervm NameOfMainClass
+#   Make sure this @run follows any use of @library.
+#   Otherwise, if the test is a samevm possibility, make sure the test is
+#     cleaning up after itself, closing all streams, deleting temp files, etc.
+#
+# Keep in mind that the bug could be in many places, and even different per
+#   platform, it could be a bug in any one of:
+#      - the testcase
+#      - the jdk (jdk classes, native code, or hotspot)
+#      - the native compiler
+#      - the javac compiler
+#      - the OS (depends on what the testcase does)
+#
+# If you managed to really fix one of these tests, here is how you can
+#    remove tests from this list:
+#  1. Make sure test passes on all platforms with samevm, or mark it othervm
+#  2. Make sure test passes on all platforms when run with it's entire group
+#  3. Make sure both VMs are tested, -server and -client, if possible
+#  4. Make sure you try the -d64 option on Solaris
+#  5. Use a tool like JPRT or something to verify these results
+#  6. Delete lines in this file, include the changes with your test changes
+#
+# You may need to repeat your testing 2 or even 3 times to verify good
+#   results, some of these samevm failures are not very predictable.
+#
+#############################################################################
+
+#hotspot_jre
+
+############################################################################
+
+# jdk_awt
+
+############################################################################
+
+# jdk_beans 
+
+############################################################################
+
+# jdk_lang
+
+############################################################################
+
+# jdk_management
+
+############################################################################
+
+# jdk_jmx
+
+############################################################################
+
+# jdk_math
+
+############################################################################
+
+# jdk_other
+
+############################################################################
+
+# jdk_net
+
+############################################################################
+
+# jdk_io
+
+############################################################################
+
+# jdk_jdi
+
+############################################################################
+
+# jdk_nio
+
+############################################################################
+
+# jdk_rmi
+
+############################################################################
+
+# jdk_security
+
+############################################################################
+
+# jdk_sound
+
+############################################################################
+
+# jdk_swing
+
+############################################################################
+
+# jdk_text
+
+############################################################################
+
+# jdk_time
+
+############################################################################
+
+# jdk_tools
+
+############################################################################
+
+# jdk_jdi
+
+############################################################################
+
+# jdk_util
+
+############################################################################
+
+# svc_tools
+
+############################################################################
+
+# jdk_other
+
+############################################################################

--- a/openjdk_regression/playlist.xml
+++ b/openjdk_regression/playlist.xml
@@ -130,10 +130,6 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
-		<impls>
-			<impl>hotspot</impl>
-			<impl>openj9</impl>
-		</impls>
 		<disabled>https://github.com/AdoptOpenJDK/openjdk-tests/issues/49</disabled>
 	</test>
 	<test>
@@ -158,10 +154,6 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
-		<impls>
-			<impl>hotspot</impl>
-			<impl>openj9</impl>
-		</impls>
 	</test>
 	<test>
 		<testCaseName>jdk_io</testCaseName>
@@ -185,10 +177,6 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
-		<impls>
-			<impl>hotspot</impl>
-			<impl>openj9</impl>
-		</impls>
 	</test>
 	<test>
 		<testCaseName>jdk_lang</testCaseName>
@@ -212,10 +200,6 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
-		<impls>
-			<impl>hotspot</impl>
-			<impl>openj9</impl>
-		</impls>
 	</test>
 	<test>
 		<testCaseName>jdk_math</testCaseName>
@@ -239,10 +223,6 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
-		<impls>
-			<impl>hotspot</impl>
-			<impl>openj9</impl>
-		</impls>
 	</test>
 	<test>
 		<testCaseName>jdk_other</testCaseName>
@@ -266,10 +246,6 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
-		<impls>
-			<impl>hotspot</impl>
-			<impl>openj9</impl>
-		</impls>
 	</test>
 	<test>
 		<testCaseName>jdk_net</testCaseName>
@@ -293,10 +269,6 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
-		<impls>
-			<impl>hotspot</impl>
-			<impl>openj9</impl>
-		</impls>
 	</test>
 	<test>
 		<testCaseName>jdk_nio</testCaseName>
@@ -320,10 +292,6 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
-		<impls>
-			<impl>hotspot</impl>
-			<impl>openj9</impl>
-		</impls>
 	</test>
 	<test>
 		<testCaseName>jdk_security1</testCaseName>
@@ -347,10 +315,6 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
-		<impls>
-			<impl>hotspot</impl>
-			<impl>openj9</impl>
-		</impls>
 	</test>
 	<test>
 		<testCaseName>jdk_security2</testCaseName>
@@ -374,10 +338,6 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
-		<impls>
-			<impl>hotspot</impl>
-			<impl>openj9</impl>
-		</impls>
 	</test>
 		<test>
 		<testCaseName>jdk_security3</testCaseName>
@@ -401,10 +361,6 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
-		<impls>
-			<impl>hotspot</impl>
-			<impl>openj9</impl>
-		</impls>
 	</test>
 	<test>
 		<testCaseName>jdk_sound</testCaseName>
@@ -428,10 +384,6 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
-		<impls>
-			<impl>hotspot</impl>
-			<impl>openj9</impl>
-		</impls>
 		<disabled>https://github.com/AdoptOpenJDK/openjdk-tests/issues/73</disabled>
 	</test>
 	<test>
@@ -456,10 +408,6 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
-		<impls>
-			<impl>hotspot</impl>
-			<impl>openj9</impl>
-		</impls>
 		<disabled>https://github.com/AdoptOpenJDK/openjdk-tests/issues/49</disabled>
 	</test>
 	<test>
@@ -484,10 +432,6 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
-		<impls>
-			<impl>hotspot</impl>
-			<impl>openj9</impl>
-		</impls>
 	</test>
 	<test>
 		<testCaseName>jdk_util</testCaseName>
@@ -511,10 +455,6 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
-		<impls>
-			<impl>hotspot</impl>
-			<impl>openj9</impl>
-		</impls>
 	</test>
 	<test>
 		<testCaseName>jdk_time</testCaseName>
@@ -538,10 +478,6 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
-		<impls>
-			<impl>hotspot</impl>
-			<impl>openj9</impl>
-		</impls>
 	</test>
 	<test>
 		<testCaseName>jdk_management</testCaseName>
@@ -565,10 +501,6 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
-		<impls>
-			<impl>hotspot</impl>
-			<impl>openj9</impl>
-		</impls>
 	</test>
 	<test>
 		<testCaseName>jdk_jmx</testCaseName>
@@ -592,10 +524,6 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
-		<impls>
-			<impl>hotspot</impl>
-			<impl>openj9</impl>
-		</impls>
 	</test>
 	<test>
 		<testCaseName>jdk_rmi</testCaseName>
@@ -619,10 +547,6 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
-		<impls>
-			<impl>hotspot</impl>
-			<impl>openj9</impl>
-		</impls>
 	</test>
 	<test>
 		<testCaseName>jdk_sound</testCaseName>
@@ -646,10 +570,6 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
-		<impls>
-			<impl>hotspot</impl>
-			<impl>openj9</impl>
-		</impls>
 	</test>
 	<test>
 		<testCaseName>jdk_tools</testCaseName>
@@ -673,10 +593,6 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
-		<impls>
-			<impl>hotspot</impl>
-			<impl>openj9</impl>
-		</impls>
 	</test>
 	<test>
 		<testCaseName>jdk_jdi</testCaseName>
@@ -700,10 +616,6 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
-		<impls>
-			<impl>hotspot</impl>
-			<impl>openj9</impl>
-		</impls>
 	</test>
 	<test>
 		<testCaseName>jdk_jfr</testCaseName>
@@ -727,9 +639,5 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
-		<impls>
-			<impl>hotspot</impl>
-			<impl>openj9</impl>
-		</impls>
 	</test>
 </playlist>


### PR DESCRIPTION
1. Remove impls tag for testcases working with all exsiting impls
(openj9,
hotspot, sap).  When there is a new impls tests can run against it
automatically. If test doesn't work with new impls we can explicitly add
impls tag.
2. Add ProblemList_openjdk10-sap.txt to enable tests on openjdk10-sap

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>