### PR TITLE
Add optional Jenkins parameter for additional Docker run arguments

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -58,7 +58,7 @@ def setupEnv() {
 	env.JVM_VERSION = params.JVM_VERSION ? params.JVM_VERSION : ""
 	env.JVM_OPTIONS = params.JVM_OPTIONS ? params.JVM_OPTIONS : ""
 	env.EXTRA_OPTIONS = params.EXTRA_OPTIONS ? params.EXTRA_OPTIONS : ""
-	env.EXTRA_DOCKER_ARGS = params.EXTRA_DOCKER_ARGS ? params.EXTRA_DOCKER_ARGS : "Foo!!!"
+	env.EXTRA_DOCKER_ARGS = params.EXTRA_DOCKER_ARGS ? params.EXTRA_DOCKER_ARGS : ""
 	env.SPEC = "${SPEC}"
 	env.TEST_FLAG = params.TEST_FLAG ? params.TEST_FLAG : ''
 

--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -58,6 +58,7 @@ def setupEnv() {
 	env.JVM_VERSION = params.JVM_VERSION ? params.JVM_VERSION : ""
 	env.JVM_OPTIONS = params.JVM_OPTIONS ? params.JVM_OPTIONS : ""
 	env.EXTRA_OPTIONS = params.EXTRA_OPTIONS ? params.EXTRA_OPTIONS : ""
+	env.EXTRA_DOCKER_ARGS = params.EXTRA_DOCKER_ARGS ? params.EXTRA_DOCKER_ARGS : "Foo!!!"
 	env.SPEC = "${SPEC}"
 	env.TEST_FLAG = params.TEST_FLAG ? params.TEST_FLAG : ''
 

--- a/thirdparty_containers/build.xml
+++ b/thirdparty_containers/build.xml
@@ -22,6 +22,8 @@
 
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/thirdparty_containers" />
+	<property name="MOUNT_JDK" value="-v ${JDK_HOME}:/java" />
+	<property name="EXTRA_DOCKER_ARGS" value="${MOUNT_JDK}" />
 
 	<target name="init" depends="docker_prune">
 		<mkdir dir="${DEST}" />

--- a/thirdparty_containers/build.xml
+++ b/thirdparty_containers/build.xml
@@ -22,8 +22,6 @@
 
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/thirdparty_containers" />
-	<property name="MOUNT_JDK" value="-v ${JDK_HOME}:/java" />
-	<property name="EXTRA_DOCKER_ARGS" value="XXX ${MOUNT_JDK}" />
 
 	<target name="init" depends="docker_prune">
 		<mkdir dir="${DEST}" />

--- a/thirdparty_containers/build.xml
+++ b/thirdparty_containers/build.xml
@@ -23,7 +23,7 @@
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/thirdparty_containers" />
 	<property name="MOUNT_JDK" value="-v ${JDK_HOME}:/java" />
-	<property name="EXTRA_DOCKER_ARGS" value="${MOUNT_JDK}" />
+	<property name="EXTRA_DOCKER_ARGS" value="XXX ${MOUNT_JDK}" />
 
 	<target name="init" depends="docker_prune">
 		<mkdir dir="${DEST}" />

--- a/thirdparty_containers/derby/playlist.xml
+++ b/thirdparty_containers/derby/playlist.xml
@@ -15,7 +15,7 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
 	<test>
 		<testCaseName>derby_test_junit_all</testCaseName>
-	<command>docker run --rm adoptopenjdk-derby-test:latest ; \
+	<command>docker run --rm $(EXTRA_DOCKER_ARGS) adoptopenjdk-derby-test:latest ; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>

--- a/thirdparty_containers/elasticsearch/playlist.xml
+++ b/thirdparty_containers/elasticsearch/playlist.xml
@@ -15,7 +15,7 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
 	<test>
 		<testCaseName>elasticsearch_test</testCaseName>
-		<command>docker run --name elasticsearch-test adoptopenjdk-elasticsearch-test:latest; \
+		<command>docker run --name elasticsearch-test--rm $(EXTRA_DOCKER_ARGS) adoptopenjdk-elasticsearch-test:latest; \
 			$(TEST_STATUS); \
 			docker cp elasticsearch-test:/elasticsearch/core/build/reports/testJunit $(REPORTDIR)/external_test_reports; \
 			docker cp elasticsearch-test:/elasticsearch/modules/transport-netty4/build/reports/testJunit $(REPORTDIR)/external_test_reports; \

--- a/thirdparty_containers/example-test/playlist.xml
+++ b/thirdparty_containers/example-test/playlist.xml
@@ -18,7 +18,7 @@
 	-->
 	<test>
 		<testCaseName>example_test</testCaseName>
-	<command>docker run --rm adoptopenjdk-example-test:latest ; \
+	<command>docker run --rm --rm $(EXTRA_DOCKER_ARGS) adoptopenjdk-example-test:latest ; \
 		$(TEST_STATUS)</command>
 		<subsets>
 			<subset>8</subset>

--- a/thirdparty_containers/jenkins/playlist.xml
+++ b/thirdparty_containers/jenkins/playlist.xml
@@ -15,7 +15,7 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
 	<test>
 		<testCaseName>jenkins_test</testCaseName>
-		<command>docker run --name jenkins-test adoptopenjdk-jenkins-test:latest; \
+		<command>docker run --name jenkins-test --rm $(EXTRA_DOCKER_ARGS) adoptopenjdk-jenkins-test:latest; \
 			 $(TEST_STATUS); \
 			 docker cp jenkins-test:/jenkins/cli/target/surefire-reports $(REPORTDIR)/external_test_reports; \
 			 docker cp jenkins-test:/jenkins/core/target/surefire-reports $(REPORTDIR)/external_test_reports; \

--- a/thirdparty_containers/kafka/playlist.xml
+++ b/thirdparty_containers/kafka/playlist.xml
@@ -15,7 +15,7 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
 	<test>
 		<testCaseName>kafka_test</testCaseName>
-	<command>docker run --rm adoptopenjdk-kafka-test:latest ; \
+	<command>docker run --rm --rm $(EXTRA_DOCKER_ARGS) adoptopenjdk-kafka-test:latest ; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>

--- a/thirdparty_containers/lucene-solr/playlist.xml
+++ b/thirdparty_containers/lucene-solr/playlist.xml
@@ -15,7 +15,7 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
 	<test>
 		<testCaseName>lucene_solr_nightly_smoketest</testCaseName>
-		<command>docker run --name lucene-solr-test adoptopenjdk-lucene-solr-test:latest; \
+		<command>docker run --name lucene-solr-test --rm $(EXTRA_DOCKER_ARGS) adoptopenjdk-lucene-solr-test:latest; \
 			 $(TEST_STATUS); \
 			 docker cp lucene-solr-test:/lucene-solr/lucene/build/core/test $(REPORTDIR)/external_test_reports; \
 			 docker rm lucene-solr-test

--- a/thirdparty_containers/openliberty-mp-tck/playlist.xml
+++ b/thirdparty_containers/openliberty-mp-tck/playlist.xml
@@ -15,7 +15,7 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
 	<test>
 		<testCaseName>openliberty_microprofile_tck</testCaseName>
-		<command>docker run --name openliberty-mp-tck adoptopenjdk-openliberty-mp-tck:latest; \
+		<command>docker run --name openliberty-mp-tck --rm $(EXTRA_DOCKER_ARGS) adoptopenjdk-openliberty-mp-tck:latest; \
 			$(TEST_STATUS); \
 			docker cp openliberty-mp-tck:/open-liberty/dev/com.ibm.ws.microprofile.metrics.1.1_fat_tck/build/libs/autoFVT/results/tck/surefire-reports $(REPORTDIR)/external_test_reports; \
 			docker cp openliberty-mp-tck:/open-liberty/dev/com.ibm.ws.microprofile.config_fat_tck/build/libs/autoFVT/results/tck/surefire-reports $(REPORTDIR)/external_test_reports; \

--- a/thirdparty_containers/payara-mp-tck/playlist.xml
+++ b/thirdparty_containers/payara-mp-tck/playlist.xml
@@ -15,7 +15,7 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
 	<test>
 		<testCaseName>payara_microprofile_tck</testCaseName>
-		<command>docker run --name payara-mp-tck adoptopenjdk-payara-mp-tck:latest; \
+		<command>docker run --name payara-mp-tck --rm $(EXTRA_DOCKER_ARGS) adoptopenjdk-payara-mp-tck:latest; \
 			 $(TEST_STATUS); \
 			 docker cp payara-mp-tck:/MicroProfile-TCK-Runners/MicroProfile-Metrics/tck-runner/target/surefire-reports $(REPORTDIR)/external_test_reports; \
 			 docker cp payara-mp-tck:/MicroProfile-TCK-Runners/MicroProfile-Fault-Tolerance/tck-runner/target/surefire-reports/junitreports $(REPORTDIR)/external_test_reports; \

--- a/thirdparty_containers/scala/playlist.xml
+++ b/thirdparty_containers/scala/playlist.xml
@@ -15,7 +15,7 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
 	<test>
 		<testCaseName>scala_test</testCaseName>
-	<command>docker run --rm adoptopenjdk-scala-test:latest; \
+	<command>docker run --rm --rm $(EXTRA_DOCKER_ARGS) adoptopenjdk-scala-test:latest; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>

--- a/thirdparty_containers/thorntail-mp-tck/playlist.xml
+++ b/thirdparty_containers/thorntail-mp-tck/playlist.xml
@@ -15,7 +15,7 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
 	<test>
 		<testCaseName>thorntail_microprofile_tck</testCaseName>
-		<command>docker run --name thorntail-mp-tck adoptopenjdk-thorntail-mp-tck:latest; \
+		<command>docker run --name thorntail-mp-tck --rm $(EXTRA_DOCKER_ARGS) adoptopenjdk-thorntail-mp-tck:latest; \
 			 $(TEST_STATUS); \
 			 docker cp thorntail-mp-tck:/thorntail/testsuite/testsuite-microprofile-metrics/target/surefire-reports $(REPORTDIR)/external_test_reports; \
 			 docker cp thorntail-mp-tck:/thorntail/testsuite/testsuite-microprofile-fault-tolerance/target/surefire-reports $(REPORTDIR)/external_test_reports; \

--- a/thirdparty_containers/tomcat/playlist.xml
+++ b/thirdparty_containers/tomcat/playlist.xml
@@ -15,7 +15,7 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
 	<test>
 		<testCaseName>tomcat_test</testCaseName>
-	<command>docker run --rm adoptopenjdk-tomcat-test:latest ; \
+	<command>docker run --rm --rm $(EXTRA_DOCKER_ARGS) adoptopenjdk-tomcat-test:latest ; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>

--- a/thirdparty_containers/wildfly/playlist.xml
+++ b/thirdparty_containers/wildfly/playlist.xml
@@ -15,7 +15,7 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
 	<test>
 		<testCaseName>wildfly_test</testCaseName>
-	<command>docker run --rm adoptopenjdk-wildfly-test:latest; \
+	<command>docker run --rm --rm $(EXTRA_DOCKER_ARGS) adoptopenjdk-wildfly-test:latest; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>


### PR DESCRIPTION
I originally wanted a way to mount a local JDK to the thirdparty_container docker VMs at runtime (specifically "-v ${JDK_HOME}:/java"), but found this to be more powerful and generic.

If your Jenkins build supplies a parameter EXTRA_DOCKER_ARGS, then the contents of that will be inserted into the Docker "run" commands (for thirdparty_containers) while running tests.  
No validation is performed.