### PR TITLE
Use mv instead of cpio

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -234,9 +234,7 @@ getTestKitGenAndFunctionalTestMaterial()
 	mv openj9/test/TestConfig TestConfig
 	mv openj9/test/Utils Utils
     if [ -d functional ]; then
-        cd openj9/test/functional
-        find . -print | cpio -pdm ../../../functional
-        cd ../../..
+        mv openj9/test/functional/* functional/
     else
 	    mv openj9/test/functional functional
     fi


### PR DESCRIPTION
cpio does not preserve file encoding. This causes problem on zos. Change
to use mv cmd.

Signed-off-by: lanxia <lan_xia@ca.ibm.com>