### PR TITLE
Exclude LambdaLoadTest_ConcurrentScavenge on x86

### DIFF
--- a/systemtest/playlist.xml
+++ b/systemtest/playlist.xml
@@ -2793,7 +2793,8 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
-		<platformRequirements>bits.64,^arch.ppc,^arch.arm,^os.win,^os.osx</platformRequirements>
+		<!-- Temporarily exclude from Linux for: https://github.com/eclipse/openj9/issues/3491 -->
+		<platformRequirements>bits.64,^arch.ppc,^arch.arm,^os.win,^os.osx,^arch.x86</platformRequirements>
 	</test>
 	
 	<test>


### PR DESCRIPTION
The test fairly consistently fails on xlinux. Windows and osx aren't
supported yet and were previously excluded anyway.
Problem is being resolved by
https://github.com/eclipse/openj9/issues/3491

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>