### PR TITLE
To update the jtreg exclude lists on jdk11 with the lists from jdk8

### DIFF
--- a/openjdk_regression/ProblemList_openjdk11-openj9.txt
+++ b/openjdk_regression/ProblemList_openjdk11-openj9.txt
@@ -21,10 +21,100 @@
 ############################################################################
 
 # jdk_lang
+jdk/lambda/vm/InterfaceAccessFlagsTest.java	126	linux-all
+java/lang/Math/HypotTests.java	128	linux-all	https://github.com/eclipse/openj9/issues/1128	generic-all
+java/lang/Class/forName/NonJavaNames.sh		https://github.com/eclipse/openj9/issues/1128	generic-all
+java/lang/Class/forName/arrayClass/ExceedMaxDim.java	https://github.com/eclipse/openj9/issues/1128	generic-all
+java/lang/ProcessBuilder/Basic.java		https://github.com/eclipse/openj9/issues/1128	generic-all
+java/lang/Runtime/shutdown/ShutdownInterruptedMain.java		https://github.com/eclipse/openj9/issues/1128	generic-all
+java/lang/SecurityManager/CheckPackageAccess.java		https://github.com/eclipse/openj9/issues/1128	generic-all
+java/lang/String/CaseInsensitiveComparator.java		https://github.com/eclipse/openj9/issues/1128	generic-all
+java/lang/StringBuffer/Exceptions.java		https://github.com/eclipse/openj9/issues/1128	generic-all
+java/lang/StringBuffer/TestSynchronization.java		https://github.com/eclipse/openj9/issues/1128	generic-all
+java/lang/StringBuilder/Exceptions.java		https://github.com/eclipse/openj9/issues/1128	generic-all
+java/lang/Thread/ITLConstructor.java		https://github.com/eclipse/openj9/issues/1128	generic-all
+java/lang/Thread/UncaughtExceptions.sh		https://github.com/eclipse/openj9/issues/1128	generic-all
+java/lang/ThreadGroup/SetMaxPriority.java		https://github.com/eclipse/openj9/issues/1128	generic-all
+java/lang/Throwable/SuppressedExceptions.java		https://github.com/eclipse/openj9/issues/1128	generic-all
+java/lang/annotation/AnnotationsInheritanceOrderRedefinitionTest.java		https://github.com/eclipse/openj9/issues/1128	generic-all
+java/lang/annotation/loaderLeak/Main.java		https://github.com/eclipse/openj9/issues/1128	generic-all
+java/lang/invoke/ArrayConstructorTest.java		https://github.com/eclipse/openj9/issues/1128	generic-all
+java/lang/invoke/CustomizedLambdaFormTest.java		https://github.com/eclipse/openj9/issues/1128	generic-all
+java/lang/invoke/ExplicitCastArgumentsTest.java		https://github.com/eclipse/openj9/issues/1128	generic-all
+java/lang/invoke/LFCaching/LFMultiThreadCachingTest.java		https://github.com/eclipse/openj9/issues/1128	generic-all
+java/lang/invoke/LFCaching/LFSingleThreadCachingTest.java		https://github.com/eclipse/openj9/issues/1128	generic-all
+java/lang/invoke/LambdaFormTest.java		https://github.com/eclipse/openj9/issues/1128	generic-all
+java/lang/invoke/MethodHandles/TestCatchException.java		https://github.com/eclipse/openj9/issues/1128	generic-all
+java/lang/invoke/MethodHandlesTest.java		https://github.com/eclipse/openj9/issues/1128	generic-all
+java/lang/invoke/PrivateInvokeTest.java		https://github.com/eclipse/openj9/issues/1128	generic-all
+java/lang/invoke/ProtectedMemberDifferentPackage/Test.java		https://github.com/eclipse/openj9/issues/1128	generic-all
+java/lang/invoke/RevealDirectTest.java		https://github.com/eclipse/openj9/issues/1128	generic-all
+java/lang/invoke/RicochetTest.java		https://github.com/eclipse/openj9/issues/1128	generic-all
+java/lang/invoke/VarargsArrayTest.java		https://github.com/eclipse/openj9/issues/1128	generic-all
+java/lang/invoke/lambda/LambdaStackTrace.java		https://github.com/eclipse/openj9/issues/1128	generic-all
+java/lang/ref/EarlyTimeout.java		https://github.com/eclipse/openj9/issues/1128	generic-all
+java/lang/ref/FinalizerHistogramTest.java		https://github.com/eclipse/openj9/issues/1128	generic-all
+java/lang/ref/NullQueue.java		https://github.com/eclipse/openj9/issues/1128	generic-all
+java/lang/ref/OOMEInReferenceHandler.java		https://github.com/eclipse/openj9/issues/1128	generic-all
+java/lang/reflect/DefaultMethodMembers/FilterNotMostSpecific.java		https://github.com/eclipse/openj9/issues/1128	generic-all
+java/lang/reflect/Generics/TestGenericReturnTypeToString.java		https://github.com/eclipse/openj9/issues/1128	generic-all
+sun/misc/Version/Version.java		https://github.com/eclipse/openj9/issues/1128	generic-all
+vm/verifier/VerifyProtectedConstructor.java 		https://github.com/eclipse/openj9/issues/1128	generic-all
+java/lang/invoke/RevealDirectTest.java
 
 ############################################################################
 
 # jdk_management
