### PR TITLE
use pax cmd for archive test output on zos

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -269,9 +269,14 @@ def runTest(subDir) {
 	}
 }
 
-def post(test_target) {
+def post(output_name) {
 	stage('Post') {
 		timestamps{
+			output_name = output_name.replace("/","_");
+			def tar_cmd = "tar -zcf"
+			def suffix = ".tar.gz"
+			def tar_opt = "-T -"
+			def pax_opt = ""
 			if (SPEC.startsWith('zos')) {
 				echo 'Converting tap file from ebcdic to ascii...'
 				sh 'cd ./openjdk-tests/TestConfig'
@@ -279,27 +284,35 @@ def post(test_target) {
 				for (String tapFile : tapFiles) {
 					sh "iconv -f ibm-1047 -t iso8859-1 ${tapFile} > ${tapFile}.ascii; rm ${tapFile}; mv ${tapFile}.ascii ${tapFile}"
 				}
+			
+				tar_cmd = "pax -wf"
+				suffix = ".pax.Z"
+				pax_opt = "-x pax"
+				tar_opt = ""
 			}
 			step([$class: "TapPublisher", testResults: "**/*.tap", outputTapToConsole: false])
 			junit allowEmptyResults: true, keepLongStdio: true, testResults: '**/work/**/*.jtr.xml, **/junitreports/**/*.xml, **/external_test_reports/**/*.xml'
 			if (currentBuild.result == 'UNSTABLE' || params.ARCHIVE_TEST_RESULTS) {
-				sh "tar -zcf ${test_target}_test_output.tar.gz ./openjdk-tests/TestConfig/test_output_*"
-				sh "find ./jvmtest/${env.BUILD_LIST}/work -name '*.jtr' | tar -zcf jtr_test_output.tar.gz -T -"
+				def test_output_tar_name = "${output_name}_test_output${suffix}"
+				def jtr_output_tar_name = "jtr_test_output${suffix}"
+				sh "${tar_cmd} ${test_output_tar_name} ${pax_opt} ./openjdk-tests/TestConfig/test_output_*"
+				sh "find ./jvmtest/${env.BUILD_LIST}/work -name '*.jtr' | ${tar_cmd} ${jtr_output_tar_name} ${tar_opt} ${pax_opt}"
 
 				if (!params.ARTIFACTORY_SERVER) {
 					echo "ARTIFACTORY_SERVER is not set. Saving artifacts on jenkins."
-					archiveArtifacts artifacts: "${test_target}_test_output.tar.gz", fingerprint: true, allowEmptyArchive: true
-					archiveArtifacts artifacts: "jtr_test_output.tar.gz", fingerprint: true, allowEmptyArchive: true
+					archiveArtifacts artifacts: test_output_tar_name, fingerprint: true, allowEmptyArchive: true
+					archiveArtifacts artifacts: jtr_output_tar_name, fingerprint: true, allowEmptyArchive: true
 				}
 			}
 			//for performance test, achive regardless the build result
 			//TODO: Need to soft-code the output dir path
 			def benchmark_test_output_dir = 'jvmtest/performance/odm/ilog_wodm881/leftoverResults';
 			if (fileExists(benchmark_test_output_dir)) {
-				sh "tar -zcf benchmark_test_output.tar.gz ${benchmark_test_output_dir}"
+				def benchmark_output_tar_name = "benchmark_test_output${suffix}"
+				sh "${tar_cmd} ${benchmark_output_tar_name} ${pax_opt} ${benchmark_test_output_dir}"
 				if (!params.ARTIFACTORY_SERVER) {
 					echo "ARTIFACTORY_SERVER is not set. Saving artifacts on jenkins."
-					archiveArtifacts artifacts: 'benchmark_test_output.tar.gz', fingerprint: true, allowEmptyArchive: true
+					archiveArtifacts artifacts: benchmark_output_tar_name, fingerprint: true, allowEmptyArchive: true
 				}
 			}
 
@@ -422,7 +435,7 @@ def uploadToArtifactory() {
 		def uploadSpec = """{
 			"files":[
 					{
-						"pattern": "${env.WORKSPACE}/*_test_output.tar.gz",
+						"pattern": "${env.WORKSPACE}/*_test_output.*",
 						"target": "${artifactoryUploadDir}"
 					}
 				]


### PR DESCRIPTION
- tar has path length limitation on zos
- pax is the more standard archiving tool on zos

Issue: #719

Signed-off-by: lanxia <lan_xia@ca.ibm.com>