### PR TITLE
Update hotspot jtreg test

### DIFF
--- a/openjdk_regression/openjdk_regression.mk
+++ b/openjdk_regression/openjdk_regression.mk
@@ -69,7 +69,7 @@ ifneq (,$(findstring $(JDK_VERSION),8-9))
 	JTREG_LANGTOOLS_TEST_DIR := $(OPENJDK_DIR)$(D)langtools$(D)test
 else
 	JTREG_TEST_DIR := $(OPENJDK_DIR)$(D)test$(D)jdk
-	JTREG_HOTSPOT_TEST_DIR := $(OPENJDK_DIR)$(D)test$(D)hotspot
+	JTREG_HOTSPOT_TEST_DIR := $(OPENJDK_DIR)$(D)test$(D)hotspot$(D)jtreg
 	JTREG_LANGTOOLS_TEST_DIR := $(OPENJDK_DIR)$(D)test$(D)langtools
 endif
 

--- a/openjdk_regression/playlist.xml
+++ b/openjdk_regression/playlist.xml
@@ -123,30 +123,6 @@
 		</impls>
 	</test>
 	<test>
-		<testCaseName>hotspot_jre_SE100</testCaseName>
-		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
-	$(JTREG_BASIC_OPTIONS) -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
-	-w $(Q)$(TEST_RESROOT)$(D)work$(Q) \
-	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
-	-jdk:$(Q)$(JDK_HOME)$(Q) \
-	-exclude:$(Q)$(TEST_RESROOT)$(D)ProblemList_$(JVM_VERSION).txt$(Q) \
-	$(Q)$(JTREG_HOTSPOT_TEST_DIR):jre$(Q); \
-	$(TEST_STATUS)</command>
-		<subsets>
-			<subset>SE100</subset>
-		</subsets>
-		<levels>
-			<level>extended</level>
-		</levels>
-		<groups>
-			<group>openjdk</group>
-		</groups>
-		<impls>
-			<impl>hotspot</impl>
-		</impls>
-		<disabled>https://github.com/AdoptOpenJDK/openjdk-tests/issues/228</disabled>
-	</test>
-	<test>
 		<testCaseName>jdk_awt</testCaseName>
 		<command>export DISPLAY=:1; $(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
 	$(JTREG_BASIC_OPTIONS)  -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \


### PR DESCRIPTION
1. update hotspot jtreg test dir
2.Remove hotspot_jre group for jdk10 and up, which is removed in
openjdk10andup test groups

Issue #565 

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>