### PR TITLE
Re-include LambdaLoadTest_ConcurrentScavenge on xLinux

### DIFF
--- a/systemtest/lambdaLoadTest/playlist.xml
+++ b/systemtest/lambdaLoadTest/playlist.xml
@@ -143,7 +143,6 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
-		<!-- Temporarily exclude from Linux for: https://github.com/eclipse/openj9/issues/3491 -->
-		<platformRequirements>bits.64,^arch.ppc,^arch.arm,^os.osx,^arch.x86</platformRequirements>
+		<platformRequirements>bits.64,^arch.ppc,^arch.arm,^os.osx</platformRequirements>
 	</test>
 </playlist>


### PR DESCRIPTION
Verify fix for https://github.com/eclipse/openj9/issues/3491 and re-include test
Signed-off-by: smlambert <slambert@gmail.com>