### PR TITLE
Skip regression jre tests

### DIFF
--- a/openjdk_regression/playlist.xml
+++ b/openjdk_regression/playlist.xml
@@ -259,7 +259,6 @@
 			<subset>8</subset>
 			<subset>9</subset>
 			<subset>10</subset>
-			<subset>11</subset>
 		</subsets>
 		<levels>
 			<level>sanity</level>


### PR DESCRIPTION
No jre image for jdk11u build and 'JRE' target will be away anytime from 12+. Temporarily skip the test for 11+.

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>