### PR TITLE
Update label ppc to ppc64

### DIFF
--- a/buildenv/jenkins/openjdk_ppc64_aix
+++ b/buildenv/jenkins/openjdk_ppc64_aix
@@ -1,5 +1,5 @@
 #!groovy
-LABEL='hw.arch.ppc&&sw.os.aix'
+LABEL='hw.arch.ppc64&&sw.os.aix'
 
 node ("master") {
     checkout scm


### PR DESCRIPTION
- Label should be ppc64 to be more correct

Related Eclipse/OpenJ9#3593

Signed-off-by: Adam Brousseau <adam.brousseau@ca.ibm.com>