### PR TITLE
Remove volume map in lucene-solr tests until user id mapping resolved

### DIFF
--- a/thirdparty_containers/lucene-solr/playlist.xml
+++ b/thirdparty_containers/lucene-solr/playlist.xml
@@ -15,7 +15,7 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
 	<test>
 		<testCaseName>lucene_solr_nightly_smoketest</testCaseName>
-	<command>docker run --rm -v $(JDK_HOME):/java -v $(REPORTDIR)/junitreports/lucene-solr:/lucene-solr/lucene/build/core/test adoptopenjdk-lucene-solr-test:latest ; \
+	<command>docker run --rm -v $(JDK_HOME):/java  adoptopenjdk-lucene-solr-test:latest ; \
 		$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>


### PR DESCRIPTION
Remove volume map in lucene-solr tests until user id mapping is resolved
Signed-off-by: Mesbah <Mesbah_Alam@ca.ibm.com>