### PR TITLE
Disale jdk_math for jre jdk test

### DIFF
--- a/openjdk_regression/playlist.xml
+++ b/openjdk_regression/playlist.xml
@@ -244,6 +244,7 @@
 		</groups>
 	</test>
 		<test>
+		<!-- this is only for jre jdk test, jdk11 build do not have jre jdk yet, disalbe for jdk11 -->
 		<testCaseName>jdk_math_jre</testCaseName>
 		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
 	$(JTREG_BASIC_OPTIONS)  -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
@@ -259,7 +260,6 @@
 			<subset>SE80</subset>
 			<subset>SE90</subset>
 			<subset>SE100</subset>
-			<subset>SE110</subset>
 		</subsets>
 		<levels>
 			<level>sanity</level>


### PR DESCRIPTION
As there is no jre jdk for jdk11 build yet

Issue #75

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>