### PR TITLE
Add openjdk10-openj9 sdk specific TEST.ROOT

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -163,7 +163,6 @@ def post(test_target) {
 				archiveArtifacts artifacts: "**/${test_target}_test_output.tar.gz", fingerprint: true, allowEmptyArchive: true
 			}
 			cleanWs cleanWhenFailure: false
-			
 		}
 	}
 }

--- a/openjdk_regression/build.xml
+++ b/openjdk_regression/build.xml
@@ -55,6 +55,12 @@
 			<arg line="clone --depth 1 -q https://github.com/AdoptOpenJDK/${openjdkGit}.git" />
 		</exec>
 		<move file="${openjdkGit}" tofile="openjdk-jdk"/>
+		<if>
+			<equals arg1="${JVM_VERSION}" arg2="openjdk10-openj9"/>
+			<then>
+				<copy file="${src}/${JVM_VERSION}/TEST.ROOT" todir="${src}/openjdk-jdk/test/jdk" overwrite="true"/>
+			</then>
+		</if>
 	</target>
 	
 	<target name="openjdk-jdk.check">

--- a/openjdk_regression/openjdk10-openj9/TEST.ROOT
+++ b/openjdk_regression/openjdk10-openj9/TEST.ROOT
@@ -1,0 +1,55 @@
+# This file identifies the root of the test-suite hierarchy.
+# It also contains test-suite configuration information.
+
+# The list of keywords supported in the entire test suite.  The
+# "intermittent" keyword marks tests known to fail intermittently.
+# The "randomness" keyword marks tests using randomness with test
+# cases differing from run to run. (A test using a fixed random seed
+# would not count as "randomness" by this definition.) Extra care
+# should be taken to handle test failures of intermittent or
+# randomness tests.
+#
+# A "headful" test requires a graphical environment to meaningfully
+# run. Tests that are not headful are "headless".
+# A test flagged with key "printer" requires a printer to succeed, else
+# throws a PrinterException or the like.
+
+keys=2d dnd headful i18n intermittent printer randomness
+
+# Tests that must run in othervm mode
+othervm.dirs=java/awt java/beans javax/accessibility javax/imageio javax/sound javax/print javax/management com/sun/awt sun/awt sun/java2d javax/xml/jaxp/testng/validation java/lang/ProcessHandle
+
+# Tests that cannot run concurrently
+exclusiveAccess.dirs=java/rmi/Naming java/util/prefs sun/management/jmxremote sun/tools/jstatd sun/security/mscapi java/util/stream java/util/Arrays/largeMemory java/util/BitSet/stream javax/rmi com/sun/corba/cachedSocket
+
+# Group definitions
+groups=TEST.groups
+
+# Allow querying of various System properties in @requires clauses
+#
+# Source files for classes that will be used at the beginning of each test suite run,
+# to determine additional characteristics of the system for use with the @requires tag.
+# Note: compiled bootlibs code will be located in the folder 'bootClasses'
+
+# comment out following requires as they don't work for eclipse openj9.
+#requires.extraPropDefns = ../../test/jtreg-ext/requires/VMProps.java [../../closed/test/jtreg-ext/requires/VMPropsExt.java]
+#requires.extraPropDefns.bootlibs = ../../test/lib/sun ../../test/lib/jdk/test/lib/Platform.java
+#requires.extraPropDefns.vmOpts = -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:bootClasses
+#requires.properties= \
+#    sun.arch.data.model \
+#    java.runtime.name \
+#    vm.graal.enabled \
+#    vm.cds
+
+# Minimum jtreg version
+requiredVersion=4.2 b09
+
+# Path to libraries in the topmost test directory. This is needed so @library
+# does not need ../../ notation to reach them
+external.lib.roots = ../../
+
+# Use new module options
+useNewOptions=true
+
+# Use --patch-module instead of -Xmodule:
+useNewPatchModule=true


### PR DESCRIPTION
openjdk-jdk10/test/jdk/TEST.ROOT doesn't work with openjdk10-openj9. Use openjdk10-openj9/TEST.ROOT instead of openjdk-jdk10/test/jdk/TEST.ROOT to run test/jdk against openjdk10-openj9 sdk.

Manually update this file may be needed if
openjdk-jdk10/test/jdk/TEST.ROOT is updated or openjdk10-openj9
implemented with corresponding package related with system properties.
 
Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>