### PR TITLE
Adding Elasticsearch under thirdparty containers

### DIFF
--- a/thirdparty_containers/elasticsearch/build.xml
+++ b/thirdparty_containers/elasticsearch/build.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<project name="elasticsearch-test" default="build" basedir=".">
+	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+	<description>
+		Build elasticsearch-test Docker image
+	</description>
+
+	<!-- set properties for this build -->
+	<property name="DEST" value="${BUILD_ROOT}/thirdparty_containers/elasticsearch-test" />
+	<property name="src" location="." />
+	<property name="jvm_version" location="${JVM_VERSION}" />
+
+	<target name="init">
+		<mkdir dir="${DEST}"/>
+	</target>
+
+	<target name="clean_image" depends="init" description="clean elasticsearch test docker image if there is one">
+		<exec executable="docker">
+			<arg line="rmi -f adoptopenjdk-elasticsearch-test" />
+		</exec>
+	</target>
+
+	<target name="build_image" depends="clean_image" description="build elasticsearch test docker image">
+		<exec executable="docker"  failonerror="true">
+			<arg line="build -t adoptopenjdk-elasticsearch-test -f dockerfile/Dockerfile --pull . --build-arg SDK=${JVM_VERSION}" />
+		</exec>
+	</target>
+
+	<target name="dist" depends="build_image" description="generate the distribution">
+		<copy todir="${DEST}">
+			<fileset dir="${src}" includes="*.xml, *.mk"/>
+		</copy>
+	</target>
+
+	<target name="build">
+		<antcall target="dist" inheritall="true" />
+	</target>
+</project>

--- a/thirdparty_containers/elasticsearch/dockerfile/Dockerfile
+++ b/thirdparty_containers/elasticsearch/dockerfile/Dockerfile
@@ -1,0 +1,101 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This Dockerfile in thirdparty_containers/elasticsearch/dockerfile dir is used to create an image with
+# AdoptOpenJDK jdk binary installed. Basic test dependent executions
+# are installed during the building process.
+#
+# Build example: `docker build -t adoptopenjdk-elasticsearch-test .`
+#
+# This Dockerfile builds image based on adoptopenjdk/openjdk8:latest.
+# If you want to build image based on other images, please use
+# `--build-arg list` to specify your base image
+#
+# Build example: `docker build --build-arg IMAGE_NAME=<image_name> --build-arg IMAGE_VERSION=<image_version >-t adoptopenjdk-elasticsearch-test .`
+
+# This Dockerfile can be used as an example for external docker based tests. 
+ 
+ARG SDK=openjdk8
+ARG IMAGE_NAME=adoptopenjdk/$SDK
+ARG IMAGE_VERSION=latest
+
+FROM $IMAGE_NAME:$IMAGE_VERSION
+
+RUN groupadd -g 1000 elasticsearch && useradd elasticsearch -u 1000 -g 1000
+
+# Install test dependent executable files
+RUN apt-get update \
+	&& apt-get -y install \
+	ant \
+	apt-transport-https \
+	ca-certificates \
+	dirmngr \
+	curl \
+	git \
+	make \
+	unzip \
+	vim \
+	wget
+
+
+#Install Gradle
+RUN mkdir -p /usr/share/gradle \
+         && cd /usr/share/gradle \
+         && wget https://services.gradle.org/distributions/gradle-4.5-bin.zip \
+         && unzip gradle-4.5-bin.zip \
+         && rm -rf gradle-4.5-bin.zip \
+         && ln -s /usr/share/gradle/gradle-4.5/bin/gradle /usr/bin/gradle \
+         && cd /
+
+
+
+VOLUME ["/java"]
+ENV JAVA_HOME=/java \
+    PATH=/java/bin:$PATH \
+    JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
+
+
+# This is the main script to run example tests. Replace this with the script for your own third party test 
+#COPY ./dockerfile/example-test.sh /example-test.sh
+
+COPY ./dockerfile/elasticsearch-test.sh /elasticsearch-test.sh
+
+
+# Clone the repo where the 3rd party application code and tests reside.
+WORKDIR /
+RUN pwd
+#RUN git clone https://github.com/smlambert/tpc-example.git
+
+RUN git clone https://github.com/elastic/elasticsearch.git
+
+RUN cd elasticsearch \
+&& git checkout v6.1.3
+
+
+RUN chown -R elasticsearch /elasticsearch
+RUN chown -R elasticsearch /elasticsearch-test.sh
+RUN chown -R elasticsearch /usr/share/gradle/gradle-4.5
+
+RUN chmod -R a+x /elasticsearch
+RUN chmod -R a+x /usr/share/gradle/gradle-4.5
+
+USER elasticsearch
+WORKDIR /
+ENV PATH="/usr/share/gradle/gradle-4.5/bin:${PATH}"
+
+
+
+
+#ENTRYPOINT ["/bin/bash", "/example-test.sh"]
+ENTRYPOINT ["/bin/bash", "/elasticsearch-test.sh"]
+CMD ["--version"]
+

