### PR TITLE
upadte jck readme example to export JAVA_HOME

### DIFF
--- a/jck/README.md
+++ b/jck/README.md
@@ -92,6 +92,7 @@ cd /test
 bash get.sh --testdir /test --customizedURL https://api.adoptopenjdk.net/openjdk8-openj9/nightly/x64_linux/latest/binary --sdkdir /java 
 export JAVA_VERSION=SE80
 export JAVA_BIN=/java/openjdkbinary/j2sdk-image/jre/bin/
+export JAVA_HOME=/java/openjdkbinary/j2sdk-image/
 export SPEC=linux_x86-64_cmprssptrs
 export BUILD_LIST=jck
 export JCK_ROOT=/jck_root


### PR DESCRIPTION
* STF JCK needs JAVA_HOME when compiled with Java9 and up

Signed-off-by: Tianyu Zuo <tianyu@ca.ibm.com>