### PR TITLE
WIP: Updates for OSX testing for OpenJ9 

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -139,7 +139,7 @@ def setup() {
 					step([$class: 'CopyArtifact',
 						fingerprintArtifacts: true,
 						flatten: true,
-						filter: "**/*.tar.gz,**/*.zip,**/*.jar",
+						filter: "**/*.tar.gz,**/*.tgz,**/*.zip,**/*.jar",
 						projectName: "${params.UPSTREAM_JOB_NAME}",
 						selector: [$class: 'SpecificBuildSelector', buildNumber: "${params.UPSTREAM_JOB_NUMBER}"]])
 				}

--- a/buildenv/jenkins/openjdk_x86-64_osx
+++ b/buildenv/jenkins/openjdk_x86-64_osx
@@ -1,0 +1,18 @@
+#!groovy
+LABEL='sw.os.osx&&hw.arch.x86'
+
+node ("master") {
+	checkout scm
+	def jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
+	jenkinsfile.setLabelParam()
+	cleanWs()
+}
+
+node("$LABEL") {
+    PLATFORM = 'x64_mac'
+    SDK_RESOURCE = 'upstream'
+    SPEC='mac_x86-64_cmprssptrs'
+    checkout scm
+    def jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
+    jenkinsfile.testBuild()
+}

--- a/get.sh
+++ b/get.sh
@@ -186,13 +186,13 @@ getBinaryOpenjdk()
 			jar_dir_name=${jar_dir%?}
 			if [[ "$jar_dir_name" =~ jre*  &&  "$jar_dir_name" != "j2jre-image" ]]; then
 				if [[ "$PLATFORM" == "x64_mac" ]]; then
-					mv "$jar_dir_name/Contents/Home" j2jre-image
+					mv "$jar_dir_name" j2jre-image
 				else
 					mv $jar_dir_name j2jre-image
 				fi
 			elif [[ "$jar_dir_name" =~ jdk*  &&  "$jar_dir_name" != "j2sdk-image" ]]; then
 				if [[ "$PLATFORM" == "x64_mac" ]]; then
-					mv "$jar_dir_name/Contents/Home" j2sdk-image
+					mv "$jar_dir_name" j2sdk-image
 				else
 					mv $jar_dir_name j2sdk-image
 				fi

--- a/maketest.sh
+++ b/maketest.sh
@@ -42,6 +42,7 @@ else
 		done
 	fi
 	else
+	  echo "Normal setup, no multiple targets passed"
 		$MAKE -C $testDir -f autoGen.mk $@
 	fi
 fi

--- a/maketest.sh
+++ b/maketest.sh
@@ -40,7 +40,6 @@ else
     	echo "> [$sub_target]"
 			$MAKE -C $testDir -f autoGen.mk $sub_target
 		done
-	fi
 	else
 	  echo "Normal setup, no multiple targets passed"
 		$MAKE -C $testDir -f autoGen.mk $@

--- a/maketest.sh
+++ b/maketest.sh
@@ -18,6 +18,7 @@ else
 fi
 
 if [ "$#" -eq 1 ];then
+	# temporarily removing DDR_Test for macos run
 	rm -rf $1/functional/DDR_Test
 	cd $1/TestConfig
 	$MAKE -f run_configure.mk
@@ -28,6 +29,20 @@ if [ "$#" -eq 1 ];then
 else
 	testDir=$1
 	shift
-	$MAKE -C $testDir -f autoGen.mk $@
+	# check if TARGET is comma-separated list of targets
+	# if so, parse and run each target, CUSTOMIZED_TEST_TARGET will be ignored
+	if [[ $1 == *[,]* ]]
+	then
+  	echo "TARGET is list of sub_targets\n"
+		subtargets=$(echo $1 | tr "," "\n")
+		for sub_target in $subtargets
+		do
+    	echo "> [$sub_target]"
+			$MAKE -C $testDir -f autoGen.mk $sub_target
+		done
+	fi
+	else
+		$MAKE -C $testDir -f autoGen.mk $@
+	fi
 fi
 

--- a/maketest.sh
+++ b/maketest.sh
@@ -18,6 +18,7 @@ else
 fi
 
 if [ "$#" -eq 1 ];then
+	rm -rf $1/functional/DDR_Test
 	cd $1/TestConfig
 	$MAKE -f run_configure.mk
 	if [ $? -ne 0 ]; then


### PR DESCRIPTION
This is also to allow running of functional test suites, subsets of which we may eventually want to use at AdoptOpenJDK for all implementations.
