### PR TITLE
Shorten JlinkPluginOption test name to work on Windows

### DIFF
--- a/systemtest/modularity/playlist.xml
+++ b/systemtest/modularity/playlist.xml
@@ -811,7 +811,7 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>JlinkPluginOptionsTest_GeneralOptionsTest</testCaseName>
+		<testCaseName>JlinkPluginOpt_GenOptTest</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>


### PR DESCRIPTION
Shorten JlinkPluginOption test name to work on Windows
Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>