### PR TITLE
clean JCK test job workspaces to avoid consuming too much disk space

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -182,6 +182,7 @@ def post() {
 				if (env.BUILD_LIST == 'jck') {
 					sh 'tar -zcf jck-test-results.tar.gz $WORKSPACE/openjdk-tests/TestConfig/test_output_*'
 					archiveArtifacts artifacts: '**/jck-test-results.tar.gz', fingerprint: true, allowEmptyArchive: true
+					cleanWs()
 				}
 				cleanWs cleanWhenFailure: false
 			}


### PR DESCRIPTION
* each JCK test job may consume 5gb disk space
* some slaves only have 50gb disk space in total
* JCK test jobs will archive its test failure results and 
  clean its workspace after each run