### PR TITLE
De-excluding test as failure unrecreatable

### DIFF
--- a/openjdk_regression/ProblemList_openjdk11-openj9.txt
+++ b/openjdk_regression/ProblemList_openjdk11-openj9.txt
@@ -188,7 +188,6 @@ java/io/FileOutputStream/UnreferencedFOSClosesFd.java https://github.com/eclipse
 java/nio/Buffer/LimitDirectMemory.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 java/nio/Buffer/LimitDirectMemoryNegativeTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 java/nio/channels/DatagramChannel/ConnectExceptions.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
-java/nio/channels/DatagramChannel/Promiscuous.java https://github.com/eclipse/openj9/issues/4128 macosx-all
 java/nio/channels/DatagramChannel/SendExceptions.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 java/nio/channels/DatagramChannel/SocketOptionTests.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 java/nio/channels/FileChannel/TempDirectBuffersReclamation.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all


### PR DESCRIPTION
Need to establish under what conditions the test fails, so de-excluding it again for now to assist with that.