### PR TITLE
Enable idle_micor perf tests for jdk11

### DIFF
--- a/performance/idle_micro/playlist.xml
+++ b/performance/idle_micro/playlist.xml
@@ -37,6 +37,7 @@
 		<subsets>
 			<subset>SE80</subset>
 			<subset>SE90</subset>
+			<subset>SE110</subset>
 		</subsets>
 	</test>
     <test>
@@ -65,6 +66,7 @@
 		<subsets>
 			<subset>SE80</subset>
 			<subset>SE90</subset>
+			<subset>SE110</subset>
 		</subsets>
 	</test>
 </playlist>


### PR DESCRIPTION
Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>