### PR TITLE
Perm exclude test and tidy up

### DIFF
--- a/openjdk_regression/ProblemList_openjdk11-openj9.txt
+++ b/openjdk_regression/ProblemList_openjdk11-openj9.txt
@@ -22,124 +22,124 @@
 
 # jdk_lang
 
-java/lang/Class/GenericStringTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	generic-all	
-java/lang/Class/GetModuleTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	generic-all	
-java/lang/Class/GetPackageBootLoaderChildLayer.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	generic-all	
-java/lang/Class/forName/NonJavaNames.sh	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	generic-all	
-java/lang/Class/forName/arrayClass/ExceedMaxDim.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/Class/forName/modules/TestDriver.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/Class/getResource/ResourcesTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/ClassLoader/EndorsedDirs.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/ClassLoader/ExtDirs.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/ClassLoader/LibraryPathProperty.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/ClassLoader/RecursiveSystemLoader.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
+java/lang/Class/GenericStringTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/Class/GetModuleTest.java	https://github.com/eclipse/openj9/issues/3040	generic-all
+java/lang/Class/GetPackageBootLoaderChildLayer.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/Class/forName/NonJavaNames.sh	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/Class/forName/arrayClass/ExceedMaxDim.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/Class/forName/modules/TestDriver.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/Class/getResource/ResourcesTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/ClassLoader/EndorsedDirs.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/ClassLoader/ExtDirs.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/ClassLoader/LibraryPathProperty.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/ClassLoader/RecursiveSystemLoader.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	generic-all
-java/lang/Enum/ConstantDirectoryOptimalCapacity.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/ModuleLayer/BasicLayerTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/ProcessBuilder/Basic.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/SecurityManager/modules/CustomSecurityManager.sh	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/StackTraceElement/PublicConstructor.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/StackTraceElement/SerialTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/StackWalker/Basic.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/StackWalker/DumpStackTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
+java/lang/Enum/ConstantDirectoryOptimalCapacity.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/ModuleLayer/BasicLayerTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/ProcessBuilder/Basic.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/SecurityManager/modules/CustomSecurityManager.sh	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/StackTraceElement/PublicConstructor.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/StackTraceElement/SerialTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/StackWalker/Basic.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/StackWalker/DumpStackTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 java/lang/StackWalker/LocalsAndOperands.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
-java/lang/StackWalker/ReflectionFrames.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/StackWalker/VerifyStackTrace.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/String/CaseConvertSameInstance.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/String/CaseInsensitiveComparator.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/String/CompactString/IndexOf.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/String/EqualsIgnoreCase.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/String/StringRepeat.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/String/concat/WithSecurityManager.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
+java/lang/StackWalker/ReflectionFrames.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/StackWalker/VerifyStackTrace.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/String/CaseConvertSameInstance.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/String/CaseInsensitiveComparator.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/String/CompactString/IndexOf.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/String/EqualsIgnoreCase.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/String/StringRepeat.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/String/concat/WithSecurityManager.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 java/lang/String/nativeEncoding/StringPlatformChars.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	generic-all
-java/lang/System/Logger/custom/CustomLoggerTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/System/Logger/default/DefaultLoggerTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/System/LoggerFinder/BaseLoggerFinderTest/BaseLoggerFinderTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/System/LoggerFinder/DefaultLoggerFinderTest/DefaultLoggerFinderTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/System/LoggerFinder/LoggerFinderAPI/LoggerFinderAPI.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/System/LoggerFinder/internal/BaseDefaultLoggerFinderTest/BaseDefaultLoggerFinderTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/System/LoggerFinder/internal/BaseLoggerBridgeTest/BaseLoggerBridgeTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/System/LoggerFinder/internal/LoggerBridgeTest/LoggerBridgeTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/System/LoggerFinder/internal/LoggerFinderLoaderTest/LoggerFinderLoaderTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/System/LoggerFinder/internal/backend/LoggerFinderBackendTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/System/LoggerFinder/jdk/DefaultLoggerBridgeTest/DefaultLoggerBridgeTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/Thread/UncaughtExceptions.sh	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/ThreadGroup/SetMaxPriority.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/Throwable/SuppressedExceptions.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/annotation/AnnotationsInheritanceOrderRedefinitionTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/annotation/loaderLeak/Main.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/8147078/Test8147078.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/8177146/TestMethodHandleBind.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/AccessControlTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/ArrayConstructorTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/CallerSensitiveAccess.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/ClassSpecializerTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/CustomizedLambdaFormTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/DefineClassTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/DropLookupModeTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/ExplicitCastArgumentsTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/FindAccessTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/InvokeMethodHandleWithBadArgument.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/InvokeWithArgumentsTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/LFCaching/LFMultiThreadCachingTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/LFCaching/LFSingleThreadCachingTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/LambdaFormTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/LoopCombinatorTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/MethodHandles/TestCatchException.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/MethodHandlesGeneralTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/MethodHandlesInsertArgumentsTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/PrivateInterfaceCall.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/PrivateInvokeTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/ProtectedMemberDifferentPackage/Test.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/RevealDirectTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/RicochetTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/SpecialInterfaceCall.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/SpreadCollectTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/TryFinallyTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/VarHandle/AccessMode/OptimalMapSize.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/VarHandles/VarHandleMethodReferenceTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/VarHandles/VarHandleTestAccessBoolean.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/VarHandles/VarHandleTestAccessByte.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/VarHandles/VarHandleTestAccessChar.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/VarHandles/VarHandleTestAccessInt.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/VarHandles/VarHandleTestAccessLong.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/VarHandles/VarHandleTestAccessModeMethodNames.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/VarHandles/VarHandleTestAccessShort.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/VarHandles/VarHandleTestByteArrayAsChar.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/VarHandles/VarHandleTestByteArrayAsInt.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/VarHandles/VarHandleTestByteArrayAsLong.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/VarHandles/VarHandleTestByteArrayAsShort.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessBoolean.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessByte.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessChar.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessShort.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/VarHandles/VarHandleTestReflection.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/VarHandles/accessibility/TestFieldLookupAccessibility.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/VarargsArrayTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/condy/CondyBSMException.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/condy/CondyBSMInvocation.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/condy/CondyNestedResolutionTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/condy/CondyWrongType.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/lambda/LambdaStackTrace.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/lambda/LogGeneratedClassesTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/invoke/modules/Driver.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/module/AutomaticModulesTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/ref/CleanerTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/ref/EarlyTimeout.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/ref/FinalizerHistogramTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/ref/NullQueue.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/ref/OOMEInReferenceHandler.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/ref/ReachabilityFenceTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/reflect/AccessibleObject/CanAccessTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/reflect/AccessibleObject/ModuleSetAccessibleTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/reflect/AccessibleObject/TrySetAccessibleTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/reflect/DefaultMethodMembers/FilterNotMostSpecific.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/reflect/Nestmates/TestReflectionAPI.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/reflect/Nestmates/TestSecurityManagerChecks.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/reflect/Proxy/ProxyForMethodHandle.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/reflect/Proxy/ProxyLayerTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/reflect/Proxy/ProxyModuleMapping.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/lang/reflect/PublicMethods/PublicMethodsTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
+java/lang/System/Logger/custom/CustomLoggerTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/System/Logger/default/DefaultLoggerTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/System/LoggerFinder/BaseLoggerFinderTest/BaseLoggerFinderTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/System/LoggerFinder/DefaultLoggerFinderTest/DefaultLoggerFinderTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/System/LoggerFinder/LoggerFinderAPI/LoggerFinderAPI.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/System/LoggerFinder/internal/BaseDefaultLoggerFinderTest/BaseDefaultLoggerFinderTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/System/LoggerFinder/internal/BaseLoggerBridgeTest/BaseLoggerBridgeTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/System/LoggerFinder/internal/LoggerBridgeTest/LoggerBridgeTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/System/LoggerFinder/internal/LoggerFinderLoaderTest/LoggerFinderLoaderTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/System/LoggerFinder/internal/backend/LoggerFinderBackendTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/System/LoggerFinder/jdk/DefaultLoggerBridgeTest/DefaultLoggerBridgeTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/Thread/UncaughtExceptions.sh	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/ThreadGroup/SetMaxPriority.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/Throwable/SuppressedExceptions.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/annotation/AnnotationsInheritanceOrderRedefinitionTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/annotation/loaderLeak/Main.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/8147078/Test8147078.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/8177146/TestMethodHandleBind.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/AccessControlTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/ArrayConstructorTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/CallerSensitiveAccess.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/ClassSpecializerTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/CustomizedLambdaFormTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/DefineClassTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/DropLookupModeTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/ExplicitCastArgumentsTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/FindAccessTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/InvokeMethodHandleWithBadArgument.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/InvokeWithArgumentsTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/LFCaching/LFMultiThreadCachingTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/LFCaching/LFSingleThreadCachingTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/LambdaFormTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/LoopCombinatorTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/MethodHandles/TestCatchException.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/MethodHandlesGeneralTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/MethodHandlesInsertArgumentsTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/PrivateInterfaceCall.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/PrivateInvokeTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/ProtectedMemberDifferentPackage/Test.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/RevealDirectTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/RicochetTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/SpecialInterfaceCall.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/SpreadCollectTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/TryFinallyTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/VarHandle/AccessMode/OptimalMapSize.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/VarHandles/VarHandleMethodReferenceTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/VarHandles/VarHandleTestAccessBoolean.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/VarHandles/VarHandleTestAccessByte.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/VarHandles/VarHandleTestAccessChar.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/VarHandles/VarHandleTestAccessInt.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/VarHandles/VarHandleTestAccessLong.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/VarHandles/VarHandleTestAccessModeMethodNames.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/VarHandles/VarHandleTestAccessShort.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/VarHandles/VarHandleTestByteArrayAsChar.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/VarHandles/VarHandleTestByteArrayAsInt.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/VarHandles/VarHandleTestByteArrayAsLong.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/VarHandles/VarHandleTestByteArrayAsShort.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessBoolean.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessByte.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessChar.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessShort.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/VarHandles/VarHandleTestReflection.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/VarHandles/accessibility/TestFieldLookupAccessibility.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/VarargsArrayTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/condy/CondyBSMException.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/condy/CondyBSMInvocation.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/condy/CondyNestedResolutionTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/condy/CondyWrongType.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/lambda/LambdaStackTrace.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/lambda/LogGeneratedClassesTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/modules/Driver.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/module/AutomaticModulesTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/ref/CleanerTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/ref/EarlyTimeout.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/ref/FinalizerHistogramTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/ref/NullQueue.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/ref/OOMEInReferenceHandler.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/ref/ReachabilityFenceTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/reflect/AccessibleObject/CanAccessTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/reflect/AccessibleObject/ModuleSetAccessibleTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/reflect/AccessibleObject/TrySetAccessibleTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/reflect/DefaultMethodMembers/FilterNotMostSpecific.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/reflect/Nestmates/TestReflectionAPI.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/reflect/Nestmates/TestSecurityManagerChecks.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/reflect/Proxy/ProxyForMethodHandle.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/reflect/Proxy/ProxyLayerTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/reflect/Proxy/ProxyModuleMapping.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/reflect/PublicMethods/PublicMethodsTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 
 ############################################################################
 
