### PR TITLE
Update Jenkinsfile_personal to drive internal personal build

### DIFF
--- a/buildenv/jenkins/Jenkinsfile_personal
+++ b/buildenv/jenkins/Jenkinsfile_personal
@@ -66,6 +66,13 @@ pipeline {
             steps {
 				timestamps{
                 	echo 'Building tests...'
+                	script {
+	                	if (JAVA_VERSION == 'SE80') {
+							sh "chmod 755 ${JAVA_BIN}/java"
+							sh "chmod 755 ${JAVA_BIN}/../../bin/javac"
+							sh "chmod 755 ${JAVA_BIN}/../../bin/java"
+						}
+					}
                 	sh '$OPENJDK_TEST/maketest.sh $OPENJDK_TEST'
                 }
             }


### PR DESCRIPTION
Updated Jenkinsfile_personal so that it can be used to define a personal build in the internal Jenkins system. 
Signed-off-by: Mesbah <Mesbah_Alam@ca.ibm.com>