### PR TITLE
Add win32 and zos specs in ci script

### DIFF
--- a/buildenv/jenkins/Jenkinsfile_personal
+++ b/buildenv/jenkins/Jenkinsfile_personal
@@ -4,7 +4,7 @@ pipeline {
 	parameters {
 		string (defaultValue: "https://github.com/AdoptOpenJDK/openjdk-tests.git", description: 'personal repo from AdoptOpenJDK/openjdk-tests', name: 'ADOPTOPENJDK_REPO')
 		string (defaultValue: "master", description: 'personal AdoptOpenJDK branch', name: 'ADOPTOPENJDK_BRANCH')
-		choice (choices: 'linux_x86-64\nlinux_x86-64_cmprssptrs\nmac_x86-64\nlinux_390-64\nlinux_390-64_cmprssptrs\nlinux_ppc-64_le\nlinux_ppc-64_cmprssptrs_le\nlinux_arm\nwin_x86-64\nwin_x86-64_cmprssptrs\naix_ppc-64\naix_ppc-64_cmprssptrs', description: 'SPEC?', name: 'SPEC')
+		choice (choices: 'linux_x86-64\nlinux_x86-64_cmprssptrs\nmac_x86-64\nlinux_390-64\nlinux_390-64_cmprssptrs\nlinux_ppc-64_le\nlinux_ppc-64_cmprssptrs_le\nlinux_arm\nwin_x86\nwin_x86-64\nwin_x86-64_cmprssptrs\naix_ppc-64\naix_ppc-64_cmprssptrs\nzos_390-64_cmprssptrs', description: 'SPEC?', name: 'SPEC')
 		choice (choices: 'SE80\nSE90\nSE100', description: 'What is JAVA_VERSION?', name: 'JAVA_VERSION')
 		string (defaultValue: 'openj9', description: 'JAVA_IMPL, e.g. hotspot, openj9, sap', name: 'JAVA_IMPL')
 		string (defaultValue: 'openjdk_regression', description: 'Equivalent to BUILD_LIST, specific test directory to compile, set blank for all projects to be compiled, e.g. openjdk_regression systemtest performance jck thirdparty_containers functional', name: 'TESTPROJECT')
@@ -21,7 +21,7 @@ pipeline {
 	}
 	options {
     	skipDefaultCheckout true
-    	timeout(time: 6, unit: 'HOURS')
+    	timeout(time: 8, unit: 'HOURS')
   	}
 	environment {
 		OPENJDK_TEST="$WORKSPACE/openjdk-tests"
@@ -168,6 +168,14 @@ def getPlatformAndLabel(SPEC) {
 		case ~/win_x86-64.*/:
 			platformAndLabel[0] = 'x64_win'
 			platformAndLabel[1] = 'hw.arch.x86&&sw.os.win'
+			break
+		case ~/win_x86/:
+			platformAndLabel[0] = 'x32_win'
+			platformAndLabel[1] = 'hw.arch.x86&&sw.os.win'
+			break
+		case ~/zos_390-64.*/:
+			platformAndLabel[0] = 's390x_zos'
+			platformAndLabel[1] = 'hw.arch.s390&&sw.os.zos'
 			break
 		default:
 			println 'not supported spec or wrong spec'

--- a/buildenv/jenkins/Jenkinsfile_personal
+++ b/buildenv/jenkins/Jenkinsfile_personal
@@ -170,7 +170,7 @@ def getPlatformAndLabel(SPEC) {
 			platformAndLabel[1] = 'hw.arch.x86&&sw.os.win'
 			break
 		case ~/win_x86/:
-			platformAndLabel[0] = 'x32_win'
+			platformAndLabel[0] = 'x64_win'
 			platformAndLabel[1] = 'hw.arch.x86&&sw.os.win'
 			break
 		case ~/zos_390-64.*/:

--- a/buildenv/jenkins/openjdk8_x86-32_windows
+++ b/buildenv/jenkins/openjdk8_x86-32_windows
@@ -1,0 +1,23 @@
+#!groovy
+/* Template for test jobs on openjdk8 linux. Configure test job as parameterized.
+	Set parameter TARGET(openjdk, system, external, perf, jck etc.).
+	Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_x86-64_linux)
+	Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
+LABEL='hw.arch.x86&&sw.os.win'
+
+node ("master") {
+	checkout scm
+	def jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
+	jenkinsfile.setLabelParam()
+	cleanWs()
+}
+
+node("$LABEL") {
+    PLATFORM = 'x32_win'
+    JAVA_VERSION = 'SE80'
+    SDK_RESOURCE = 'upstream'
+    SPEC='win_x86'
+    checkout scm
+    def jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
+    jenkinsfile.testBuild()
+}

--- a/buildenv/jenkins/openjdk8_x86-32_windows
+++ b/buildenv/jenkins/openjdk8_x86-32_windows
@@ -13,7 +13,7 @@ node ("master") {
 }
 
 node("$LABEL") {
-    PLATFORM = 'x32_win'
+    PLATFORM = 'x64_win'
     JAVA_VERSION = 'SE80'
     SDK_RESOURCE = 'upstream'
     SPEC='win_x86'

--- a/buildenv/jenkins/openjdk8_x86-64_linux_largeHeap
+++ b/buildenv/jenkins/openjdk8_x86-64_linux_largeHeap
@@ -1,0 +1,23 @@
+#!groovy
+/* Template for test jobs on openjdk8 linux. Configure test job as parameterized.
+	Set parameter TARGET(openjdk, system, external, perf, jck etc.).
+	Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_x86-64_linux)
+	Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
+LABEL='sw.os.linux&&hw.arch.x86'
+
+node ("master") {
+	checkout scm
+	def jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
+	jenkinsfile.setLabelParam()
+	cleanWs()
+}
+
+node("$LABEL") {
+    PLATFORM = 'x64_linux_largeHeap'
+    JAVA_VERSION = 'SE80'
+    SDK_RESOURCE = 'upstream'
+    SPEC='linux_x86-64'
+    checkout scm
+    def jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
+    jenkinsfile.testBuild()
+}


### PR DESCRIPTION
Add ability to run personal testing against win32 & zos builds
Ability to incorporate Win32 and x64_linux_largeHeap to nightly build pipeline for Java8
Signed-off-by: smlambert <slambert@gmail.com>