### PR TITLE
Change Machine label type to String

### DIFF
--- a/buildenv/jenkins/Jenkinsfile_personal
+++ b/buildenv/jenkins/Jenkinsfile_personal
@@ -11,7 +11,7 @@ pipeline {
 		choice (choices: 'openjdk8\nopenjdk8-openj9\nopenjdk9\nopenjdk9-openj9\nopenjdk10\nopenjdk10-openj9\nopenjdk10-sap', description: 'What is JVM Version?', name: 'JVM_VERSION')
 		string (defaultValue: '', description: 'Specific test project, leave blank by default for all projects to be compiled, e.g. openjdk_regression systemtest performance jck thirdparty_containers', name: 'TESTPROJECT')
 		string (defaultValue: 'runtest', description: 'Test Target to execute, default is runtest which will run all tests. You can also select sub-targets such as:\ndifferent group: openjdk, system, jck, functional, perf, etc\ndifferent level: sanity, extended\nindividual test: jdk_beans_0, etc', name: 'TARGET')
- 		choice (choices: 'linux&&x64&&test\nmac&&x64&&test\nwindows&&x64&&test\nsw.tool.docker', description: 'What is machine label?', name: 'MACHINE_LABEL')
+ 		string (defaultValue: 'linux&&x64&&test', description: 'Machine label for jenkins node. Could be any reasonable and workable label For example:\nlinux&&x64&&test\nmac&&x64&&test\nwindows&&x64&&test\nlinux&&ppc64le&&test\nsw.tool.docker\nci.project.openj9&&sw.os.linux&&hw.arch.x86\n etc.', name: 'MACHINE_LABEL')
 		choice (choices: 'releases\nnightly\nupstream\ncustomized', description: 'Where is sdk?', name: 'SDK_RESOURCE')
 		string (defaultValue: "N/A", description: 'Upstream build name, only set when SDK_RESOURCE is upstream', name: 'UPSTREAM_JOB_NAME')
 		string (defaultValue: "N/A", description: 'Build number of upstream build, working with UPSTREAM_JOB_NAME, only set when SDK_RESOURCE is upstream', name: 'UPSTREAM_JOB_NUMBER')


### PR DESCRIPTION
Change Machine label type to String, which will be more flexible when
new label is required or enabled 

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>