### PR TITLE
Allow artifacts from the build to be nested in directories

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -112,7 +112,7 @@ def setup() {
 					step([$class: 'CopyArtifact',
 						fingerprintArtifacts: true,
 						flatten: true,
-					    filter: "**/*.tar.gz,**/*.zip",
+						filter: "**/*.tar.gz,**/*.zip",
 						projectName: "${params.UPSTREAM_JOB_NAME}",
 						selector: [$class: 'SpecificBuildSelector', buildNumber: "${params.UPSTREAM_JOB_NUMBER}"]])
 				}

--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -112,6 +112,7 @@ def setup() {
 					step([$class: 'CopyArtifact',
 						fingerprintArtifacts: true,
 						flatten: true,
+					    filter: "**/*.tar.gz,**/*.zip",
 						projectName: "${params.UPSTREAM_JOB_NAME}",
 						selector: [$class: 'SpecificBuildSelector', buildNumber: "${params.UPSTREAM_JOB_NUMBER}"]])
 				}

--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -111,6 +111,7 @@ def setup() {
 				dir('openjdkbinary') {
 					step([$class: 'CopyArtifact',
 						fingerprintArtifacts: true,
+						flatten: true,
 						projectName: "${params.UPSTREAM_JOB_NAME}",
 						selector: [$class: 'SpecificBuildSelector', buildNumber: "${params.UPSTREAM_JOB_NUMBER}"]])
 				}


### PR DESCRIPTION
When artifacts are copied from the build to test, flatten them so if they are nested in a sub-dir, they are taken out. Also filter to only take zip and tar.gz artifacts.

This should not effect the current builds as those are in the top dir, however for the upcoming improvements to the build scripts, this will help.