### PR TITLE
Re-enable ExportSubtree on mac

### DIFF
--- a/openjdk_regression/ProblemList_openjdk11-openj9.txt
+++ b/openjdk_regression/ProblemList_openjdk11-openj9.txt
@@ -269,7 +269,6 @@ java/util/concurrent/forkjoin/FJExceptionTableLeak.java	https://github.com/eclip
 java/util/concurrent/locks/Lock/TimedAcquireLeak.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 java/util/concurrent/tck/JSR166TestCase.java	https://github.com/eclipse/openj9/issues/3213	generic-all
 java/util/logging/TestLoggerWeakRefLeak.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
-java/util/prefs/ExportSubtree.java https://github.com/eclipse/openj9/issues/4130 macosx-all
 java/util/prefs/PrefsSpi.sh	https://github.com/eclipse/openj9/issues/3232	generic-all
 java/util/stream/boottest/java.base/java/util/stream/NodeTest.java https://github.com/eclipse/openj9/issues/4129 macosx-all
 java/util/stream/test/org/openjdk/tests/java/util/stream/ToArrayOpTest.java	https://github.com/eclipse/openj9/issues/3447	generic-all


### PR DESCRIPTION
Issue: https://github.com/eclipse/openj9/issues/4130

Signed-off-by: lanxia <lan_xia@ca.ibm.com>