### PR TITLE
set outputTapToConsole to false in TapPublisher

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -155,7 +155,7 @@ def runTest(subDir) {
 def post(test_target) {
 	stage('Post') {
 		timestamps{
-			step([$class: "TapPublisher", testResults: "**/*.tap"])
+			step([$class: "TapPublisher", testResults: "**/*.tap", outputTapToConsole: false])
 			junit allowEmptyResults: true, keepLongStdio: true, testResults: '**/work/**/*.jtr.xml, **/junitreports/**/*.xml'
 			if (currentBuild.result == 'UNSTABLE') {
 				archiveArtifacts artifacts: '**/work/**/*.jtr, **/junitreports/**/*.xml', fingerprint: true, allowEmptyArchive: true


### PR DESCRIPTION
- Avoid to echo TAP file content to console output. User can
check the result in the TAP UI.

Signed-off-by: lanxia <lan_xia@ca.ibm.com>