+com/sun/management/DiagnosticCommandMBean/DcmdMBeanPermissionsTest.java 55	generic-all
+com/sun/management/OperatingSystemMXBean/GetCommittedVirtualMemorySize.java		134	macosx-all
+java/lang/management/MemoryMXBean/LowMemoryTest2.sh	157	linux-all
+com/sun/management/HotspotClassLoadingMBean/GetClassInitializationTime.java	000 generic-all
+com/sun/management/HotspotClassLoadingMBean/GetClassLoadingTime.java	000 generic-all
+com/sun/management/HotspotClassLoadingMBean/GetInitializedClassCount.java	000 generic-all
+com/sun/management/HotspotClassLoadingMBean/GetLoadedClassSize.java	 000 generic-all
+com/sun/management/HotspotClassLoadingMBean/GetMethodDataSize.java	000 generic-all
+com/sun/management/HotspotClassLoadingMBean/GetUnloadedClassSize.java	000 generic-all
+com/sun/management/HotspotRuntimeMBean/GetSafepointCount.java	000 generic-all
+com/sun/management/HotspotRuntimeMBean/GetSafepointSyncTime.java	000 generic-all
+com/sun/management/HotspotRuntimeMBean/GetTotalSafepointTime.java	000 generic-all
+com/sun/management/HotspotThreadMBean/GetInternalThreads.java   000 generic-all
+com/sun/management/HotSpotDiagnosticMXBean/DumpHeap.sh  000 generic-all
+com/sun/management/HotSpotDiagnosticMXBean/DumpHeap.java  000 generic-all
+com/sun/management/HotSpotDiagnosticMXBean/GetDiagnosticOptions.java  000 generic-all
+com/sun/management/HotSpotDiagnosticMXBean/GetVMOption.java   000 generic-all
+com/sun/management/HotSpotDiagnosticMXBean/SetAllVMOptions.java   000 generic-all
+com/sun/management/HotSpotDiagnosticMXBean/SetVMOption.java   000 generic-all
+com/sun/management/HotSpotDiagnosticMXBean/CheckOrigin.java  000 generic-all
+com/sun/management/HotSpotDiagnosticMXBean/GetDoubleVMOption.java 000 generic-all
+com/sun/management/OperatingSystemMXBean/TestTotalSwap.java  000 generic-all
+com/sun/management/CheckSomeMXBeanImplPackage.java  000 generic-all
+java/lang/management/RuntimeMXBean/TestInputArgument.sh  000 generic-all
+jdk/internal/agent/AgentCMETest.java 000 generic-all
+jdk/internal/agent/AgentCheckTest.java 000 generic-all
+sun/management/LoggingTest/LoggingWithJULTest.java 000 generic-all
+sun/management/LoggingTest/LoggingWithLoggerFinderTest.java 000 generic-all
+sun/management/PlatformMBeanProviderConstructorCheck.java	 000 generic-all
+sun/management/StackTraceElementCompositeData/CompatibilityTest.java	 000 generic-all
+sun/management/jdp/JdpDefaultsTest.java	 000 generic-all
+sun/management/jdp/JdpJmxRemoteDynamicPortTest.java    000 generic-all
+sun/management/jdp/JdpOffTest.java	 000 generic-all
+sun/management/jdp/JdpSpecificAddressTest.java 000 generic-all
+sun/management/jmxremote/bootstrap/JMXInterfaceBindingTest.java	 000 generic-all
+sun/management/jmxremote/bootstrap/PasswordFilePermissionTest.java  000 generic-all
+sun/management/jmxremote/bootstrap/RmiRegistrySslTest.java  000 generic-all
+sun/management/jmxremote/bootstrap/SSLConfigFilePermissionTest.java  000 generic-all
+sun/management/jmxremote/startstop/JMXStatusPerfCountersTest.java  000 generic-all
+sun/management/jmxremote/startstop/JMXStatusTest.java  000 generic-all
+com/sun/management/GarbageCollectorMXBean/GarbageCollectionNotificationContentTest.java  000 generic-all
+com/sun/management/GarbageCollectorMXBean/GarbageCollectionNotificationTest.java  000 generic-all
+java/lang/management/CompositeData/ThreadInfoCompositeData.java 000 generic-all
+sun/management/jmxremote/bootstrap/CustomLauncherTest.java 000 generic-all
+sun/management/jmxremote/bootstrap/JvmstatCountersTest.java 000 generic-all
+sun/management/jmxremote/bootstrap/LocalManagementTest.java 000 generic-all
+sun/management/jmxremote/bootstrap/RmiBootstrapTest.sh 000 generic-all
+sun/management/jmxremote/bootstrap/RmiSslBootstrapTest.sh 000 generic-all
+sun/management/jmxremote/bootstrap/RmiSslNoKeyStoreTest.sh 000 generic-all
+sun/management/jmxremote/startstop/JMXStartStopTest.java 000 generic-all
 
 ############################################################################
 
