### PR TITLE
Add Jenkins data file for docker-equipped Linux machines at Adopt

### DIFF
--- a/buildenv/jenkins/openjdk8_x86-64_linux_docker
+++ b/buildenv/jenkins/openjdk8_x86-64_linux_docker
@@ -1,0 +1,14 @@
+#!groovy
+/* Template for test jobs on openjdk8 linux. Configure test job as parameterized.
+	Set parameter TARGET(openjdk, system, external, perf, jck etc.).
+	Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_x86-64_linux)
+	Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
+node('linux&&x64&&test&&sw.tool.docker') {
+    PLATFORM = 'x64_linux'
+    JAVA_VERSION = 'SE80'
+    SDK_RESOURCE = 'upstream'
+    SPEC='linux_x86-64_cmprssptrs'
+    checkout scm
+    def jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
+    jenkinsfile.test()
+}


### PR DESCRIPTION
Added a new Jenkins data file that contains the machine tag for Linux machines that have docker in them (e.g. "sw.tool.docker"). This data file is to be used in the External test builds that require docker. 
Signed-off-by: Mesbah <Mesbah_Alam@ca.ibm.com>