### PR TITLE
Correct copyright to Apache 2.0 license header.

### DIFF
--- a/thirdparty_containers/example-test/dockerfile/Dockerfile
+++ b/thirdparty_containers/example-test/dockerfile/Dockerfile
@@ -1,5 +1,3 @@
-# (C) Copyright IBM Corporation 2017.
-#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/thirdparty_containers/example-test/dockerfile/example-test.sh
+++ b/thirdparty_containers/example-test/dockerfile/example-test.sh
@@ -1,7 +1,4 @@
 #/bin/bash
-#
-# (C) Copyright IBM Corporation 2017.
-#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/thirdparty_containers/scala/dockerfile/Dockerfile
+++ b/thirdparty_containers/scala/dockerfile/Dockerfile
@@ -1,5 +1,3 @@
-# (C) Copyright IBM Corporation 2017.
-#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/thirdparty_containers/scala/dockerfile/scala-test.sh
+++ b/thirdparty_containers/scala/dockerfile/scala-test.sh
@@ -1,7 +1,4 @@
 #/bin/bash
-#
-# (C) Copyright IBM Corporation 2017.
-#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/thirdparty_containers/tomcat/dockerfile/Dockerfile
+++ b/thirdparty_containers/tomcat/dockerfile/Dockerfile
@@ -1,5 +1,3 @@
-# (C) Copyright IBM Corporation 2018.
-#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/thirdparty_containers/tomcat/dockerfile/tomcat-test.sh
+++ b/thirdparty_containers/tomcat/dockerfile/tomcat-test.sh
@@ -1,7 +1,4 @@
 #/bin/bash
-#
-# (C) Copyright IBM Corporation 2018.
-#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at


### PR DESCRIPTION
Correct copyright to Apache 2.0 license header.
Signed-off-by: Mesbah <Mesbah_Alam@ca.ibm.com>