### PR TITLE
Problem list SecretKeysBasic.sh for non-solaris platforms

### DIFF
--- a/openjdk_regression/ProblemList_openjdk8-openj9.txt
+++ b/openjdk_regression/ProblemList_openjdk8-openj9.txt
@@ -208,6 +208,7 @@ javax/crypto/CryptoPermission/CryptoPolicyFallback.java	125	generic-all
 javax/crypto/CryptoPermission/TestUnlimited.java	125	generic-all
 sun/security/rsa/TestCACerts.java	125	generic-all
 sun/security/ssl/SSLSocketImpl/SSLSocketCloseHang.java	125	generic-all
+sun/security/pkcs11/KeyStore/SecretKeysBasic.sh	JDK-8189603	linux-all macosx-all windows-all
 
 ############################################################################
 

--- a/openjdk_regression/ProblemList_openjdk8.txt
+++ b/openjdk_regression/ProblemList_openjdk8.txt
@@ -161,6 +161,7 @@ sun/security/pkcs11/ec/TestECDSA.java	70	linux-all
 sun/security/pkcs11/ec/TestECGenSpec.java	70	linux-all
 sun/security/pkcs11/rsa/TestCACerts.java	68	linux-all
 sun/security/rsa/TestCACerts.java	68	generic-all
+sun/security/pkcs11/KeyStore/SecretKeysBasic.sh	JDK-8189603	linux-all macosx-all windows-all
 
 ############################################################################
 


### PR DESCRIPTION
The test lists in its notes:
"test only runs on solaris at the moment"

It's failing on Linux. Thus, problem list it for all
platforms except Solaris.

Signed-off-by: Severin Gehwolf <sgehwolf@redhat.com>