### PR TITLE
Reintroduce the Files.writeString tests

### DIFF
--- a/openjdk_regression/ProblemList_openjdk11-openj9.txt
+++ b/openjdk_regression/ProblemList_openjdk11-openj9.txt
@@ -197,8 +197,6 @@ java/nio/channels/ServerSocketChannel/SocketOptionTests.java	https://github.com/
 java/nio/channels/SocketChannel/ExceptionTranslation.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 java/nio/channels/SocketChannel/SocketOptionTests.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 java/nio/channels/spi/SelectorProvider/inheritedChannel/InheritedChannelTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
-java/nio/file/Files/CallWithInterruptSet.java	https://github.com/eclipse/openj9/issues/3325	generic-all
-java/nio/file/Files/ReadWriteString.java	https://github.com/eclipse/openj9/issues/3325	generic-all
 java/nio/file/attribute/BasicFileAttributeView/UnixSocketFile.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/602	linux-all
 java/nio/channels/AsyncCloseAndInterrupt.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/602	linux-all
 


### PR DESCRIPTION
Files.writeString had a bug in the last release. Writing a utf-16
string to a file, while specifying a utf-8 charset for the write,
resulted in every other character being blank.

Since this issue is resolved in the latest Java nightlies, as well as a
local build, we've concluded that the issue has been resolved in one of
the change sets between the release and now.

Adding the tests back in.

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>