### PR TITLE
WIP: Re-enable the MethodHandles/TestCatchException test

### DIFF
--- a/openjdk_regression/ProblemList_openjdk11-openj9.txt
+++ b/openjdk_regression/ProblemList_openjdk11-openj9.txt
@@ -87,7 +87,6 @@ java/lang/invoke/LFCaching/LFMultiThreadCachingTest.java	https://github.com/Adop
 java/lang/invoke/LFCaching/LFSingleThreadCachingTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 java/lang/invoke/LambdaFormTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 java/lang/invoke/LoopCombinatorTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
-java/lang/invoke/MethodHandles/TestCatchException.java	https://github.com/eclipse/openj9/issues/3274	generic-all
 java/lang/invoke/MethodHandlesGeneralTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 java/lang/invoke/MethodHandlesInsertArgumentsTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 java/lang/invoke/PrivateInterfaceCall.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all


### PR DESCRIPTION
The underlying issue in OpenJ9 has been fixed so this test can be re-enabled.

issue: eclipse/openj9#4223

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>