### PR TITLE
Include back TestJlmRemoteMemoryAuth since eclipse/openj9#1520 is fixed

### DIFF
--- a/systemtest/playlist.xml
+++ b/systemtest/playlist.xml
@@ -1137,6 +1137,7 @@
 		</groups>
 		<impls>
 			<impl>hotspot</impl>
+			<impl>openj9</impl>
 		</impls>
 	</test>
 


### PR DESCRIPTION
Include back TestJlmRemoteMemoryAuth since https://github.com/eclipse/openj9/issues/1520 is fixed
Signed-off-by: Mesbah <Mesbah_Alam@ca.ibm.com>