### PR TITLE
update build name for personal build only

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -382,10 +382,13 @@ def setLabelParam() {
 }
 
 def addJobDescription() {
-	// update build name
-	wrap([$class: 'BuildUser']) {
-		currentBuild.displayName = "#${BUILD_NUMBER} - ${BUILD_USER_EMAIL}"
+	if (params.PERSONAL_BUILD) {
+		// update build name if personal build
+		wrap([$class: 'BuildUser']) {
+			currentBuild.displayName = "#${BUILD_NUMBER} - ${BUILD_USER_EMAIL}"
+		}
 	}
+	
 	def description = (currentBuild.description) ? currentBuild.description + "<br>" : ""
 	currentBuild.description = description \
 		+ "TARGET: ${params.TARGET}<br/>" \


### PR DESCRIPTION
Jenkins throws MissingPropertyException if it cannot find
BUILD_USER_EMAIL. This happens when the build is started by timer.
Update build name for personal build only.

Signed-off-by: lanxia <lan_xia@ca.ibm.com>