### PR TITLE
Use pre-built mauve.jar in systemtest builds

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -188,6 +188,9 @@ def buildTest() {
 			try {
 				//get pre-staged jars from test.getDependency build before test compilation
 				copyArtifacts fingerprintArtifacts: true, projectName: "test.getDependency", selector: lastSuccessful(), target: 'openjdk-tests/TestConfig/lib'
+				
+				//get pre-staged test jars from systemtest.getDependency build before system test compilation
+				copyArtifacts fingerprintArtifacts: true, projectName: "systemtest.getDependency", selector: lastSuccessful(), target: 'openjdk-tests/TestConfig/lib'
 			} catch (Exception e) {
 				echo 'Cannot run copyArtifacts from test.getDependency. Skipping copyArtifacts...'
 			}

--- a/systemtest/build.xml
+++ b/systemtest/build.xml
@@ -176,6 +176,7 @@
 			<else>
 				<ant antfile="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build/build.xml" dir="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build/" target="configure" inheritAll="false">
 					<property name="java.home" value="${env.JAVA_HOME}"/>
+					<property name="isAutomatedBuild" value="true"/>
 				</ant>
 			</else>
 		</if>


### PR DESCRIPTION
Resolves: https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/187
Signed-off-by: Mesbah Alam <Mesbah_Alam@ca.ibm.com>