@@ -159,24 +159,24 @@ java/math/BigInteger/PrimeTest.java 440 linux_arm
 
 # jdk_net
 
-java/net/InetAddress/BadDottedIPAddress.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/net/InetAddress/CachedUnknownHostName.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/net/InetAddress/IPv4Formats.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/net/Socket/asyncClose/AsyncClose.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/net/SocketOption/OptionsTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/net/SocketOption/UnsupportedOptionsTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/net/SocketPermission/SocketPermissionCollection.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/net/SocketPermission/Wildcard.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/net/Socks/SocksV4Test.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/net/URL/OpenStream.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/net/httpclient/ConnectExceptionTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
+java/net/InetAddress/BadDottedIPAddress.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/net/InetAddress/CachedUnknownHostName.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/net/InetAddress/IPv4Formats.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/net/Socket/asyncClose/AsyncClose.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/net/SocketOption/OptionsTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/net/SocketOption/UnsupportedOptionsTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/net/SocketPermission/SocketPermissionCollection.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/net/SocketPermission/Wildcard.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/net/Socks/SocksV4Test.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/net/URL/OpenStream.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/net/httpclient/ConnectExceptionTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 
 ############################################################################
 
 # jdk_io
 
-java/io/CharArrayReader/OverflowInRead.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	generic-all	
-java/io/StringBufferInputStream/OverflowInRead.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	generic-all	
+java/io/CharArrayReader/OverflowInRead.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/io/StringBufferInputStream/OverflowInRead.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 
 ############################################################################
 
