### PR TITLE
remove JCK_ROOT and JCK_VERSION from jck.mk

### DIFF
--- a/jck/jck.mk
+++ b/jck/jck.mk
@@ -12,13 +12,5 @@
 # limitations under the License.
 ##############################################################################
 ifndef JCK_TEST_TARGET
-JCK_TEST_TARGET=api/math
-endif
-
-ifndef JCK_VERSION
-JCK_VERSION=jck8b
-endif
-
-ifndef JCK_ROOT
-JCK_ROOT=$(TEST_ROOT)/jck/jck_root
+JCK_TEST_TARGET=api/java_math
 endif


### PR DESCRIPTION
* We restrict user to define JCK_ROOT and JCK_VERSION
  before compile tests materials. So we do not need to
  pre-define these two variables in jck.mk
* update default test subset to the correct java_math,
  which do not need extra dependencies other than JCK materials

Signed-off-by: Tianyu Zuo <tianyu@ca.ibm.com>