### PR TITLE
update default time limit to 8 hours to fit JCK tests

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -169,7 +169,11 @@ def post(test_target) {
 }
 
 def testBuild() {
-	timeout(time: 6, unit: 'HOURS') {
+	def time_limit = 8
+	if(params.TIME_LIMIT) {
+		time_limit = params.TIME_LIMIT.toInteger()
+	}
+	timeout(time: time_limit, unit: 'HOURS') {
 		// prepare environment and compile test projects
 		setup()
 		buildTest()


### PR DESCRIPTION
* update default time limit to 8 hours to fit JCK tests
* add variable time_limit to accept user defined time limit

Signed-off-by: Tianyu Zuo <tianyu@ca.ibm.com>