### PR TITLE
Add test report directory mount for lucene-solr tests

### DIFF
--- a/thirdparty_containers/lucene-solr/playlist.xml
+++ b/thirdparty_containers/lucene-solr/playlist.xml
@@ -15,7 +15,7 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
 	<test>
 		<testCaseName>lucene_solr_nightly_smoketest</testCaseName>
-	<command>docker run --rm -v $(JDK_HOME):/java  adoptopenjdk-lucene-solr-test:latest ; \
+	<command>docker run --rm -v $(JDK_HOME):/java -v $(REPORTDIR)/junitreports/lucene-solr:/lucene-solr/lucene/build/core/test adoptopenjdk-lucene-solr-test:latest ; \
 		$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>


### PR DESCRIPTION
Adds step to mount lucene-solr test output folder onto host machine to enable junit reporting
Signed-off-by: Mesbah <Mesbah_Alam@ca.ibm.com>