### PR TITLE
Support builds also with JRE image and enable JRE tests

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -27,6 +27,7 @@ def stageTestBinaries() {
 
 def setupEnv() {
 	env.JAVA_BIN = "$WORKSPACE/openjdkbinary/j2sdk-image/${(JAVA_VERSION == 'SE80') ? 'jre/' : ''}bin"
+	env.JRE_IMAGE = "$WORKSPACE/openjdkbinary/j2jre-image"
 	env.JAVA_HOME = "${JAVA_BIN}/.."
 	env.JAVA_VERSION = "${JAVA_VERSION}"
 	env.JVM_VERSION = "${JVM_VERSION}"

--- a/get.sh
+++ b/get.sh
@@ -125,20 +125,33 @@ getBinaryOpenjdk()
 	# temporarily remove *test* until upstream build is updated and not staging test material
 	rm -rf *test*
 	
-	jar_file_name=`ls`
-	if [[ $jar_file_name == *zip || $jar_file_name == *jar ]]; then
-		unzip -q $jar_file_name -d .
-	else
-		echo $jar_file_name 
-		gzip -cd $jar_file_name | tar xf -
-	fi
-	jarDir=`ls -d */`
-	dirName=${jarDir%?}
-	if [ "$dirName" != "j2sdk-image" ]; then
-		mv $dirName j2sdk-image
-	else
-		echo "dirName is equal to j2sdk-image, skip moving"
-	fi
+	jar_files=`ls`
+	jar_file_array=(${jar_files//\\n/ })
+	for jar_name in "${jar_file_array[@]}"
+		do
+			if [[ $jar_name == *zip || $jar_file_name == *jar ]]; then
+				unzip -q $jar_file_name -d .
+			else
+				echo $jar_name 
+				gzip -cd $jar_name | tar xf -
+			fi
+			#rm jar_name
+		done
+	
+	jar_dirs=`ls -d */`
+	jar_dir_array=(${jar_dirs//\\n/ })
+	for jar_dir in "${jar_dir_array[@]}"
+		do
+			jar_dir_name=${jar_dir%?}
+			if [[ "$jar_dir_name" =~ jdk*  &&  "$jar_dir_name" != "j2sdk-image" ]]; then
+				mv $jar_dir_name j2sdk-image
+			elif [[ "$jar_dir_name" =~ jre*  &&  "$jar_dir_name" != "j2jre-image" ]]; then
+				mv $jar_dir_name j2jre-image
+			#The following only needed if openj9 has a different image name convention
+			elif [[ "$jar_dir_name" != "j2sdk-image" ]]; then
+				mv $jar_dir_name j2sdk-image
+			fi
+		done
 }
 
 getTestKitGenAndFunctionalTestMaterial()

--- a/openjdk_regression/openjdk_regression.mk
+++ b/openjdk_regression/openjdk_regression.mk
@@ -47,6 +47,15 @@ JTREG_BASIC_OPTIONS += $(JTREG_XML_OPTION)
 # Add any extra options
 JTREG_BASIC_OPTIONS += $(EXTRA_JTREG_OPTIONS)
 
+ifndef JRE_IMAGE
+	ifeq ($(JAVA_VERSION),SE80)
+		JRE_ROOT := $(JAVA_BIN)$(D)..$(D)..
+	else
+		JRE_ROOT := $(JAVA_BIN)$(D)..
+	endif
+	JRE_IMAGE := $(JRE_ROOT)$(D)..$(D)j2jre-image
+endif
+
 ifdef OPENJDK_DIR 
 # removing "
 OPENJDK_DIR := $(subst ",,$(OPENJDK_DIR))

--- a/openjdk_regression/playlist.xml
+++ b/openjdk_regression/playlist.xml
@@ -243,6 +243,31 @@
 			<group>openjdk</group>
 		</groups>
 	</test>
+		<test>
+		<testCaseName>jdk_math_jre</testCaseName>
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
+	$(JTREG_BASIC_OPTIONS)  -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
+	-w $(Q)$(TEST_RESROOT)$(D)work$(Q) \
+	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
+	-compilejdk:$(Q)$(JDK_HOME)$(Q) \
+	-jdk:$(Q)$(JRE_IMAGE)$(Q) \
+	-exclude:$(Q)$(JTREG_TEST_DIR)$(D)ProblemList.txt$(Q) \
+	-exclude:$(Q)$(TEST_RESROOT)$(D)ProblemList_$(JVM_VERSION).txt$(Q) \
+	$(Q)$(JTREG_TEST_DIR):jdk_math$(Q); \
+	$(TEST_STATUS)</command>
+		<subsets>
+			<subset>SE80</subset>
+		</subsets>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>openjdk</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+		</impls>
+	</test>
 	<test>
 		<testCaseName>jdk_other</testCaseName>
 		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \


### PR DESCRIPTION
Support builds with both JRE as well as JDK image.

Enable jdk_math tests for JRE image produced by openjdk8-openj9. When others builds make jre image available we can easily turn on this test against different JVM version.

Fix #417 , fix #437 

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>