### PR TITLE
Always Clean Workspace after build

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -220,7 +220,6 @@ def post(test_target) {
 				sh "tar -zcf benchmark_test_output.tar.gz ${benchmark_test_output_dir}"
 				archiveArtifacts artifacts: '**/benchmark_test_output.tar.gz', fingerprint: true, allowEmptyArchive: true
 			}
-			cleanWs cleanWhenFailure: false
 		}
 	}
 }
@@ -231,43 +230,48 @@ def testBuild() {
 		time_limit = params.TIME_LIMIT.toInteger()
 	}
 	timeout(time: time_limit, unit: 'HOURS') {
-		addNodeToDescription()
+		try {
+			addNodeToDescription()
 
-		// prepare environment and compile test projects
-		setup()
-		buildTest()
-		if( params.IS_PARALLEL ){
-			// archive compiled test binaries for parallel jobs
-			archiveTestBinaries()
-			def testSubDirs = []
-			def testSubDirSize = 0
-			dir("$WORKSPACE/openjdk-tests/${env.BUILD_LIST}") {
-				testSubDirs = sh(returnStdout: true, script: "ls -d */").trim().split()
-				testSubDirSize = testSubDirs.size()
-			}
-			echo "testSubDirSize is ${testSubDirSize}, testSubDirs is ${testSubDirs}, running test in parallel mode"
-			def parallel_tests = [:]
-			for (int i = 0; i < testSubDirSize; i++) {
-				def testSubDir = testSubDirs[i].trim().replace("/","");
-				parallel_tests[testSubDir] = {
-					node ("$LABEL") {
-						addNodeToDescription()
-						setupParallelEnv()
-						stageTestBinaries()
-						if( env.BUILD_LIST == "jck") {
-							buildTest()
+			// prepare environment and compile test projects
+			setup()
+			buildTest()
+			if( params.IS_PARALLEL ){
+				// archive compiled test binaries for parallel jobs
+				archiveTestBinaries()
+				def testSubDirs = []
+				def testSubDirSize = 0
+				dir("$WORKSPACE/openjdk-tests/${env.BUILD_LIST}") {
+					testSubDirs = sh(returnStdout: true, script: "ls -d */").trim().split()
+					testSubDirSize = testSubDirs.size()
+				}
+				echo "testSubDirSize is ${testSubDirSize}, testSubDirs is ${testSubDirs}, running test in parallel mode"
+				def parallel_tests = [:]
+				for (int i = 0; i < testSubDirSize; i++) {
+					def testSubDir = testSubDirs[i].trim().replace("/","");
+					parallel_tests[testSubDir] = {
+						node ("$LABEL") {
+							addNodeToDescription()
+							setupParallelEnv()
+							stageTestBinaries()
+							if( env.BUILD_LIST == "jck") {
+								buildTest()
+							}
+							runTest("${env.BUILD_LIST}/${testSubDir}")
+							post("${env.BUILD_LIST}-${testSubDir}")
 						}
-						runTest("${env.BUILD_LIST}/${testSubDir}")
-						post("${env.BUILD_LIST}-${testSubDir}")
 					}
 				}
+				parallel parallel_tests
+			} else {
+				echo "running test in default mode"
+				runTest("${env.BUILD_LIST}")
+				post("${env.BUILD_LIST}")
 			}
-			parallel parallel_tests
-			cleanWs()
-		} else {
-			echo "running test in default mode"
-			runTest("${env.BUILD_LIST}")
-			post("${env.BUILD_LIST}")
+		} finally {
+			if (!params.KEEP_WORKSPACE) {
+				cleanWs()
+			}
 		}
 		
 	}


### PR DESCRIPTION
- Wrap all steps in try/finally.
- Move CleanWs to finally block.
- This ensures CleanWs always runs even if
  the build has failed a step.
- This also reverts #320 which stopped the
  clean from running if the build failed.
- Proper archiving should ensure we don't need
  to leave workspaces around for test failure
  investigation.

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>