### PR TITLE
Enable JCK11 test

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -52,10 +52,8 @@ def setupEnv() {
 	if (env.BUILD_LIST == "jck") {
 		if ( JAVA_VERSION == "SE80" ) {
 			env.JCK_VERSION = "jck8b"
-		} else if ( JAVA_VERSION == "SE90" ) {
-			env.JCK_VERSION = "jck9"
-		} else if ( JAVA_VERSION == "SE100" ) {
-			env.JCK_VERSION = "jck10"
+		} else {
+			env.JCK_VERSION = "jck${JAVA_VERSION[2..-2]}"
 		}
 		env.JCK_ROOT = "$WORKSPACE/../jck_root"
 		echo "env.JCK_ROOT is: ${env.JCK_ROOT}, env.JCK_VERSION is: ${env.JCK_VERSION}"

--- a/jck/README.md
+++ b/jck/README.md
@@ -79,6 +79,7 @@ git clone https://github.com/AdoptOpenJDK/openjdk-tests.git
 // the JCK_ROOT structure should be like
 //root:jck_root root$ tree -L 2 ./
 //./
+//├── jck11
 //├── jck10
 //├── jck8b
 //└── jck9

--- a/jck/build.xml
+++ b/jck/build.xml
@@ -47,9 +47,14 @@
 			<else>
 				<echo message="${env.JCK_ROOT}/${env.JCK_VERSION} exists, try to update jck materials" />
 				<if>
- 					<equals arg1="jck10" arg2="${env.JCK_VERSION}" />
+					<or>
+ 						<equals arg1="jck10" arg2="${env.JCK_VERSION}" />
+						<equals arg1="jck11" arg2="${env.JCK_VERSION}" />
+					</or>
  				<then>
 					<exec executable="git" failonerror="true">
+						<arg value="-C" />
+						<arg value="${env.JCK_ROOT}/${env.JCK_VERSION}" />
 						<arg value="reset" />
 						<arg value="--hard" />
 						<arg value="origin/master" />

--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -33,11 +33,6 @@
 		<groups>
 			<group>jck</group>
 		</groups>
-		<subsets>
-			<subset>SE80</subset>
-			<subset>SE90</subset>
-			<subset>SE100</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api</testCaseName>
@@ -58,11 +53,6 @@
 		<groups>
 			<group>jck</group>
 		</groups>
-		<subsets>
-			<subset>SE80</subset>
-			<subset>SE90</subset>
-			<subset>SE100</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-java_lang-instrument</testCaseName>
@@ -83,11 +73,6 @@
 		<groups>
 			<group>jck</group>
 		</groups>
-		<subsets>
-			<subset>SE80</subset>
-			<subset>SE90</subset>
-			<subset>SE100</subset>
-		</subsets>
 	</test>
 
 	<test>
@@ -109,11 +94,6 @@
 		<groups>
 			<group>jck</group>
 		</groups>
-		<subsets>
-			<subset>SE80</subset>
-			<subset>SE90</subset>
-			<subset>SE100</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-java_lang-reflect</testCaseName>
@@ -134,11 +114,6 @@
 		<groups>
 			<group>jck</group>
 		</groups>
-		<subsets>
-			<subset>SE80</subset>
-			<subset>SE90</subset>
-			<subset>SE100</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-java_lang-Package</testCaseName>
@@ -159,11 +134,6 @@
 		<groups>
 			<group>jck</group>
 		</groups>
-		<subsets>
-			<subset>SE80</subset>
-			<subset>SE90</subset>
-			<subset>SE100</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-java_lang-String</testCaseName>
@@ -184,11 +154,6 @@
 		<groups>
 			<group>jck</group>
 		</groups>
-		<subsets>
-			<subset>SE80</subset>
-			<subset>SE90</subset>
-			<subset>SE100</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-java_lang-StringBuilder</testCaseName>
@@ -209,11 +174,6 @@
 		<groups>
 			<group>jck</group>
 		</groups>
-		<subsets>
-			<subset>SE80</subset>
-			<subset>SE90</subset>
-			<subset>SE100</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-java_lang-StringBuffer</testCaseName>
@@ -234,11 +194,6 @@
 		<groups>
 			<group>jck</group>
 		</groups>
-		<subsets>
-			<subset>SE80</subset>
-			<subset>SE90</subset>
-			<subset>SE100</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-java_lang-ClassLoader</testCaseName>
@@ -259,11 +214,6 @@
 		<groups>
 			<group>jck</group>
 		</groups>
-		<subsets>
-			<subset>SE80</subset>
-			<subset>SE90</subset>
-			<subset>SE100</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-signaturetest</testCaseName>
@@ -284,11 +234,6 @@
 		<groups>
 			<group>jck</group>
 		</groups>
-		<subsets>
-			<subset>SE80</subset>
-			<subset>SE90</subset>
-			<subset>SE100</subset>
-		</subsets>
 	</test>	
 
 	<test>
@@ -313,6 +258,7 @@
 		<subsets>
 			<subset>SE90</subset>
 			<subset>SE100</subset>
+			<subset>SE110</subset>
 		</subsets>
 	</test>
 	<test>
@@ -337,6 +283,7 @@
 		<subsets>
 			<subset>SE90</subset>
 			<subset>SE100</subset>
+			<subset>SE110</subset>
 		</subsets>
 	</test>
 	<test>
@@ -361,6 +308,7 @@
 		<subsets>
 			<subset>SE90</subset>
 			<subset>SE100</subset>
+			<subset>SE110</subset>
 		</subsets>
 	</test>
 	<test>
@@ -385,6 +333,7 @@
 		<subsets>
 			<subset>SE90</subset>
 			<subset>SE100</subset>
+			<subset>SE110</subset>
 		</subsets>
 	</test>
 	<test>
@@ -409,6 +358,7 @@
 		<subsets>
 			<subset>SE90</subset>
 			<subset>SE100</subset>
+			<subset>SE110</subset>
 		</subsets>
 	</test>
 	<test>
@@ -433,6 +383,7 @@
 		<subsets>
 			<subset>SE90</subset>
 			<subset>SE100</subset>
+			<subset>SE110</subset>
 		</subsets>
 	</test>
 
@@ -457,6 +408,7 @@
 		</groups>
 		<subsets>
 			<subset>SE100</subset>
+			<subset>SE110</subset>
 		</subsets>
 	</test>
 	<test>
@@ -480,6 +432,7 @@
 		</groups>
 		<subsets>
 			<subset>SE100</subset>
+			<subset>SE110</subset>
 		</subsets>
 	</test>
 	<test>
@@ -503,6 +456,7 @@
 		</groups>
 		<subsets>
 			<subset>SE100</subset>
+			<subset>SE110</subset>
 		</subsets>
 	</test>
 </playlist>

--- a/jck/runtime.lang/playlist.xml
+++ b/jck/runtime.lang/playlist.xml
@@ -33,10 +33,5 @@
 		<groups>
 			<group>jck</group>
 		</groups>
-		<subsets>
-			<subset>SE80</subset>
-			<subset>SE90</subset>
-			<subset>SE100</subset>
-		</subsets>
 	</test>
 </playlist>

--- a/jck/runtime.vm/playlist.xml
+++ b/jck/runtime.vm/playlist.xml
@@ -34,10 +34,6 @@
 			<group>jck</group>
 		</groups>
 		<subsets>
-			<subset>SE80</subset>
-			<subset>SE90</subset>
-			<subset>SE100</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>jck-runtime-vm-constantpool</testCaseName>
@@ -58,11 +54,6 @@
 		<groups>
 			<group>jck</group>
 		</groups>
-		<subsets>
-			<subset>SE80</subset>
-			<subset>SE90</subset>
-			<subset>SE100</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>jck-runtime-vm-jvmti</testCaseName>
@@ -83,11 +74,6 @@
 		<groups>
 			<group>jck</group>
 		</groups>
-		<subsets>
-			<subset>SE80</subset>
-			<subset>SE90</subset>
-			<subset>SE100</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>jck-runtime-vm-overview</testCaseName>
@@ -108,11 +94,6 @@
 		<groups>
 			<group>jck</group>
 		</groups>
-		<subsets>
-			<subset>SE80</subset>
-			<subset>SE90</subset>
-			<subset>SE100</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>jck-runtime-vm-classfmt-clf</testCaseName>
@@ -133,11 +114,6 @@
 		<groups>
 			<group>jck</group>
 		</groups>
-		<subsets>
-			<subset>SE80</subset>
-			<subset>SE90</subset>
-			<subset>SE100</subset>
-		</subsets>
 	</test>
 	
 	<test>
@@ -162,6 +138,7 @@
 		<subsets>
 			<subset>SE90</subset>
 			<subset>SE100</subset>
+			<subset>SE110</subset>
 		</subsets>
 	</test>
 	<test>
@@ -186,6 +163,7 @@
 		<subsets>
 			<subset>SE90</subset>
 			<subset>SE100</subset>
+			<subset>SE110</subset>
 		</subsets>
 	</test>
 	
@@ -210,6 +188,7 @@
 		</groups>
 		<subsets>
 			<subset>SE100</subset>
+			<subset>SE110</subset>
 		</subsets>
 	</test>
 	<test>
@@ -233,6 +212,7 @@
 		</groups>
 		<subsets>
 			<subset>SE100</subset>
+			<subset>SE110</subset>
 		</subsets>
 	</test>
 </playlist>

--- a/jck/runtime.xml_schema/playlist.xml
+++ b/jck/runtime.xml_schema/playlist.xml
@@ -33,10 +33,5 @@
 		<groups>
 			<group>jck</group>
 		</groups>
-		<subsets>
-			<subset>SE80</subset>
-			<subset>SE90</subset>
-			<subset>SE100</subset>
-		</subsets>
 	</test>
 </playlist>


### PR DESCRIPTION
Enable `JCK11` test

Initial addition to run `JCK11` tests based on `JCK10` setup;
Added `-C <path>` for `git reset hard` command;
Removed those subsets containing `SE80/90/100` hence make targets for all versions. (Thanks to Shelley)

Manually verified that `make _jck-runtime-api-java_lang-String` and `make _jck-runtime-custom  JCK_TEST_TARGET=api/java_math` are working.

Related to https://github.com/AdoptOpenJDK/openjdk-systemtest/pull/162

Reviewer @smlambert 
FYI: @DanHeidinga @pshipton @llxia 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>