### PR TITLE
Use master branch instead of dev to git clone adoptOpenJDK openjdk repo

### DIFF
--- a/openjdk_regression/ProblemList_openjdk8.txt
+++ b/openjdk_regression/ProblemList_openjdk8.txt
@@ -90,7 +90,6 @@ runtime/ErrorHandling/TestExitOnOutOfMemoryError.java	121	generic-all
 runtime/ErrorHandling/TestOnOutOfMemoryError.java	122	generic-all
 runtime/NMT/NMTWithCDS.java	124	generic-all
 runtime/memory/ReserveMemory.java	124	generic-all
-runtime/RedefineTests/RedefineInterfaceCall.java	267 generic-all
 serviceability/jvmti/TestRedefineWithUnresolvedClass.java	124	generic-all
 serviceability/jvmti/GetObjectSizeOverflow.java	124	linux-all
 serviceability/sa/jmap-hashcode/Test8028623.java	124	linux-all

--- a/openjdk_regression/build.xml
+++ b/openjdk_regression/build.xml
@@ -37,7 +37,7 @@
 	
 	<target name="getOpenjdk" depends="openjdk-jdk.check" unless="jdkdir.exists">
 		<exec executable="git" failonerror="false">
-			<arg line="clone -b dev -q https://github.com/AdoptOpenJDK/${openjdkGit}.git" />
+			<arg line="clone --depth 1 -q https://github.com/AdoptOpenJDK/${openjdkGit}.git" />
 		</exec>
 		<move file="${openjdkGit}" tofile="openjdk-jdk"/>
 	</target>


### PR DESCRIPTION
Use master branch instead of dev to git clone adoptOpenJDK openjdk repo
as master has been updated as the default branch.
Also use shallow clone to save clone time.
 
Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>