@@ -43,10 +133,17 @@ java/math/BigInteger/PrimeTest.java 440 linux_arm
 ############################################################################
 
 # jdk_net
+java/net/InetAddress/BadDottedIPAddress.java		https://github.com/eclipse/openj9/issues/1129 generic-all
+java/net/InetAddress/CachedUnknownHostName.java		https://github.com/eclipse/openj9/issues/1129 generic-all
+java/net/InetAddress/IPv4Formats.java		https://github.com/eclipse/openj9/issues/1129 generic-all
+java/net/SocketPermission/Wildcard.java		https://github.com/eclipse/openj9/issues/1129 generic-all
+java/net/Socks/SocksV4Test.java		https://github.com/eclipse/openj9/issues/1129 generic-all
+java/net/URLPermission/URLTest.java		https://github.com/eclipse/openj9/issues/1129 generic-all
 
 ############################################################################
 
 # jdk_io
+java/io/Serializable/clearHandleTable/ClearHandleTable.java		https://github.com/eclipse/openj9/issues/1127 generic-all
 
 ############################################################################
 
@@ -55,18 +152,65 @@ java/math/BigInteger/PrimeTest.java 440 linux_arm
 ############################################################################
 
 # jdk_nio
+java/nio/channels/SocketChannel/Connect.java	156	macosx-all
+java/nio/Buffer/Chew.java	https://github.com/eclipse/openj9/issues/1130	generic-all
+java/nio/Buffer/DirectBufferAllocTest.java	https://github.com/eclipse/openj9/issues/1130	generic-all
+java/nio/Buffer/LimitDirectMemory.sh	https://github.com/eclipse/openj9/issues/1130	generic-all
+java/nio/channels/DatagramChannel/SendToUnresolved.java	https://github.com/eclipse/openj9/issues/1130	generic-all
+java/nio/channels/Selector/KeySets.java	https://github.com/eclipse/openj9/issues/1130	generic-all
+java/nio/channels/SocketChannel/ExceptionTranslation.java	https://github.com/eclipse/openj9/issues/1130	generic-all
+java/nio/charset/Charset/EmptyCharsetName.java	https://github.com/eclipse/openj9/issues/1130	generic-all
+java/nio/charset/Charset/NIOCharsetAvailabilityTest.java	https://github.com/eclipse/openj9/issues/1130	generic-all
+java/nio/charset/CharsetDecoder/AverageMax.java	https://github.com/eclipse/openj9/issues/1130	generic-all
+java/nio/charset/coders/Check.java	https://github.com/eclipse/openj9/issues/1130	generic-all
+java/nio/charset/coders/CheckSJISMappingProp.sh	https://github.com/eclipse/openj9/issues/1130	generic-all
+java/nio/charset/spi/basic.sh	https://github.com/eclipse/openj9/issues/1130	generic-all
+sun/nio/ch/TestMaxCachedBufferSize.java		https://github.com/eclipse/openj9/issues/1130	generic-all
+sun/nio/cs/TestCompoundTest.java	https://github.com/eclipse/openj9/issues/1130	generic-all
 
 ############################################################################
 
 # jdk_rmi
