### PR TITLE
Update

### DIFF
--- a/openjdk_regression/ProblemList_openjdk11-openj9.txt
+++ b/openjdk_regression/ProblemList_openjdk11-openj9.txt
@@ -239,6 +239,8 @@ java/util/concurrent/tck/JSR166TestCase.java	https://github.com/eclipse/openj9/i
 java/util/logging/TestLoggerWeakRefLeak.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 java/util/prefs/PrefsSpi.sh	https://github.com/eclipse/openj9/issues/3232	generic-all
 java/util/stream/test/org/openjdk/tests/java/util/stream/ToArrayOpTest.java	https://github.com/eclipse/openj9/issues/3447	generic-all
+java/util/Currency/ValidateISO4217.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/678 generic-all
+java/util/Currency/CurrencyTest.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/678 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
Temporarily exclude tests which are failing due to outdated test code acquired as a result of failing sync Jenkins job