@@ -186,31 +186,31 @@ java/io/StringBufferInputStream/OverflowInRead.java	https://github.com/AdoptOpen
 
 # jdk_nio
 
-java/nio/Buffer/LimitDirectMemory.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/nio/Buffer/LimitDirectMemoryNegativeTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/nio/channels/DatagramChannel/ConnectExceptions.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/nio/channels/DatagramChannel/SendExceptions.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/nio/channels/DatagramChannel/SocketOptionTests.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/nio/channels/FileChannel/TempDirectBuffersReclamation.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
+java/nio/Buffer/LimitDirectMemory.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/nio/Buffer/LimitDirectMemoryNegativeTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/nio/channels/DatagramChannel/ConnectExceptions.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/nio/channels/DatagramChannel/SendExceptions.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/nio/channels/DatagramChannel/SocketOptionTests.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/nio/channels/FileChannel/TempDirectBuffersReclamation.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 java/nio/channels/FileChannel/directio/DirectIOTest.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	generic-all
-java/nio/channels/ServerSocketChannel/SocketOptionTests.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/nio/channels/SocketChannel/ExceptionTranslation.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/nio/channels/SocketChannel/SocketOptionTests.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/nio/channels/spi/SelectorProvider/inheritedChannel/InheritedChannelTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/nio/file/Files/CallWithInterruptSet.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/nio/file/Files/ReadWriteString.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
+java/nio/channels/ServerSocketChannel/SocketOptionTests.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/nio/channels/SocketChannel/ExceptionTranslation.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/nio/channels/SocketChannel/SocketOptionTests.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/nio/channels/spi/SelectorProvider/inheritedChannel/InheritedChannelTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/nio/file/Files/CallWithInterruptSet.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/nio/file/Files/ReadWriteString.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 
 ############################################################################
 
 # jdk_rmi
 
