### PR TITLE
integrate JCK material staging into ant build process

### DIFF
--- a/jck/README.md
+++ b/jck/README.md
@@ -33,9 +33,9 @@
 
 
 This test directory contains:
-  * build.xml file - that clones AdoptOpenJDK/stf repo to pick up a test framework
-  * playlist.xml - to allow easy inclusion of JCK tests into automated builds
-  * jck.mk - define extra settings for JCK tests.
+  * `build.xml` file - that clones AdoptOpenJDK/stf repo to pick up a test framework
+  * `<test_subset>/playlist.xml` - to allow easy inclusion of JCK tests into automated builds
+  * `jck.mk` - define extra settings for running JCK tests.
 
 
 # How-to Run customized JCK test targets

--- a/jck/build.xml
+++ b/jck/build.xml
@@ -24,6 +24,64 @@
 	<property name="SYSTEMTEST_BUILD_ROOT" value="${BUILD_ROOT}/systemtest" />
 	<property environment="env" />
 
+	<target name="stage_jck_material">
+		<!-- Starting downloading or updating JCK materials based on JCK GIT REPO and JCK VERSION-->
+		<if>
+			<!-- jck materials don't exist, download them -->
+			<then>
+				<echo message="${env.JCK_ROOT}/${env.JCK_VERSION} does not exist, 
+					clone from ${env.JCK_GIT_REPO} to ${env.JCK_ROOT}/${env.JCK_VERSION}" />
+				<exec executable="git" dir="${env.JCK_ROOT}" failonerror="true">
+					<arg value="clone" />
+					<arg value="--depth" />
+					<arg value="1" />
+					<arg value="--single-branch" />
+					<arg value="${env.JCK_GIT_REPO}" />
+					<arg value="${env.JCK_VERSION}" />
+				</exec>
+			</then>
+			<!-- jck materials exist, update jck materials if needed-->
+			<else>
+				<echo message="${env.JCK_ROOT}/${env.JCK_VERSION} exists, try to update jck materials" />
+				<echo message="git fetch ${env.JCK_GIT_REPO}" />
+				<exec executable="git" dir="${env.JCK_ROOT}/${env.JCK_VERSION}" failonerror="true">
+					<arg value="fetch" />
+				</exec>
+				<echo message="git rebase origin/master" />
+				<exec executable="git" dir="${env.JCK_ROOT}/${env.JCK_VERSION}" failonerror="true">
+					<arg value="rebase" />
+					<arg value="origin/master" />
+				</exec>
+			</else>
+		</if>
+	</target>
+
+	<target name="compile_jck">
+		<propertyregex property="jck_short_version" input="${env.JCK_VERSION}" regexp="jck([^\.]*)" select="\1" casesensitive="false" />
+		<propertyregex property="spec_short_name" defaultValue="${env.SPEC}" input="${env.SPEC}" regexp="([^\.]*)_cmprssptrs" select="\1" casesensitive="false" />
+		<echo message="jck_short_version is ${jck_short_version}" />
+		<echo message="spec_short_name is {spec_short_name}" />
+		<if>
+			<not>
+				<available file="${env.JCK_ROOT}/${env.JCK_VERSION}/natives/${spec_short_name}" type="dir" />
+			</not>
+			<!-- jck natives doesn't exist, compile them -->
+			<then>
+				<exec executable="make" failonerror="true">
+					<arg value="-f" />
+					<arg value="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.test.jck/src/native/makefile" />
+					<arg value="PLATFORM=${spec_short_name}" />
+					<arg value="SRCDIR=${env.JCK_ROOT}/${env.JCK_VERSION}/JCK-runtime-${jck_short_version}" />
+					<arg value="OUTDIR=${env.JCK_ROOT}/${env.JCK_VERSION}/natives" />
+					<arg value="build" />
+				</exec>
+			</then>
+			<else>
+				<echo message="${env.JCK_ROOT}/${env.JCK_VERSION}/natives/${spec_short_name} exists" />
+			</else>
+		</if>
+	</target>
+
 	<target name="init">
 		<mkdir dir="${DEST}" />
 		<if>
@@ -86,17 +144,17 @@
 	</target>
 
 	<target name="configure_stf" depends="check_systemtest">
-		<ant antfile="${SYSTEMTEST_ROOT}/stf/stf.build/build.xml" dir="${SYSTEMTEST_ROOT}/stf/stf.build/" target="configure" inheritAll="false" >
-			<property name="java.home" value="${JAVA_BIN}/.."/>
+		<ant antfile="${SYSTEMTEST_ROOT}/stf/stf.build/build.xml" dir="${SYSTEMTEST_ROOT}/stf/stf.build/" target="configure" inheritAll="false">
+			<property name="java.home" value="${JAVA_BIN}/.." />
 		</ant>