--- a/thirdparty_containers/elasticsearch/dockerfile/elasticsearch-test.sh
+++ b/thirdparty_containers/elasticsearch/dockerfile/elasticsearch-test.sh
@@ -1,0 +1,69 @@
+#/bin/bash
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#Set up Java to be used by the the example-test
+
+if [ -d /java/jre/bin ];then
+	echo "Using mounted Java8"
+	export JAVA_BIN=/java/jre/bin
+	export JAVA_HOME=/java
+	export PATH=$JAVA_BIN:$PATH
+	java -version
+elif [ -d /java/bin ]; then
+	echo "Using mounted Java9"
+	export JAVA_BIN=/java/bin
+	export JAVA_HOME=/java
+	export PATH=$JAVA_BIN:$PATH
+	java -version
+else
+	echo "Using docker image default Java"
+	java_path=$(type -p java)
+	suffix="/java"
+	java_root=${java_path%$suffix}
+	export JAVA_BIN="$java_root"
+	echo "JAVA_BIN is: $JAVA_BIN"
+	$JAVA_BIN/java -version
+fi
+
+TEST_SUITE=$1
+
+echo "PATH is : $PATH"
+echo "JAVA_HOME is : $JAVA_HOME"
+echo "type -p java is :"
+type -p java
+echo "java -version is: \n"
+java -version
+
+# Replace the following with the initial command lines that trigger execution of your test
+# For this example, we will simply compile and run the ExampleTest class
+#cd /tpc-example
+cd /elasticsearch
+ls .
+pwd
+
+#echo "Compile and execute example-test" && \
+#javac src/net/adoptopenjdk/example/test/ExampleTest.java && \
+#java -cp ./src net.adoptopenjdk.example.test.ExampleTest
+
+
+echo "Building elasticsearch  using gradle \"gradle assemble\"" && \
+gradle -g /tmp assemble
+
+
+echo "Elasticsearch Build - Completed"
+
+echo "Running elasticsearch tests :"
+./gradlew -g /tmp test
+
+

--- a/thirdparty_containers/elasticsearch/playlist.xml
+++ b/thirdparty_containers/elasticsearch/playlist.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+-->
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
+	<!--Add entries corresponding to your test similar to the example below so that
+		TestKitGen can produce the equivalent make command lines to be executed in the build 
+	-->
+	<test>
+		<testCaseName>elasticsearch_test</testCaseName>
+	<command>docker run --rm -v $(JDK_HOME):/java  adoptopenjdk-elasticsearch-test:latest "jvm pos neg"; \
+		$(TEST_STATUS)</command>
+		<subsets>
+			<subset>SE80</subset>
+			<subset>SE90</subset>
+		</subsets>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>external</group>
+		</groups>
+	</test>
+</playlist>

--- a/thirdparty_containers/jenkins/dockerfile/Dockerfile
+++ b/thirdparty_containers/jenkins/dockerfile/Dockerfile
@@ -45,10 +45,10 @@ RUN apt-get update \
 # Install Maven
 RUN mkdir -p /usr/share/maven \
 	&& cd /usr/share/maven \
-	&& wget http://www-us.apache.org/dist/maven/maven-3/3.5.2/binaries/apache-maven-3.5.2-bin.zip \
-	&& unzip apache-maven-3.5.2-bin.zip \
-	&& rm -rf apache-maven-3.5.2-bin.zip \
-	&& ln -s /usr/share/maven/apache-maven-3.5.2/bin/mvn /usr/bin/mvn \
+	&& wget http://www-us.apache.org/dist/maven/maven-3/3.5.3/binaries/apache-maven-3.5.3-bin.zip \
+	&& unzip apache-maven-3.5.3-bin.zip \
+	&& rm -rf apache-maven-3.5.3-bin.zip \
+	&& ln -s /usr/share/maven/apache-maven-3.5.3/bin/mvn /usr/bin/mvn \
 	&& cd /
 
 VOLUME ["/java"]


### PR DESCRIPTION
Two kind of changes are there under my fork

1. changes related to elasticsearch which is under openjdk-tests/thirdparty_containers/elasticsearch

2. changes made under openjdk-tests/thirdparty_containers/jenkins/dockerfile/Dockerfile  file where replaced maven 3.5.2 with 3.5.3