-java/rmi/dgc/dgcAckFailure/DGCAckFailure.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/rmi/dgc/retryDirtyCalls/RetryDirtyCalls.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/rmi/server/RemoteServer/AddrInUse.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/rmi/server/UnicastRemoteObject/serialFilter/FilterUROTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/rmi/server/UnicastRemoteObject/unexportObject/UnexportLeak.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/rmi/server/UnicastServerRef/serialFilter/FilterUSRTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/rmi/transport/runtimeThreadInheritanceLeak/RuntimeThreadInheritanceLeak.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
+java/rmi/dgc/dgcAckFailure/DGCAckFailure.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/rmi/dgc/retryDirtyCalls/RetryDirtyCalls.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/rmi/server/RemoteServer/AddrInUse.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/rmi/server/UnicastRemoteObject/serialFilter/FilterUROTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/rmi/server/UnicastRemoteObject/unexportObject/UnexportLeak.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/rmi/server/UnicastServerRef/serialFilter/FilterUSRTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/rmi/transport/runtimeThreadInheritanceLeak/RuntimeThreadInheritanceLeak.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 
 ############################################################################
 
@@ -244,18 +244,18 @@ java/rmi/transport/runtimeThreadInheritanceLeak/RuntimeThreadInheritanceLeak.jav
 
 # jdk_util
 
-java/util/Arrays/TimSortStackSize2.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/util/Spliterator/SpliteratorCharacteristics.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/util/Spliterator/SpliteratorCollisions.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/util/concurrent/LinkedTransferQueue/WhiteBox.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/util/concurrent/atomic/VMSupportsCS8.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/util/concurrent/forkjoin/FJExceptionTableLeak.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/util/concurrent/locks/Lock/TimedAcquireLeak.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/util/concurrent/tck/JSR166TestCase.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/util/logging/TestLoggerWeakRefLeak.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/util/logging/modules/GetResourceBundleTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/util/prefs/PrefsSpi.sh	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-java/util/stream/test/org/openjdk/tests/java/util/stream/ToArrayOpTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
+java/util/Arrays/TimSortStackSize2.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/util/Spliterator/SpliteratorCharacteristics.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/util/Spliterator/SpliteratorCollisions.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/util/concurrent/LinkedTransferQueue/WhiteBox.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/util/concurrent/atomic/VMSupportsCS8.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/util/concurrent/forkjoin/FJExceptionTableLeak.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/util/concurrent/locks/Lock/TimedAcquireLeak.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/util/concurrent/tck/JSR166TestCase.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/util/logging/TestLoggerWeakRefLeak.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/util/logging/modules/GetResourceBundleTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/util/prefs/PrefsSpi.sh	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/util/stream/test/org/openjdk/tests/java/util/stream/ToArrayOpTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 
 ############################################################################
 
@@ -265,16 +265,16 @@ java/util/stream/test/org/openjdk/tests/java/util/stream/ToArrayOpTest.java	http
 
 # jdk_other
 
-jdk/internal/misc/TerminatingThreadLocal/TestTerminatingThreadLocal.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-jdk/internal/misc/VM/GetNanoTimeAdjustment.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-jdk/internal/misc/VM/RuntimeArguments.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-jdk/internal/reflect/CallerSensitive/CheckCSMs.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-jdk/internal/reflect/constantPool/ConstantPoolTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
+jdk/internal/misc/TerminatingThreadLocal/TestTerminatingThreadLocal.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+jdk/internal/misc/VM/GetNanoTimeAdjustment.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+jdk/internal/misc/VM/RuntimeArguments.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+jdk/internal/reflect/CallerSensitive/CheckCSMs.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+jdk/internal/reflect/constantPool/ConstantPoolTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 
-sun/misc/SunMiscSignalTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-sun/net/www/protocol/jrt/WithSecurityManager.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
-sun/nio/ch/TestMaxCachedBufferSize.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
+sun/misc/SunMiscSignalTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+sun/net/www/protocol/jrt/WithSecurityManager.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+sun/nio/ch/TestMaxCachedBufferSize.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 
-vm/verifier/VerifyProtectedConstructor.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all	
+vm/verifier/VerifyProtectedConstructor.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 
 ############################################################################


### PR DESCRIPTION
Perm exclude java/lang/Class/GetModuleTest.java, remove platform duplicates for some entries and crud at end of line for most entries.

Signed-off-by: Ben Walsh ben_walsh@uk.ibm.com