### PR TITLE
Include back locking load test for aarch64 linux

### DIFF
--- a/systemtest/playlist.xml
+++ b/systemtest/playlist.xml
@@ -93,7 +93,6 @@
 		</groups>
 	</test>
 	
-	<!-- Temporarily exclude from aarch64 linux for: https://github.com/eclipse/openj9/issues/3066 -->
 	<test>
 		<testCaseName>LockingLoadTest</testCaseName>
 		<variations>
@@ -113,7 +112,6 @@
 		<groups>
 			<group>system</group>
 		</groups>
-		<platformRequirements>^arch.arm</platformRequirements>
 	</test>
 	
 	<!-- Exclude from JDK11 due to : https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/178 -->


### PR DESCRIPTION
Include back locking load test for aarch64 linux
Signed-off-by: Mesbah <Mesbah_Alam@ca.ibm.com>