### PR TITLE
Increase global timeout of Adopt builds to 10 hrs

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -264,7 +264,7 @@ def post(test_target) {
 }
 
 def testBuild() {
-	def time_limit = 8
+	def time_limit = 10
 	if(params.TIME_LIMIT) {
 		time_limit = params.TIME_LIMIT.toInteger()
 	}


### PR DESCRIPTION
Increase global timeout of Adopt builds to 10 hrs
Signed-off-by: Mesbah <Mesbah_Alam@ca.ibm.com>