### PR TITLE
Exclude jlm remote thread no auth test from Windows

### DIFF
--- a/systemtest/playlist.xml
+++ b/systemtest/playlist.xml
@@ -1296,6 +1296,7 @@
 
 	<!-- Excluding the following test for Hotspot & OpenJDK10-Openj9 and JDK11 for eclipse/openj9/issues/1566  -->
 	<!--Exclude TestJlmRemoteThreadNoAuth from running on openjdk8-openj9 on ppc64le Linux. Reason: AdoptOpenJDK/openjdk-systemtest/issues/145-->
+	<!--Exclude from Windows due to : https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/208 -->
 	<test>
 		<testCaseName>TestJlmRemoteThreadNoAuth</testCaseName>
 		<variations>
@@ -1321,6 +1322,7 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
+		<platformRequirements>^os.win</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>TestJlmRemoteThreadNoAuth_SE80</testCaseName>
@@ -1347,7 +1349,7 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
-		<platformRequirements>^os.linux</platformRequirements>
+		<platformRequirements>^os.linux,^os.win</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>TestJlmRemoteThreadNoAuth_SE80_Linux</testCaseName>


### PR DESCRIPTION
Exclude jlm remote thread no auth test from Windows
Signed-off-by: Mesbah_Alam@ca.ibm.com  