### PR TITLE
Update excludes in systemtest playlist

### DIFF
--- a/systemtest/playlist.xml
+++ b/systemtest/playlist.xml
@@ -306,6 +306,23 @@
 			<group>system</group>
 		</groups>
 	</test>
+
+	<test>
+		<testCaseName>HCRLateAttachWorkload</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>export JAVA_HOME=$(JDK_HOME)$(D)  && \
+	perl $(TEST_RESROOT)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
+	-test-root=$(Q)$(TEST_RESROOT)$(D)stf;$(TEST_RESROOT)$(D)openjdk-systemtest$(Q) \
+	-systemtest-prereqs=$(Q)$(TEST_RESROOT)$(D)systemtest_prereqs$(Q)  \
+	-results-root=$(REPORTDIR)  \
+	-test=HCRLateAttachWorkload; \
+	$(TEST_STATUS)</command>	
+		<tags>
+			<tag>system</tag>
+		</tags>
+	</test>
 	
 	<!-- Exclude LambdaLoad test on Linux x64 non-compressedrefs sdks for OpenJ9 builds only,
 		Reason: https://github.com/eclipse/openj9/issues/2209)-->

--- a/systemtest/playlist.xml
+++ b/systemtest/playlist.xml
@@ -307,6 +307,7 @@
 		</groups>
 	</test>
 
+	<!-- Temporarily exclude from jdk11 for: https://github.com/adoptopenjdk/openjdk-systemtest/issues/7 -->
 	<test>
 		<testCaseName>HCRLateAttachWorkload</testCaseName>
 		<variations>
@@ -319,6 +320,9 @@
 	-results-root=$(REPORTDIR)  \
 	-test=HCRLateAttachWorkload; \
 	$(TEST_STATUS)</command>	
+		<subsets>
+			<subset>8</subset>
+		</subsets>
 		<tags>
 			<tag>system</tag>
 		</tags>

--- a/systemtest/playlist.xml
+++ b/systemtest/playlist.xml
@@ -50,6 +50,7 @@
 	</test>
 	
 	<!-- Temporarily exclude from Linux aarch64 for: https://github.com/eclipse/openj9/issues/3065 -->
+	<!-- Temporarily exclude from AIX due to : https://github.com/eclipse/openj9/issues/3933 -->
 	<test>
 		<testCaseName>DirectByteBufferLoadTest</testCaseName>
 		<variations>
@@ -69,7 +70,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
-		<platformRequirements>^arch.arm</platformRequirements>
+		<platformRequirements>^arch.arm,^os.aix</platformRequirements>
 	</test>
 	
 	<test>


### PR DESCRIPTION
Reinclude HCRLateAttachWorkload on jdk8 
Exclude DirectByteBufferLoadTest on AIX