### PR TITLE
jck: enable signature test on all platforms

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -149,7 +149,7 @@ def buildTest() {
 def runTest() {
 	stage('Test') {
 		timestamps{
-			if (env.BUILD_LIST == "jck" && env.SPEC.contains('linux_x86-64') ){
+			if (env.BUILD_LIST == "jck"){
 				wrap([$class: 'Xvfb', autoDisplayName: true]) {
 					def DISPLAY = sh (
 						script: 'ps -f  | grep \'[X]vfb\' | awk \'{print \$9}\'',

--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -268,7 +268,6 @@
 	-results-root=$(REPORTDIR)  \
 	-test=Jck -test-args=$(Q)tests=api/signaturetest,jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
 	$(TEST_STATUS)</command>
-		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements><!-- Temporarily for linux_x86-64 Jenkins machines only. -->
 		<levels>
 			<level>sanity</level>
 		</levels>


### PR DESCRIPTION
* Xvfb has been installed on most supported platforms
* enable signature test and make it run normally


Signed-off-by: Tianyu Zuo <tianyu@ca.ibm.com>