### PR TITLE
Temporarily exclude security enabled JLM tests on Windows

### DIFF
--- a/systemtest/playlist.xml
+++ b/systemtest/playlist.xml
@@ -952,6 +952,7 @@
 	</test>
 	
 	<!-- Excluding the following test for openj9 for eclipse/openj9/issues/1520  -->
+	<!-- Excluded from Windows due to https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/198 -->
 	<test>
 		<testCaseName>TestJlmRemoteClassAuth</testCaseName>
 		<variations>
@@ -974,6 +975,7 @@
 		<impls>
 			<impl>hotspot</impl>
 		</impls>
+		<platformRequirements>^os.win</platformRequirements> 
 	</test>
 	
 	<!--Exclude TestJlmRemoteClassNoAuth from running on openjdk8-openj9 on ppc64le Linux. Reason: AdoptOpenJDK/openjdk-systemtest/issues/145-->
@@ -1065,6 +1067,7 @@
 	</test>
 	
 	<!--Exclude TestJlmRemoteMemoryAuth from running on openjdk8-openj9 on ppc64le Linux. Reason: AdoptOpenJDK/openjdk-systemtest/issues/145-->
+	<!-- Excluded from Windows due to https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/198 -->
 	<test>
 		<testCaseName>TestJlmRemoteMemoryAuth</testCaseName>
 		<variations>
@@ -1093,7 +1096,10 @@
 			<impl>hotspot</impl>
 			<impl>openj9</impl>
 		</impls>
+		<platformRequirements>^os.win</platformRequirements> 
 	</test>
+	
+	<!-- Excluded from Windows due to https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/198 -->
 	<test>
 		<testCaseName>TestJlmRemoteMemoryAuth_SE80</testCaseName>
 		<variations>
@@ -1120,8 +1126,9 @@
 			<impl>hotspot</impl>
 			<impl>openj9</impl>
 		</impls>
-		<platformRequirements>^os.linux</platformRequirements>
+		<platformRequirements>^os.linux,^os.win</platformRequirements> 
 	</test>
+	
 	<test>
 		<testCaseName>TestJlmRemoteMemoryAuth_SE80_Linux</testCaseName>
 		<variations>
@@ -1148,7 +1155,7 @@
 			<impl>hotspot</impl>
 			<impl>openj9</impl>
 		</impls>
-		<platformRequirements>os.linux,^arch.ppc</platformRequirements>
+		<platformRequirements>os.linux,^arch.ppc</platformRequirements> 
 	</test>
 
 	<!--Exclude TestJlmRemoteMemoryNoAuth from running on openjdk8-openj9 on ppc64le Linux. Reason: AdoptOpenJDK/openjdk-systemtest/issues/145-->
@@ -1238,6 +1245,7 @@
 		<platformRequirements>os.linux,^arch.ppc</platformRequirements>
 	</test>
 
+	<!-- Excluded from Windows due to https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/198 -->
 	<test>
 		<testCaseName>TestJlmRemoteNotifierProxyAuth</testCaseName>
 		<variations>
@@ -1260,6 +1268,7 @@
 		<impls>
 			<impl>hotspot</impl>
 		</impls>
+		<platformRequirements>^os.win</platformRequirements> 
 	</test>
 
 	<!-- Excluding the following test for Hotspot & OpenJDK10-Openj9 and JDK11 for eclipse/openj9/issues/1566  -->
@@ -1371,6 +1380,7 @@
 	</test>
 	
 	<!--Exclude TestIBMJlmRemoteClassAuth from running on openjdk8-openj9 on ppc64le Linux. Reason: AdoptOpenJDK/openjdk-systemtest/issues/145-->
+	<!-- Excluded from Windows due to https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/198 -->
 	<test>
 		<testCaseName>TestIBMJlmRemoteClassAuth</testCaseName>
 		<variations>
@@ -1398,7 +1408,10 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
+		<platformRequirements>^os.win</platformRequirements> 
 	</test>
+	
+	<!-- Excluded from Windows due to https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/198 -->
 	<test>
 		<testCaseName>TestIBMJlmRemoteClassAuth_SE80</testCaseName>
 		<variations>
@@ -1424,8 +1437,9 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
-		<platformRequirements>^os.linux</platformRequirements>
+		<platformRequirements>^os.linux,^os.win</platformRequirements>
 	</test>
+
 	<test>
 		<testCaseName>TestIBMJlmRemoteClassAuth_SE80_Linux</testCaseName>
 		<variations>
@@ -1539,6 +1553,7 @@
 	</test>
 	
 	<!--Exclude TestIBMJlmRemoteMemoryAuth from running on openjdk8-openj9 on ppc64le Linux. Reason: AdoptOpenJDK/openjdk-systemtest/issues/145-->
+	<!-- Excluded from Windows due to https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/198 -->
 	<test>
 		<testCaseName>TestIBMJlmRemoteMemoryAuth</testCaseName>
 		<variations>
@@ -1566,7 +1581,10 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
+		<platformRequirements>^os.win</platformRequirements> 
 	</test>
+	
+	<!-- Excluded from Windows due to https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/198 -->
 	<test>
 		<testCaseName>TestIBMJlmRemoteMemoryAuth_SE80</testCaseName>
 		<variations>
@@ -1592,8 +1610,9 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
-		<platformRequirements>^os.linux</platformRequirements>
+		<platformRequirements>^os.linux,^os.win</platformRequirements>
 	</test>
+
 	<test>
 		<testCaseName>TestIBMJlmRemoteMemoryAuth_SE80_Linux</testCaseName>
 		<variations>


### PR DESCRIPTION
Temporarily exclude security enabled JLM tests on Windows due to https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/198
Signed-off-by: Mesbah Alam <Mesbah_Alam@ca.ibm.com>