+java/rmi/Naming/legalRegistryNames/LegalRegistryNames.java 61	linux-all
+java/rmi/activation/rmidViaInheritedChannel/InheritedChannelNotServerSocket.java 154 macosx-all
+java/rmi/dgc/dgcAckFailure/DGCAckFailure.java		https://github.com/eclipse/openj9/issues/1144	generic-all
+java/rmi/dgc/retryDirtyCalls/RetryDirtyCalls.java		https://github.com/eclipse/openj9/issues/1144	generic-all
+java/rmi/registry/serialFilter/RegistryFilterTest.java		https://github.com/eclipse/openj9/issues/1144	generic-all
+java/rmi/server/UnicastRemoteObject/unexportObject/UnexportLeak.java		https://github.com/eclipse/openj9/issues/1144	generic-all
+java/rmi/server/RemoteObject/notExtending/NotExtending.java		https://github.com/eclipse/openj9/issues/1144	generic-all
+java/rmi/transport/runtimeThreadInheritanceLeak/RuntimeThreadInheritanceLeak.java		https://github.com/eclipse/openj9/issues/1144	generic-all
+sun/rmi/server/UnicastServerRef/FilterUSRTest.java		https://github.com/eclipse/openj9/issues/1144	generic-all
+java/rmi/activation/Activatable/downloadParameterClass/DownloadParameterClass.java	https://github.com/eclipse/openj9/issues/1144	generic-all
+java/rmi/activation/Activatable/extLoadedImpl/ext.sh	https://github.com/eclipse/openj9/issues/1144	generic-all
+java/rmi/activation/Activatable/forceLogSnapshot/ForceLogSnapshot.java	https://github.com/eclipse/openj9/issues/1144	generic-all
+java/rmi/activation/Activatable/inactiveGroup/InactiveGroup.java	https://github.com/eclipse/openj9/issues/1144	generic-all
+java/rmi/activation/Activatable/restartCrashedService/RestartCrashedService.java	https://github.com/eclipse/openj9/issues/1144	generic-all
+java/rmi/activation/Activatable/restartLatecomer/RestartLatecomer.java	https://github.com/eclipse/openj9/issues/1144	generic-all
+java/rmi/activation/Activatable/restartService/RestartService.java	https://github.com/eclipse/openj9/issues/1144	generic-all
+java/rmi/activation/ActivateFailedException/activateFails/ActivateFails.java	https://github.com/eclipse/openj9/issues/1144	generic-all
+java/rmi/activation/ActivationSystem/modifyDescriptor/ModifyDescriptor.java		https://github.com/eclipse/openj9/issues/1144	generic-all
 
 ############################################################################
 
 # jdk_security
+sun/security/tools/jarsigner/diffend.sh	113	linux-all
+sun/security/pkcs11/tls/TestKeyMaterial.java	71	linux-all
+sun/security/tools/jarsigner/emptymanifest.sh	114
+sun/security/pkcs11/Signature/TestDSAKeyLength.java	125 linux-all
+sun/security/pkcs11/Secmod/AddTrustedCert.java	125	linux-all
+sun/security/pkcs11/ec/TestECDH.java	125	linux-all
+sun/security/pkcs11/ec/TestECDSA.java	125	linux-all
+sun/security/pkcs11/ec/TestECGenSpec.java	125	linux-all
+sun/security/pkcs11/rsa/TestCACerts.java	125	linux-all
+javax/crypto/CryptoPermission/CryptoPolicyFallback.java	125	generic-all
+javax/crypto/CryptoPermission/TestUnlimited.java	125	generic-all
+sun/security/rsa/TestCACerts.java	125	generic-all
+sun/security/ssl/SSLSocketImpl/SSLSocketCloseHang.java	125	generic-all
 
 ############################################################################
 
 # jdk_sound
+javax/sound/midi/Devices/InitializationHang.java 73	generic-all
 
 ############################################################################
 
@@ -87,10 +231,25 @@ java/math/BigInteger/PrimeTest.java 440 linux_arm
 ############################################################################
 
 # jdk_jdi
