### PR TITLE
Include back Mauve load tests in SE80 build after omitting CORBA Tests

### DIFF
--- a/systemtest/playlist.xml
+++ b/systemtest/playlist.xml
@@ -210,7 +210,9 @@
 		<groups>
 			<group>system</group>
 		</groups>
-		<disabled>AdoptOpenJDK/openjdk-systemtest/issues/75</disabled>
+		<subsets>
+			<subset>SE80</subset>
+		</subsets>
 	</test>
 	
 	<test>
@@ -232,7 +234,9 @@
 		<groups>
 			<group>system</group>
 		</groups>
-		<disabled>AdoptOpenJDK/openjdk-systemtest/issues/78</disabled>
+		<subsets>
+			<subset>SE80</subset>
+		</subsets>
 	</test>
 	
 	<test>
@@ -254,7 +258,9 @@
 		<groups>
 			<group>system</group>
 		</groups>
-		<disabled>AdoptOpenJDK/openjdk-systemtest/issues/64</disabled>
+		<subsets>
+			<subset>SE80</subset>
+		</subsets>
 	</test>
 	
 	<!-- Temporarily exclude from Linux aarch64 for: https://github.com/eclipse/openj9/issues/3065 -->


### PR DESCRIPTION
Include back Mauve load tests in SE80 build after omitting CORBA Tests
Signed-off-by: Mesbah Alam <Mesbah_Alam@ca.ibm.com>