### PR TITLE
Temporarily exclude all modularity tests on Windows

### DIFF
--- a/systemtest/build.xml
+++ b/systemtest/build.xml
@@ -64,8 +64,9 @@
 			<arg value="clone" />
 			<arg value="--depth" />
 			<arg value="1" />
-			<arg value="--single-branch" />
-			<arg value="${git-prefix}://github.com/AdoptOpenJDK/openjdk-systemtest.git" />
+			<arg value="-b" />
+			<arg value="temporarilyExcludeModTestFromWindows"/>
+			<arg value="${git-prefix}://github.com/Mesbah-Alam/openjdk-systemtest.git" />
 		</exec>
 		<if>
 			<isset property="isZOS" />

--- a/systemtest/playlist.xml
+++ b/systemtest/playlist.xml
@@ -1752,6 +1752,7 @@
 	
 	<!-- Tests below pertain to Java 9 Modularity -->
 	<!-- All modularity tests will not be included for testing JDK11 due to https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/150 -->
+	<!-- Temporarily exclude all modularity tests on Windows due to test compile issue on Windows : https://github.com/eclipse/openj9-systemtest/issues/61 -->
 	<test>
 		<testCaseName>CpMpTest_CpMp</testCaseName>
 		<variations>
@@ -1777,6 +1778,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
+		<platformRequirements>^os.win</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>CpMpTest_MP</testCaseName>
@@ -1803,6 +1805,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
+		<platformRequirements>^os.win</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>CpMpTest2</testCaseName>
@@ -1828,6 +1831,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
+		<platformRequirements>^os.win</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>CpMpTest3</testCaseName>
@@ -1853,6 +1857,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
+		<platformRequirements>^os.win</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>CpMpModularJarTest</testCaseName>
@@ -1878,6 +1883,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
+		<platformRequirements>^os.win</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>CpMpModularJarTest2</testCaseName>
@@ -1903,6 +1909,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
+		<platformRequirements>^os.win</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>CpMpModularJarTest3</testCaseName>
@@ -1928,6 +1935,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
+		<platformRequirements>^os.win</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>JDKInternalAPIsTest</testCaseName>
@@ -1953,6 +1961,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
+		<platformRequirements>^os.win</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>AutomaticModulesTest1</testCaseName>
@@ -1979,6 +1988,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
+		<platformRequirements>^os.win</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>AutomaticModulesTest2</testCaseName>
@@ -2005,6 +2015,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
+		<platformRequirements>^os.win</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>AutomaticModulesTest_ImpliedReadabilityTest1</testCaseName>
@@ -2031,6 +2042,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
+		<platformRequirements>^os.win</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>AutomaticModulesTest_ImpliedReadabilityTest2</testCaseName>
@@ -2057,6 +2069,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
+		<platformRequirements>^os.win</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>AutomaticModulesTest_ImpliedReadabilityTest3</testCaseName>
@@ -2083,6 +2096,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
+		<platformRequirements>^os.win</platformRequirements>
 	</test>
 	
 	<!-- Temporarily excluded due to : https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/200 -->
@@ -2135,6 +2149,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
+		<platformRequirements>^os.win</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>ServiceLoadersTest</testCaseName>
@@ -2160,6 +2175,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
+		<platformRequirements>^os.win</platformRequirements>
 	</test>
 	
 	<!-- Temporarily excluding this test from AIX due to : https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/202 -->
@@ -2188,7 +2204,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
-		<platformRequirements>^os.aix</platformRequirements>
+		<platformRequirements>^os.aix,^os.win</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>PatchModuleTest_AppModPatchModule</testCaseName>
@@ -2215,6 +2231,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
+		<platformRequirements>^os.win</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>PatchModuleTest_UnexportedTypePatchModule</testCaseName>
@@ -2241,6 +2258,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
+		<platformRequirements>^os.win</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>PatchModuleTest_AdvancedPatchModule</testCaseName>
@@ -2267,6 +2285,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
+		<platformRequirements>^os.win</platformRequirements>
 	</test>
 	
 	<!-- Temporarily excluding this test from AIX due to : https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/202 -->
@@ -2295,7 +2314,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
-		<platformRequirements>^os.aix</platformRequirements>
+		<platformRequirements>^os.aix,^os.win</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>PatchModuleImageTest_AppModPatchModule</testCaseName>
@@ -2322,6 +2341,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
+		<platformRequirements>^os.win</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>PatchModuleImageTest_UnexportedTypePatchModule</testCaseName>
@@ -2348,6 +2368,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
+		<platformRequirements>^os.win</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>PatchModuleImageTest_AdvancedPatchModule</testCaseName>
@@ -2374,6 +2395,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
+		<platformRequirements>^os.win</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>UpgradeModPathTest_ExpDirModUpgrade</testCaseName>
@@ -2400,6 +2422,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
+		<platformRequirements>^os.win</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>UpgradeModPathTest_ExpDirModUpgradeCRImage</testCaseName>
@@ -2426,6 +2449,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
+		<platformRequirements>^os.win</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>UpgradeModPathTest_JarredModUpgrade</testCaseName>
@@ -2452,6 +2476,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
+		<platformRequirements>^os.win</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>UpgradeModPathTest_JarredModUpgradeCRImage</testCaseName>
@@ -2478,6 +2503,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
+		<platformRequirements>^os.win</platformRequirements>
 	</test>	
 	
 	<!-- Temporarily excluded from osx due to : https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/203 -->
@@ -2506,7 +2532,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
-		<platformRequirements>^os.osx</platformRequirements>
+		<platformRequirements>^os.osx,^os.win</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>JlinkTest_AddModLimitMod</testCaseName>
@@ -2532,7 +2558,8 @@
 		</levels>
 		<groups>
 			<group>system</group>
-		</groups>
+		</groups>	
+		<platformRequirements>^os.win</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>CpMpJlinkTest</testCaseName>
@@ -2558,6 +2585,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
+		<platformRequirements>^os.win</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>JlinkPluginOptionsTest_GeneralOptionsTest</testCaseName>
@@ -2584,6 +2612,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
+		<platformRequirements>^os.win</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>LayersTest</testCaseName>
@@ -2613,8 +2642,9 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
+		<platformRequirements>^os.win</platformRequirements>
 	</test>
-		<test>
+	<test>
 		<testCaseName>CLTest</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
@@ -2639,6 +2669,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
+		<platformRequirements>^os.win</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>CLTestImage</testCaseName>
@@ -2665,6 +2696,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
+		<platformRequirements>^os.win</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>CLLoadTest</testCaseName>
@@ -2690,6 +2722,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
+		<platformRequirements>^os.win</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>CLStressWithLayers</testCaseName>


### PR DESCRIPTION
Temporarily exclude all modularity tests on Windows
Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>