### PR TITLE
Add missing flag to the invocation of openj9-systemtest build

### DIFF
--- a/systemtest/build.xml
+++ b/systemtest/build.xml
@@ -171,6 +171,7 @@
 			<then>
 				<ant antfile="${SYSTEMTEST_ROOT}/openj9-systemtest/openj9.build/build.xml" dir="${SYSTEMTEST_ROOT}/openj9-systemtest/openj9.build/" target="configure" inheritAll="false">
 					<property name="java.home" value="${env.JAVA_HOME}"/>
+					<property name="isAutomatedBuild" value="true"/>
 				</ant>
 			</then>
 			<else>


### PR DESCRIPTION
Resolves https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/192
Signed-off-by: Mesbah Alam <Mesbah_Alam@ca.ibm.com>