### PR TITLE
Exclude failing external test targets

### DIFF
--- a/thirdparty_containers/kafka/playlist.xml
+++ b/thirdparty_containers/kafka/playlist.xml
@@ -23,5 +23,6 @@
 		<groups>
 			<group>external</group>
 		</groups>
+		<disabled>https://github.com/AdoptOpenJDK/openjdk-tests/issues/855</disabled>
 	</test>
 </playlist>

--- a/thirdparty_containers/payara-mp-tck/playlist.xml
+++ b/thirdparty_containers/payara-mp-tck/playlist.xml
@@ -23,6 +23,9 @@
 			 docker cp payara-mp-tck:/MicroProfile-TCK-Runners/MicroProfile-OpenAPI/tck-runner/target/surefire-reports/junitreports $(REPORTDIR)/external_test_reports; \
 			 docker rm payara-mp-tck
 		</command>
+		<subsets>
+			<subset>8</subset>
+		</subsets>
 		<levels>
 			<level>extended</level>
 		</levels>

--- a/thirdparty_containers/thorntail-mp-tck/playlist.xml
+++ b/thirdparty_containers/thorntail-mp-tck/playlist.xml
@@ -24,6 +24,9 @@
 			 docker cp thorntail-mp-tck:/thorntail/testsuite//testsuite-microprofile-jwt/target/surefire-reports $(REPORTDIR)/external_test_reports; \
 			 docker rm thorntail-mp-tck
 		</command>
+		<subsets>
+			<subset>8</subset>
+		</subsets>
 		<levels>
 			<level>extended</level>
 		</levels>

--- a/thirdparty_containers/wildfly/playlist.xml
+++ b/thirdparty_containers/wildfly/playlist.xml
@@ -23,5 +23,6 @@
 		<groups>
 			<group>external</group>
 		</groups>
+		<disabled>https://github.com/AdoptOpenJDK/openjdk-tests/issues/855</disabled>
 	</test>
 </playlist>


### PR DESCRIPTION
Both payara & thorntail microprofile tcks fail to compile with jdk11 at present, exclude until they are able to be built for jdk11
Exclude wildfly & kafka on jdk8/jdk11 

Fixes #839 
Signed-off-by: smlambert <slambert@gmail.com>