### PR TITLE
Enable jdk_math tests for JRE Images

### DIFF
--- a/openjdk_regression/playlist.xml
+++ b/openjdk_regression/playlist.xml
@@ -262,6 +262,9 @@
 	$(TEST_STATUS)</command>
 		<subsets>
 			<subset>SE80</subset>
+			<subset>SE90</subset>
+			<subset>SE100</subset>
+			<subset>SE110</subset>
 		</subsets>
 		<levels>
 			<level>sanity</level>
@@ -269,9 +272,6 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
-		<impls>
-			<impl>openj9</impl>
-		</impls>
 	</test>
 	<test>
 		<testCaseName>jdk_other</testCaseName>


### PR DESCRIPTION
Enable jdk_math tests for JRE Image with
	- hotspot/openj9 impls
	- Java9and up version 

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>