+com/sun/jdi/RedefineCrossEvent.java	227	macosx-all
 
 ############################################################################
 
 # jdk_util
+java/util/ResourceBundle/Control/Bug6530694.java	137	macosx-all
+java/util/concurrent/atomic/VMSupportsCS8.java		https://github.com/eclipse/openj9/issues/1131	generic-all
+java/util/concurrent/locks/Lock/TimedAcquireLeak.java		https://github.com/eclipse/openj9/issues/1131	generic-all
+java/util/logging/TestLoggerWeakRefLeak.java		https://github.com/eclipse/openj9/issues/1131	generic-all
+java/util/prefs/PrefsSpi.sh		https://github.com/eclipse/openj9/issues/1131	generic-all
+java/util/regex/RegExTest.java		https://github.com/eclipse/openj9/issues/1131	generic-all
+java/util/Spliterator/SpliteratorCollisions.java		https://github.com/eclipse/openj9/issues/1131	generic-all
+java/util/stream/test/org/openjdk/tests/java/util/stream/CountLargeTest.java		https://github.com/eclipse/openj9/issues/1131	generic-all
+java/util/stream/test/org/openjdk/tests/java/util/stream/ExplodeOpTest.java		https://github.com/eclipse/openj9/issues/1131	generic-all
+java/util/stream/test/org/openjdk/tests/java/util/stream/SequentialOpTest.java		https://github.com/eclipse/openj9/issues/1131	generic-all
+java/util/stream/test/org/openjdk/tests/java/util/stream/ToArrayOpTest.java		https://github.com/eclipse/openj9/issues/1131	generic-all
+java/util/logging/FileHandlerMaxLocksTest.java		https://github.com/eclipse/openj9/issues/1131	generic-all
+java/util/zip/InflateIn_DeflateOut.java		https://github.com/eclipse/openj9/issues/1131	generic-all
+sun/util/calendar/zi/TestZoneInfo310.java		https://github.com/eclipse/openj9/issues/1131	generic-all
 
 ############################################################################
 

