### PR TITLE
Exclude intermittent rmi cannot destroy failure tests

### DIFF
--- a/openjdk_regression/ProblemList_openjdk8.txt
+++ b/openjdk_regression/ProblemList_openjdk8.txt
@@ -163,6 +163,8 @@ java/rmi/Naming/legalRegistryNames/LegalRegistryNames.java 61	linux-all
 java/rmi/activation/rmidViaInheritedChannel/InheritedChannelNotServerSocket.java 154 macosx-all
 java/rmi/server/RemoteServer/AddrInUse.java	821	windows-all
 sun/rmi/runtime/Log/6409194/NoConsoleOutput.java	821	windows-all
+java/rmi/activation/Activatable/extLoadedImpl/ext.sh	819 macosx-all
+
 ############################################################################
 
 # jdk_security


### PR DESCRIPTION
Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>