### PR TITLE
Enable concurrent scavenge related tests on X86

### DIFF
--- a/systemtest/playlist.xml
+++ b/systemtest/playlist.xml
@@ -2645,7 +2645,7 @@
 	</test>
 	<!-- Tests above pertain to Java 9 Modularity -->
 	
-	<!-- The tests below are added to test concurrent scavenge on z/OS and z/Linux using OpenJ9 SDK -->	
+	<!-- The tests below are added to test concurrent scavenge on z/OS, z/Linux and x/Linux using 64-bit OpenJ9 SDK -->	
 	<test>
 		<testCaseName>ClassLoadingTest_ConcurrentScavenge</testCaseName>
 		<variations>
@@ -2668,7 +2668,7 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
-		<platformRequirements>arch.390</platformRequirements>
+		<platformRequirements>bits.64,^arch.ppc,^arch.arm,^os.win</platformRequirements>
 	</test>
 	
 	<test>
@@ -2693,7 +2693,7 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
-		<platformRequirements>arch.390</platformRequirements>
+		<platformRequirements>bits.64,^arch.ppc,^arch.arm,^os.win</platformRequirements>
 	</test>
 	
 	<test>
@@ -2718,7 +2718,7 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
-		<platformRequirements>arch.390</platformRequirements>
+		<platformRequirements>bits.64,^arch.ppc,^arch.arm,^os.win</platformRequirements>
 	</test>
 	
 	<test>
@@ -2744,7 +2744,7 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
-		<platformRequirements>arch.390</platformRequirements>
+		<platformRequirements>bits.64,^arch.ppc,^arch.arm,^os.win</platformRequirements>
 	</test>
 	
 	<test>
@@ -2770,7 +2770,7 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
-		<platformRequirements>arch.390</platformRequirements>
+		<platformRequirements>bits.64,^arch.ppc,^arch.arm,^os.win</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>DaaLoadTest_daa1_ConcurrentScavenge</testCaseName>
@@ -2795,7 +2795,7 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
-		<platformRequirements>arch.390</platformRequirements>
+		<platformRequirements>bits.64,^arch.ppc,^arch.arm,^os.win</platformRequirements>
 	</test>
 	
 	<test>
@@ -2821,7 +2821,7 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
-		<platformRequirements>arch.390</platformRequirements>
+		<platformRequirements>bits.64,^arch.ppc,^arch.arm,^os.win</platformRequirements>
 	</test>
 	
 	<test>
@@ -2847,7 +2847,7 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
-		<platformRequirements>arch.390</platformRequirements>
+		<platformRequirements>bits.64,^arch.ppc,^arch.arm,^os.win</platformRequirements>
 	</test>
 	
 	<test>
@@ -2872,7 +2872,7 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
-		<platformRequirements>arch.390</platformRequirements>
+		<platformRequirements>bits.64,^arch.ppc,^arch.arm,^os.win</platformRequirements>
 	</test>
 	
 	<test>
@@ -2897,7 +2897,7 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
-		<platformRequirements>arch.390</platformRequirements>
+		<platformRequirements>bits.64,^arch.ppc,^arch.arm,^os.win</platformRequirements>
 		<disabled>AdoptOpenJDK/openjdk-systemtest/issues/75</disabled>
 	</test>
 	
@@ -2923,7 +2923,7 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
-		<platformRequirements>arch.390</platformRequirements>
+		<platformRequirements>bits.64,^arch.ppc,^arch.arm,^os.win</platformRequirements>
 		<disabled>AdoptOpenJDK/openjdk-systemtest/issues/78</disabled>
 	</test>
 	
@@ -2949,7 +2949,7 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
-		<platformRequirements>arch.390</platformRequirements>
+		<platformRequirements>bits.64,^arch.ppc,^arch.arm,^os.win</platformRequirements>
 		<disabled>AdoptOpenJDK/openjdk-systemtest/issues/64</disabled>
 	</test>
 	<!-- The above tests are to be run using concurrentScavenge on z/OS and z/Linux using OpenJ9 SDK -->


### PR DESCRIPTION
OpenJ9 has expanded its concurrent scavenge support on X86, and hence related tests should be enabled.

Issue #651 

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>