### PR TITLE
Correct TEST.ROOT copy if logic

### DIFF
--- a/openjdk_regression/build.xml
+++ b/openjdk_regression/build.xml
@@ -70,7 +70,10 @@
 		</exec>
 		<move file="${openjdkGit}" tofile="openjdk-jdk"/>
 		<if>
-			<equals arg1="${JVM_VERSION}" arg2="openjdk1?-openj9"/>
+                        <or>
+			  <equals arg1="${JVM_VERSION}" arg2="openjdk10-openj9"/>
+			  <equals arg1="${JVM_VERSION}" arg2="openjdk11-openj9"/>
+                        </or>
 			<then>
 				<copy file="${src}/${JVM_VERSION}/TEST.ROOT" todir="${src}/openjdk-jdk/test/jdk" overwrite="true"/>
 			</then>


### PR DESCRIPTION
Signed-off-by: andrew-m-leonard <andrew_m_leonard@uk.ibm.com>

Original change used "openjdk1?-openj9" but it seems that is not supported.
Changed it to use \<or\> operation.