-		<ant antfile="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build/build.xml" dir="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build/" target="configure" inheritAll="false" >
-			<property name="java.home" value="${JAVA_BIN}/.."/>
+		<ant antfile="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build/build.xml" dir="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build/" target="configure" inheritAll="false">
+			<property name="java.home" value="${JAVA_BIN}/.." />
 		</ant>
 	</target>
 
 	<target name="compile_stf" depends="configure_stf">
-		<ant antfile="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build/build.xml" dir="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build" inheritAll="false" >
-			<property name="java.home" value="${JAVA_BIN}/.."/>
+		<ant antfile="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build/build.xml" dir="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build" inheritAll="false">
+			<property name="java.home" value="${JAVA_BIN}/.." />
 		</ant>
 	</target>
 
@@ -119,43 +177,57 @@
 		</if>
 		<copy todir="${DEST}">
 			<fileset dir="${basedir}">
-				<exclude name="jck_root/"/>
-				<exclude name="README.md"/>
+				<exclude name="jck_root/" />
+				<exclude name="README.md" />
 			</fileset>
 		</copy>
-		<copy todir="${JCK_ROOT}/">
+		<copy todir="${env.JCK_ROOT}/">
 			<fileset dir="${basedir}/../systemtest_prereqs/" includes="**" />
 		</copy>
 	</target>
 
 	<target name="build">
-		<echo>JCK_ROOT is set to: ${JCK_ROOT}</echo>
 		<if>
-			<isset property="JCK_ROOT" />
+			<and>
+				<isset property="env.JCK_ROOT" />
+				<isset property="env.JCK_VERSION" />
+			</and>
 			<then>
+				<echo>=== env.JCK_ROOT is set to ${env.JCK_ROOT} ===</echo>
+				<echo>=== env.JCK_VERSION is set to ${env.JCK_VERSION} ===</echo>
 				<if>
-					<not>
-						<equals arg1="${JCK_ROOT}" arg2="" />
-					</not>
+					<isset property="env.JCK_GIT_REPO" />
 					<then>
-						<echo>=== JCK_ROOT is set to ${JCK_ROOT} ===</echo>
+						<echo>=== env.JCK_GIT_REPO is set to ${env.JCK_GIT_REPO} ===</echo>
+						<echo>start staging jck materials</echo>
+						<antcall target="stage_jck_material" inheritall="true" />
+						<echo>start building stf-based jck project</echo>
+						<antcall target="dist" inheritall="true" />
+						<echo>start compiling jck natives</echo>
+						<antcall target="compile_jck" inheritall="true" />
+					</then>
+					<else>
 						<echo>start building jck project</echo>
 						<antcall target="dist" inheritall="true" />
-					</then>
+						<echo>start compiling jck natives</echo>
+						<antcall target="compile_jck" inheritall="true" />
+					</else>
 				</if>
 			</then>
 			<else>
-				<echo message="JCK_ROOT is not set, skip building jck" />
+				<fail message="env.JCK_ROOT: ${env.JCK_ROOT} or env.JCK_VERSION: ${env.JCK_VERSION}
+					was not corretly set. If you do not want to compile JCK tests, 
+					please use BUILD_LIST to include test folders you want to test." />
 			</else>
 		</if>
 	</target>
 
 	<target name="clean">
-		<ant antfile="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build/build.xml" dir="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build" inheritAll="false" target="clean" >
-			<property name="java.home" value="${JAVA_BIN}/.."/>
+		<ant antfile="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build/build.xml" dir="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build" inheritAll="false" target="clean">
+			<property name="java.home" value="${JAVA_BIN}/.." />
 		</ant>
-		<ant antfile="${SYSTEMTEST_ROOT}/stf/stf.build/build.xml" dir="${SYSTEMTEST_ROOT}/stf/stf.build" inheritAll="false" target="clean" >
-			<property name="java.home" value="${JAVA_BIN}/.."/>
+		<ant antfile="${SYSTEMTEST_ROOT}/stf/stf.build/build.xml" dir="${SYSTEMTEST_ROOT}/stf/stf.build" inheritAll="false" target="clean">
+			<property name="java.home" value="${JAVA_BIN}/.." />
 		</ant>
 	</target>
 </project>


### PR DESCRIPTION
* download JCK materials from GIT repo if JCK_GIT_REPO was defined
* fetch and rebase to update JCK materials if necessary
* compile JCK natives if necessary
* skip downloading if JCK material folder exists
* fail compilation if no JCK_ROOT was defined

Issue:#335

Signed-off-by: Tianyu Zuo <tianyu@ca.ibm.com>