### PR TITLE
Specify default jdk_custom test class

### DIFF
--- a/openjdk_regression/openjdk_regression.mk
+++ b/openjdk_regression/openjdk_regression.mk
@@ -61,3 +61,7 @@ else
 	JTREG_TEST_DIR := $(OPENJDK_DIR)$(D)test$(D)jdk
 	JTREG_HOTSPOT_TEST_DIR := $(OPENJDK_DIR)$(D)test$(D)hotspot
 endif
+
+ifndef CUSTOM_TARGET
+	CUSTOM_TARGET := java/math/BigInteger/BigIntegerTest.java
+endif

--- a/openjdk_regression/playlist.xml
+++ b/openjdk_regression/playlist.xml
@@ -24,8 +24,6 @@
 	-w $(Q)$(TEST_RESROOT)$(D)work$(Q) \
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
 	-jdk:$(Q)$(JDK_HOME)$(Q) \
-	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
-	-exclude:$(Q)$(TEST_RESROOT)$(D)ProblemList_$(JVM_VERSION).txt$(Q) \
 	$(Q)$(JTREG_TEST_DIR)$(D)$(CUSTOM_TARGET)$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>


### PR DESCRIPTION
Specify default jdk_custom test class be a simple test to avoid running whole test set
Remove jtreg exclude options for jdk_custom target. In this way re-running or grinder jdk_custom target do not need any changes. 

close #423 

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>