### PR TITLE
Update

### DIFF
--- a/openjdk_regression/ProblemList_openjdk11-openj9.txt
+++ b/openjdk_regression/ProblemList_openjdk11-openj9.txt
@@ -180,8 +180,8 @@ java/nio/channels/SocketChannel/SocketOptionTests.java	https://github.com/AdoptO
 java/nio/channels/spi/SelectorProvider/inheritedChannel/InheritedChannelTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 java/nio/file/Files/CallWithInterruptSet.java	https://github.com/eclipse/openj9/issues/3325	generic-all
 java/nio/file/Files/ReadWriteString.java	https://github.com/eclipse/openj9/issues/3325	generic-all
-java/nio/file/attribute/BasicFileAttributeView/UnixSocketFile.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/593	linux-all
-java/nio/channels/AsyncCloseAndInterrupt.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/593	linux-all
+java/nio/file/attribute/BasicFileAttributeView/UnixSocketFile.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/602	linux-all
+java/nio/channels/AsyncCloseAndInterrupt.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/602	linux-all
 
 ############################################################################
 

--- a/openjdk_regression/ProblemList_openjdk11-openj9.txt
+++ b/openjdk_regression/ProblemList_openjdk11-openj9.txt
@@ -180,6 +180,9 @@ java/nio/channels/SocketChannel/SocketOptionTests.java	https://github.com/AdoptO
 java/nio/channels/spi/SelectorProvider/inheritedChannel/InheritedChannelTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 java/nio/file/Files/CallWithInterruptSet.java	https://github.com/eclipse/openj9/issues/3325	generic-all
 java/nio/file/Files/ReadWriteString.java	https://github.com/eclipse/openj9/issues/3325	generic-all
+java/nio/file/attribute/BasicFileAttributeView/UnixSocketFile.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/593	linux-all
+java/nio/channels/AsyncCloseAndInterrupt.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/593	linux-all
+
 ############################################################################
 
 # jdk_rmi


### PR DESCRIPTION
Exclude tests which fail on OJ9 same way they fail on HS