### PR TITLE
update gitignore file to ignore .classpath and .project change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ TestConfig/lib/*
 openjdk_regression/*.gz
 example/*.jar
 .DS_Store
+.classpath
+.project


### PR DESCRIPTION
* when this repo was imported into eclispe as project, eclispe
  will generate .project and .classpath file automatically.
  This commit is used to update gitignore file to ignore
  .classpath and .project changes

Signed-off-by: Tianyu Zuo <tianyu@ca.ibm.com>