### PR TITLE
Use gmake on AIX for teardown target

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -25,11 +25,12 @@ def stageTestBinaries() {
 }
 
 def makeTest(testParam) {
+	String tearDownCmd = "if [ `uname` = AIX ]; then MAKE=gmake; else MAKE=make; fi; \$MAKE -f ./openjdk-tests/TestConfig/testEnv.mk testEnvTeardown"
 	try {
-		sh "make -f ./openjdk-tests/TestConfig/testEnv.mk testEnvTeardown"
+		sh "$tearDownCmd"
 		sh "./openjdk-tests/maketest.sh $testParam" 
 	} finally {
-		sh "make -f ./openjdk-tests/TestConfig/testEnv.mk testEnvTeardown"
+		sh "$tearDownCmd"
 	}
 }
 


### PR DESCRIPTION
- If uname is AIX, use gmake instead of make

Fixes #621

Signed-off-by: Renfei Wang <renfeiw@ca.ibm.com>