### PR TITLE
[tomcat8] Bump tomcat to 8_5_30

### DIFF
--- a/thirdparty_containers/tomcat/dockerfile/tomcat-test.sh
+++ b/thirdparty_containers/tomcat/dockerfile/tomcat-test.sh
@@ -49,7 +49,7 @@ cd /tomcat85
 ls .
 pwd
 echo "Building tomcat" && \
-git checkout TOMCAT_8_5_24 && \
+git checkout TOMCAT_8_5_30 && \
 cp build.properties.default build.properties && \
 ant && \
 


### PR DESCRIPTION
Before that, bulid.xml attempts to download auxiliary libraries using HTTP.
sourceforge.net automatically forwards those requests to https, which is prohibited
by ant. 8_5_30 updated URLs to https.

#735 has more details.   Fixes #735 