### PR TITLE
Double the timeoutFactor from 4 to 8

### DIFF
--- a/openjdk_regression/openjdk_regression.mk
+++ b/openjdk_regression/openjdk_regression.mk
@@ -39,7 +39,7 @@ JTREG_BASIC_OPTIONS += -retain:fail,error
 JTREG_IGNORE_OPTION = -ignore:quiet
 JTREG_BASIC_OPTIONS += $(JTREG_IGNORE_OPTION)
 # Multiple by 4 the timeout numbers
-JTREG_TIMEOUT_OPTION =  -timeoutFactor:4
+JTREG_TIMEOUT_OPTION =  -timeoutFactor:8
 JTREG_BASIC_OPTIONS += $(JTREG_TIMEOUT_OPTION)
 # Create junit xml
 JTREG_XML_OPTION = -xml:verify


### PR DESCRIPTION
Occasionally tests which would pass take longer than the 480s to complete - e.g. https://ci.adoptopenjdk.net/view/Test_grinder/job/Grinder/528/testReport/java_util_Map_InPlaceOpsCollisions vs https://ci.adoptopenjdk.net/view/Test_grinder/job/Grinder/529/testReport/java_util_Map_InPlaceOpsCollisions.