### PR TITLE
Stop calling testEnvTeardown target before building.

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -221,16 +221,14 @@ def buildTest() {
 				echo 'Cannot run copyArtifacts from systemtest.getDependency. Skipping copyArtifacts...'
 			}
 
-			echo 'Running tests...'
 			// use sshagent with Jenkins credentials ID for all platforms except zOS
 			if (!env.SPEC.startsWith('zos')) {
 				sshagent (credentials: ["$params.SSH_AGENT_CREDENTIAL"], ignoreMissing: true) {
-					makeTest("./openjdk-tests");
+					sh "./openjdk-tests/maketest.sh ./openjdk-tests";
 				}
 			} else {
-				makeTest("./openjdk-tests");
-			}	
-			
+				sh "./openjdk-tests/maketest.sh ./openjdk-tests";
+			}
 		}
 	}
 }


### PR DESCRIPTION
Only calling it before running tests
Remove bogus comment

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>