### PR TITLE
Turn off Tap output to console

### DIFF
--- a/buildenv/jenkins/Jenkinsfile_personal
+++ b/buildenv/jenkins/Jenkinsfile_personal
@@ -95,7 +95,7 @@ pipeline {
     }
     post {
     	always {
-			step([$class: "TapPublisher", testResults: "**/*.tap"])
+			step([$class: "TapPublisher", testResults: "**/*.tap", outputTapToConsole: false])
 			junit allowEmptyResults: true, keepLongStdio: true, testResults: '**/work/**/*.jtr.xml, **/junitreports/**/*.xml'
 			
 		}


### PR DESCRIPTION
Turn off Tap output to console, which is consumed by Tap plugin.

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>