### PR TITLE
Update get.sh for OSX

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -185,13 +185,13 @@ getBinaryOpenjdk()
 		do
 			jar_dir_name=${jar_dir%?}
 			if [[ "$jar_dir_name" =~ jre*  &&  "$jar_dir_name" != "j2jre-image" ]]; then
-				if [[ "$PLATFORM" == "x64_mac" ]]; then
+				if [[ -d $jar_dir_name/Contents/Home ]]; then
 					mv "$jar_dir_name/Contents/Home" j2jre-image
 				else
 					mv $jar_dir_name j2jre-image
 				fi
 			elif [[ "$jar_dir_name" =~ jdk*  &&  "$jar_dir_name" != "j2sdk-image" ]]; then
-				if [[ "$PLATFORM" == "x64_mac" ]]; then
+				if [[ -d $jar_dir_name/Contents/Home ]]; then
 					mv "$jar_dir_name/Contents/Home" j2sdk-image
 				else
 					mv $jar_dir_name j2sdk-image


### PR DESCRIPTION
On OSX, there are two SDK flavors: with and without \*/Contents/Home/\*
directory structure.

When creating j2jre-image or j2sdk-image, get.sh must distinguish and
account for both the flavors on OSX.

Currently, get.sh assumes that all OSX SDKs have \*/Contents/Home/\*
directory structure, which is incorrect.

get.sh has been updated to account for the above-mentioned two SDK
flavors on OSX.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>