### PR TITLE
enhance get.sh

### DIFF
--- a/doc/userGuide.md
+++ b/doc/userGuide.md
@@ -39,7 +39,7 @@ You can set up your own Jenkins-based test builds using the AdoptOpenJDK openjdk
 ``` bash
 git clone https://github.com/AdoptOpenJDK/openjdk-tests.git
 cd openjdk-tests
-get.sh -t openjdk-testsDIR -p platform [-j SE80] [-i hotspot] [-R latest] [-t jdk] [-s downloadBinarySDKDIR] [-r SDK_RESOURCE] [-c CUSTOMIZED_SDK_URL]
+get.sh -t openjdk-testsDIR -p platform [-j SE80] [-i hotspot] [-R latest] [-T jdk] [-s downloadBinarySDKDIR] [-r SDK_RESOURCE] [-c CUSTOMIZED_SDK_URL]
 ```
 
 Where possible values of get.sh script are:
@@ -53,7 +53,7 @@ Usage : get.sh  --testdir|-t openjdktestdir
 
                 [--releases|-R ] : optional. Example: latest, jdk8u172-b00-201807161800
 
-                [--type|-t ] : optional. jdk or jre
+                [--type|-T ] : optional. jdk or jre
 
                 [--sdkdir|-s binarySDKDIR] : if do not have a local sdk available, specify preferred directory
 

--- a/get.sh
+++ b/get.sh
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -e
+
 SDKDIR=""
 TESTDIR=""
 PLATFORM=""
@@ -38,7 +40,7 @@ usage ()
 	echo '                [--jdk_version|-j ]: optional. JDK version'
 	echo '                [--jdk_impl|-i ]: optional. JDK implementation'
 	echo '                [--releases|-R ]: optional. Example: latest, jdk8u172-b00-201807161800'
-	echo '                [--type|-t ]: optional. jdk or jre'
+	echo '                [--type|-T ]: optional. jdk or jre'
 	echo '                [--sdkdir|-s binarySDKDIR] : if do not have a local sdk available, specify preferred directory'
 	echo '                [--sdk_resource|-r ] : indicate where to get sdk - releases, nightly , upstream or customized'
 	echo '                [--customizedURL|-c ] : indicate sdk url if sdk source is set as customized.  Multiple urls can be passed with space as separator'
@@ -77,7 +79,7 @@ parseCommandLineArgs()
 			"--releases" | "-R" )
 				RELEASES="$1"; shift;;
 
-			"--type" | "-t" )
+			"--type" | "-T" )
 				TYPE="$1"; shift;;
 
 			"--sdk_resource" | "-r" )
@@ -298,11 +300,26 @@ getTestKitGenAndFunctionalTestMaterial()
 	fi
 }
 
-parseCommandLineArgs "$@"
-if [ ! -d "$TESTDIR/TestConfig" ]; then
-	getTestKitGenAndFunctionalTestMaterial
+testJavaVersion()
+{
+# use environment variable JAVA_BIN to run java -version
+_java=${JAVA_BIN}/java
+if [ -x ${_java} ]; then
+	echo "Run ${_java} -version"
+	${_java} -version
+else
+	echo "Cannot find java executable in JAVA_BIN: ${JAVA_BIN}!"
+	exit 1
 fi
+}
 
+parseCommandLineArgs "$@"
 if [[ "$SDKDIR" != "" ]]; then
 	getBinaryOpenjdk
+fi
+
+testJavaVersion
+
+if [ ! -d "$TESTDIR/TestConfig" ]; then
+	getTestKitGenAndFunctionalTestMaterial
 fi


### PR DESCRIPTION
- set -e to exit immediately if a command exits with a non-zero status
- add java -version check once we have sdk and/or jre ready
- call getBinaryOpenjdk() before
getTestKitGenAndFunctionalTestMaterial(). Because if SDK does not exist,
there is no point to download test material

Fixes: #505 #695

Signed-off-by: lanxia <lan_xia@ca.ibm.com>