--- a/openjdk_regression/ProblemList_openjdk11.txt
+++ b/openjdk_regression/ProblemList_openjdk11.txt
@@ -1,0 +1,208 @@
+############################################################################
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#############################################################################
+
+#hotspot_jre
+gc/g1/TestShrinkAuxiliaryData05.java 110 generic-all
+gc/g1/TestShrinkAuxiliaryData10.java 110 generic-all
+gc/g1/TestShrinkAuxiliaryData15.java 110 generic-all
+gc/g1/TestShrinkAuxiliaryData20.java 110 generic-all
+runtime/os/AvailableProcessors.java	110	linux-all
+compiler/5091921/Test7005594.java	116	generic-all
+compiler/c1/TestUnresolvedFieldMain.java	116	generic-all
+compiler/c1/Test8172751.java	116	generic-all
+compiler/c1/TestPinnedIntrinsics.java	116	generic-all
+compiler/c2/FloatingPointFoldingTest.java	116 generic-all
+compiler/jsr292/PollutedTrapCounts.java		116	generic-all
+compiler/jsr292/RedefineMethodUsedByMultipleMethodHandles.java	116	generic-all
+compiler/loopopts/UseCountedLoopSafepoints.java	116	generic-all
+compiler/loopopts/TestImpossibleIV.java	116	generic-all
+compiler/types/correctness/OffTest.java	116	generic-all
+gc/TestVerifySilently.java	116	generic-all
+gc/TestVerifySubSet.java	116	generic-all
+gc/arguments/TestG1HeapRegionSize.java	116	generic-all
+gc/arguments/TestMinInitialErgonomics.java	116	linux-all
+gc/arguments/TestAggressiveHeap.java	116	linux-all
+gc/arguments/TestUseCompressedOopsErgo.java	116	linux-all
+gc/class_unloading/TestCMSClassUnloadingEnabledHWM.java	116	generic-all
+gc/class_unloading/TestG1ClassUnloadingHWM.java	116	generic-all
+gc/ergonomics/TestDynamicNumberOfGCThreads.java	116	generic-all
+gc/g1/TestEagerReclaimHumongousRegions.java	116	generic-all
+gc/g1/TestEagerReclaimHumongousRegionsClearMarkBits.java	116	generic-all
+gc/g1/TestEagerReclaimHumongousRegionsWithRefs.java	116	generic-all
+gc/g1/TestG1TraceEagerReclaimHumongousObjects.java	116	generic-all
+gc/g1/TestGCLogMessages.java	116	generic-all
+gc/g1/TestHumongousAllocInitialMark.java	116	generic-all
+gc/g1/TestPrintGCDetails.java	116	generic-all
+gc/g1/TestPrintRegionRememberedSetInfo.java	116	generic-all
+gc/g1/TestShrinkAuxiliaryData00.java	116	generic-all
+gc/g1/TestShrinkDefragmentedHeap.java	116	generic-all
+gc/g1/TestStringDeduplicationAgeThreshold.java	116	generic-all
+gc/g1/TestStringDeduplicationFullGC.java	116	generic-all
+gc/g1/TestStringDeduplicationInterned.java	116	generic-all
+gc/g1/TestStringDeduplicationPrintOptions.java	116	generic-all
+gc/g1/TestStringDeduplicationTableRehash.java	116	generic-all
+gc/g1/TestStringDeduplicationTableResize.java	116	generic-all
+gc/g1/TestStringDeduplicationYoungGC.java	116	generic-all
+gc/g1/TestStringSymbolTableStats.java	116	generic-all
+gc/logging/TestGCId.java	116	generic-all
+gc/whitebox/TestWBGC.java	116	generic-all
+runtime/Metaspace/FragmentMetaspaceSimple.java 120	generic-all
+runtime/ErrorHandling/TestCrashOnOutOfMemoryError.java	121	generic-all
+runtime/ErrorHandling/TestExitOnOutOfMemoryError.java	121	generic-all
+runtime/ErrorHandling/TestOnOutOfMemoryError.java	122	generic-all
+runtime/NMT/NMTWithCDS.java	124	generic-all
+runtime/memory/ReserveMemory.java	124	generic-all
+serviceability/jvmti/TestRedefineWithUnresolvedClass.java	124	generic-all
+serviceability/jvmti/GetObjectSizeOverflow.java	124	linux-all
+serviceability/sa/jmap-hashcode/Test8028623.java	124	linux-all
+############################################################################
+
+# jdk_awt
+
+############################################################################
+
+# jdk_beans 
+java/beans/Introspector/Test8027648.java	117	linux-all
+java/beans/PropertyEditor/6380849/TestPropertyEditor.java	117	generic-all
+java/beans/PropertyEditor/TestColorClass.java	117	generic-all
+java/beans/PropertyEditor/TestColorClassJava.java	117	generic-all
+java/beans/PropertyEditor/TestColorClassNull.java	117	generic-all
+java/beans/PropertyEditor/TestColorClassValue.java	117	generic-all
+java/beans/PropertyEditor/TestFontClass.java	117	generic-all
+java/beans/PropertyEditor/TestFontClassJava.java	117	generic-all
+java/beans/PropertyEditor/TestFontClassNull.java	117	generic-all
+java/beans/PropertyEditor/TestFontClassValue.java	117	generic-all
+java/beans/XMLEncoder/java_awt_ScrollPane.java	117	generic-all
+java/beans/EventHandler/Test6179222.java	136	macosx-all
+java/beans/EventHandler/Test6788531.java	136	macosx-all
+java/beans/PropertyChangeSupport/Test4682386.java	136	macosx-all
+java/beans/PropertyChangeSupport/TestSynchronization.java	136	macosx-all
+java/beans/Statement/Test4653179.java	136	macosx-all
+java/beans/XMLDecoder/8028054/TestConstructorFinder.java	136	macosx-all
+java/beans/XMLDecoder/spec/TestObject.java	136	macosx-all
+java/beans/XMLEncoder/Test4631471.java	136	macosx-all
+java/beans/XMLEncoder/Test4652928.java	136	macosx-all
+java/beans/XMLEncoder/Test4822050.java	136	macosx-all
+java/beans/XMLEncoder/Test4903007.java	136	macosx-all
+java/beans/XMLEncoder/Test6437265.java	136	macosx-all
+java/beans/XMLEncoder/Test6501431.java	136	macosx-all
+java/beans/XMLEncoder/Test6570354.java	136	macosx-all
+java/beans/XMLEncoder/java_awt_BorderLayout.java	136	macosx-all
+java/beans/XMLEncoder/java_awt_CardLayout.java	136	macosx-all
+java/beans/XMLEncoder/java_awt_GridBagLayout.java	136	macosx-all
+java/beans/XMLEncoder/javax_swing_BoxLayout.java	136	macosx-all
+java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java	136	macosx-all
+java/beans/XMLEncoder/javax_swing_JButton.java	136	macosx-all
+java/beans/XMLEncoder/javax_swing_JLayeredPane.java	136	macosx-all
+java/beans/XMLEncoder/javax_swing_JSplitPane.java	136	macosx-all
+java/beans/XMLEncoder/javax_swing_JTree.java	136	macosx-all
+java/beans/XMLEncoder/javax_swing_OverlayLayout.java	136	macosx-all
+java/beans/XMLEncoder/javax_swing_border_TitledBorder.java	136	macosx-all
+java/beans/XMLEncoder/javax_swing_plaf_BorderUIResource_TitledBorderUIResource.java	136	macosx-all
+java/beans/XMLEncoder/sun_swing_PrintColorUIResource.java	136	macosx-all
+############################################################################
+
+# jdk_lang
+jdk/lambda/vm/InterfaceAccessFlagsTest.java	126	linux-all
+java/lang/Math/HypotTests.java	128	linux-all
+############################################################################
+
+# jdk_management
+com/sun/management/DiagnosticCommandMBean/DcmdMBeanPermissionsTest.java 55	generic-all
+com/sun/management/OperatingSystemMXBean/GetCommittedVirtualMemorySize.java		134	macosx-all
+java/lang/management/MemoryMXBean/LowMemoryTest2.sh	157	linux-all
+############################################################################
+
+
+# jdk_jmx
+
+############################################################################
+
+# jdk_math
+
+############################################################################
+
+# jdk_net
+
+############################################################################
+
+# jdk_io
+java/nio/Buffer/Basic.java	118 linux-all
+############################################################################
+
+
+# jdk_nio
+java/nio/channels/SocketChannel/Connect.java	156	macosx-all
+############################################################################
+
+# jdk_rmi
+java/rmi/Naming/legalRegistryNames/LegalRegistryNames.java 61	linux-all
+java/rmi/activation/rmidViaInheritedChannel/InheritedChannelNotServerSocket.java 154 macosx-all
+
+############################################################################
+
+# jdk_security
+sun/security/pkcs11/tls/TestKeyMaterial.java	71	linux-all
+sun/security/pkcs11/Signature/TestDSAKeyLength.java	70 linux-all
+sun/security/pkcs11/Secmod/AddTrustedCert.java	125	linux-all
+sun/security/pkcs11/ec/TestECDH.java	70	linux-all
+sun/security/pkcs11/ec/TestECDSA.java	70	linux-all
+sun/security/pkcs11/ec/TestECGenSpec.java	70	linux-all
+sun/security/pkcs11/rsa/TestCACerts.java	68	linux-all
+sun/security/rsa/TestCACerts.java	68	generic-all
+
+############################################################################
+
+# jdk_sound
+javax/sound/midi/Devices/InitializationHang.java 73	generic-all
+javax/sound/midi/Devices/InitializationHang.java	136	generic-all
+############################################################################
+
+# jdk_swing
+
+############################################################################
+
+# jdk_text
+
+############################################################################
+
+# jdk_time
+
+############################################################################
+
+# jdk_tools
+sun/tools/jstatd/TestJstatdDefaults.java	115	linux-all
+sun/tools/jstatd/TestJstatdExternalRegistry.java	115	linux-all
+sun/tools/jstatd/TestJstatdPort.java	115	linux-all
+sun/tools/jstatd/TestJstatdPortAndServer.java	115	linux-all
+sun/tools/jstatd/TestJstatdServer.java	115	linux-all
+com/sun/tools/attach/StartManagementAgent.java	115	generic-all
+############################################################################
+
+# jdk_jdi
+com/sun/jdi/RedefineCrossEvent.java	227	macosx-all
+
+############################################################################
+
+# jdk_util
+java/util/ResourceBundle/Control/Bug6530694.java	137	macosx-all
+############################################################################
+
+# svc_tools
+
+############################################################################
+
+# jdk_other
+
+############################################################################


### PR DESCRIPTION
The tests excluded from the jdk8 test runs should not be run against
jdk11 until the issues that they are raised against have been resolved.

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>