### PR TITLE
Support systemtest parallelization

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -10,20 +10,6 @@ def getBuildList() {
 	return TESTPROJECT
 }
 
-def archiveTestBinaries() {
-	dir("$WORKSPACE") {
-		sh "tar -zcf test-binaries.tar.gz ./openjdk-tests ./jvmtest ./openjdkbinary"
-	}
-	archiveArtifacts artifacts: '**/test-binaries.tar.gz', fingerprint: true, allowEmptyArchive: false
-}
-
-def stageTestBinaries() {
-	copyArtifacts filter: 'test-binaries.tar.gz', fingerprintArtifacts: true, projectName: "${env.JOB_NAME}", selector: specific("${env.BUILD_ID}")
-	sh "tar -xzf test-binaries.tar.gz"
-	echo pwd()
-	sh "ls"
-}
-
 def makeTest(testParam) {
 	String tearDownCmd = "if [ `uname` = AIX ]; then MAKE=gmake; else MAKE=make; fi; \$MAKE -f ./openjdk-tests/TestConfig/testEnv.mk testEnvTeardown"
 	try {
@@ -61,6 +47,7 @@ def setupEnv() {
 	env.EXTRA_DOCKER_ARGS = params.EXTRA_DOCKER_ARGS ? params.EXTRA_DOCKER_ARGS : ""
 	env.SPEC = "${SPEC}"
 	env.TEST_FLAG = params.TEST_FLAG ? params.TEST_FLAG : ''
+	SDK_RESOURCE = params.SDK_RESOURCE ? params.SDK_RESOURCE : "upstream"
 
 	if (params.JDK_IMPL) {
 		env.JDK_IMPL = params.JDK_IMPL
@@ -79,7 +66,7 @@ def setupEnv() {
 		env.PERF_ROOT = "$WORKSPACE/../../benchmarks"
 	}
 
-	if (env.BUILD_LIST == "jck") {
+	if (env.BUILD_LIST.startsWith("jck")) {
 		if ( JAVA_VERSION == "SE80" ) {
 			env.JCK_VERSION = "jck8b"
 		} else {
@@ -109,8 +96,54 @@ def setupEnv() {
 def setupParallelEnv() {
 	stage('setupParallelEnv') {
 		timestamps{
-			cleanWs()
 			setupEnv()
+			def testSubDirs = []
+			def testSubDirSize = 0
+			dir("$WORKSPACE/openjdk-tests/${env.BUILD_LIST}") {
+				testSubDirs = sh(returnStdout: true, script: "ls -d */").trim().tokenize()
+				testSubDirSize = testSubDirs.size()
+			}
+			echo "testSubDirSize is ${testSubDirSize}, testSubDirs is ${testSubDirs}, running test in parallel mode"
+			def parallel_tests = [:]
+			
+			for (int i = 0; i < testSubDirSize; i++) {
+				def testSubDir = testSubDirs[i].trim().replace("/","");
+				def TEST_JOB_NAME = "${JOB_NAME}"
+
+				//ToDo: need to find a better way to pass parameters to downstream builds. 
+				//Ideally, we should only need to pass in modified parameters (i.e., 
+				//BUILD_LIST, IS_PARALLEL)
+				parallel_tests[testSubDir] = {
+					build job: TEST_JOB_NAME, parameters: [
+						string(name: 'ADOPTOPENJDK_REPO', value: ADOPTOPENJDK_REPO),
+						string(name: 'ADOPTOPENJDK_BRANCH', value: ADOPTOPENJDK_BRANCH),
+						string(name: 'OPENJ9_REPO', value: OPENJ9_REPO),
+						string(name: 'OPENJ9_BRANCH', value: OPENJ9_BRANCH),
+						string(name: 'JAVA_VERSION', value: JAVA_VERSION),
+						string(name: 'JDK_IMPL', value: JDK_IMPL),
+						string(name: 'BUILD_LIST', value: "${env.BUILD_LIST}/${testSubDir}"),
+						string(name: 'TARGET', value: TARGET),
+						string(name: 'CUSTOM_TARGET', value: CUSTOM_TARGET),
+						string(name: 'SDK_RESOURCE', value: SDK_RESOURCE),
+						string(name: 'CUSTOMIZED_SDK_URL', value: CUSTOMIZED_SDK_URL),
+						string(name: 'CUSTOMIZED_SDK_URL_CREDENTIAL_ID', value: CUSTOMIZED_SDK_URL_CREDENTIAL_ID),
+						string(name: 'UPSTREAM_JOB_NAME', value: UPSTREAM_JOB_NAME),
+						string(name: 'UPSTREAM_JOB_NUMBER', value: UPSTREAM_JOB_NUMBER),
+						string(name: 'TEST_FLAG', value: TEST_FLAG),
+						string(name: 'EXTRA_OPTIONS', value: EXTRA_OPTIONS),
+						string(name: 'JVM_OPTIONS', value: JVM_OPTIONS),
+						string(name: 'ITERATIONS', value: ITERATIONS),
+						string(name: 'LABEL', value: LABEL),
+						string(name: 'JCK_GIT_REPO', value: JCK_GIT_REPO),
+						string(name: 'SSH_AGENT_CREDENTIAL', value: SSH_AGENT_CREDENTIAL),
+						booleanParam(name: 'KEEP_WORKSPACE', value: KEEP_WORKSPACE),
+						string(name: 'ARTIFACTORY_SERVER', value: ARTIFACTORY_SERVER),
+						booleanParam(name: 'PERSONAL_BUILD', value: PERSONAL_BUILD),
+						booleanParam(name: 'IS_PARALLEL', value: false),
+					]
+				}
+			}
+			parallel parallel_tests
 		}
 	}
 }
@@ -130,8 +163,6 @@ def setup() {
 					deleteDir()
 				}
 			}
-			
-			SDK_RESOURCE = params.SDK_RESOURCE ? params.SDK_RESOURCE : "upstream"
 
 			if (params.CUSTOMIZED_SDK_URL) {
 				SDK_RESOURCE = "customized"
@@ -212,8 +243,8 @@ def buildTest() {
 				echo 'Cannot run copyArtifacts from test.getDependency. Skipping copyArtifacts...'
 			}
 			
-			try { 
-				if (env.BUILD_LIST == 'systemtest') { 	
+			try {
+				if (env.BUILD_LIST.startsWith('systemtest') || env.BUILD_LIST.startsWith('jck')) {
 					//get pre-staged test jars from systemtest.getDependency build before system test compilation
 					copyArtifacts fingerprintArtifacts: true, projectName: "systemtest.getDependency", selector: lastSuccessful(), target: 'openjdk-tests'
 				}
@@ -247,7 +278,7 @@ def runTest(subDir) {
 			}
 			RUNTEST_CMD = "./openjdk-tests/${subDir} _${params.TARGET} ${CUSTOM_OPTION}"
 			for (i = 0; i < iterations; i++) {
-				if (env.BUILD_LIST == 'openjdk_regression' || env.BUILD_LIST == 'jck') {
+				if (env.BUILD_LIST == 'openjdk_regression' || env.BUILD_LIST.startsWith('jck')) {
 					if (env.SPEC.startsWith('linux_x86-64')) { 
 						wrap([$class: 'Xvfb', autoDisplayName: true]) {
 							def DISPLAY = sh (
@@ -331,37 +362,20 @@ def testBuild() {
 			addJobDescription()
 
 			// prepare environment and compile test projects
-			setup()
-			buildTest()
-			if( params.IS_PARALLEL ){
-				// archive compiled test binaries for parallel jobs
-				archiveTestBinaries()
-				def testSubDirs = []
-				def testSubDirSize = 0
-				dir("$WORKSPACE/openjdk-tests/${env.BUILD_LIST}") {
-					testSubDirs = sh(returnStdout: true, script: "ls -d */").trim().split()
-					testSubDirSize = testSubDirs.size()
-				}
-				echo "testSubDirSize is ${testSubDirSize}, testSubDirs is ${testSubDirs}, running test in parallel mode"
-				def parallel_tests = [:]
-				for (int i = 0; i < testSubDirSize; i++) {
-					def testSubDir = testSubDirs[i].trim().replace("/","");
-					parallel_tests[testSubDir] = {
-						node ("$LABEL") {
-							addJobDescription()
-							setupParallelEnv()
-							stageTestBinaries()
-							if( env.BUILD_LIST == "jck") {
-								buildTest()
-							}
-							runTest("${env.BUILD_LIST}/${testSubDir}")
-							post("${env.BUILD_LIST}-${testSubDir}")
-						}
-					}
-				}
-				parallel parallel_tests
+			if( params.IS_PARALLEL == true ){
+				setupParallelEnv()
 			} else {
-				echo "running test in default mode"
+				setup()
+				//ToDo: temporary workaround for jck test parallel runs
+				// until build.xml is added into each subfolder
+				if( env.BUILD_LIST.startsWith('jck/')) {
+					def temp = env.BUILD_LIST
+					env.BUILD_LIST = "jck"
+					buildTest()
+					env.BUILD_LIST = temp
+				} else {
+					buildTest()
+				}
 				runTest("${env.BUILD_LIST}")
 				post("${env.BUILD_LIST}")
 			}

--- a/systemtest/common.xml
+++ b/systemtest/common.xml
@@ -1,0 +1,240 @@
+<?xml version="1.0"?>
+<project name="systemtest_common" default="build" basedir=".">
+	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+	<description>Build STF based System Tests </description>
+
+	<!-- set global properties for this build -->
+	<property name="SYSTEMTEST_ROOT" value="${TEST_ROOT}/systemtest" />
+	<property name="SYSTEMTEST_DEST" value="${BUILD_ROOT}/systemtest" />
+	<property environment="env" />
+	<property name="env.JAVA_HOME" value="${JAVA_BIN}/.." />
+	
+	<condition property="isZOS" value="true">
+		<equals arg1="${os.name}" arg2="z/OS"/>
+	</condition>
+	
+	<condition property="git-prefix" value="git" else="https">
+		<isset property="isZOS"/>
+	</condition>
+	
+	<target name="common_init">
+		<if>
+			<not>
+				<available file="${SYSTEMTEST_DEST}" type="dir" />
+			</not>
+			<then>
+				<mkdir dir="${SYSTEMTEST_DEST}" />
+			</then>
+		</if>
+	</target>
+
+	<target name="clone_stf">
+		<exec executable="git" failonerror="false" dir="${SYSTEMTEST_ROOT}">
+			<arg value="clone" />
+			<arg value="--depth" />
+			<arg value="1" />
+			<arg value="--single-branch" />
+			<arg value="${git-prefix}://github.com/AdoptOpenJDK/stf.git" />
+		</exec>
+		<if>
+			<isset property="isZOS" />
+			<then>
+				<delete includeemptydirs="true" failonerror="false">
+				   <fileset dir="${SYSTEMTEST_ROOT}/stf/.git/info" includes="**/*"/>
+				</delete>  
+				<mkdir dir="${SYSTEMTEST_ROOT}/stf/.git/info" />
+				<move file="${SYSTEMTEST_ROOT}/stf/.gitattributes.zos" tofile="${SYSTEMTEST_ROOT}/stf/.git/info/attributes" /> 
+				<exec executable="git" dir="${SYSTEMTEST_ROOT}/stf" failonerror="false">
+					<arg value="rm" />
+					<arg value="--cached" />
+					<arg value="-r" />
+					<arg value="-q" />
+					<arg value="." />
+				</exec>
+				<exec executable="git" dir="${SYSTEMTEST_ROOT}/stf" failonerror="false">
+					<arg value="reset" />
+					<arg value="--hard" />
+				</exec>
+			</then>
+		</if>
+	</target>
+
+	<target name="clone_systemtest">
+		<exec executable="git" failonerror="false" dir="${SYSTEMTEST_ROOT}">
+			<arg value="clone" />
+			<arg value="--depth" />
+			<arg value="1" />
+			<arg value="--single-branch" />
+			<arg value="${git-prefix}://github.com/AdoptOpenJDK/openjdk-systemtest.git" />
+		</exec>
+		<if>
+			<isset property="isZOS" />
+			<then>
+				<delete includeemptydirs="true" failonerror="false">
+				   <fileset dir="${SYSTEMTEST_ROOT}/openjdk-systemtest/.git/info" includes="**/*"/>
+				</delete>  
+				<mkdir dir="${SYSTEMTEST_ROOT}/openjdk-systemtest/.git/info" />
+				<move file="${SYSTEMTEST_ROOT}/openjdk-systemtest/.gitattributes.zos" tofile="${SYSTEMTEST_ROOT}/openjdk-systemtest/.git/info/attributes" /> 
+				<exec executable="git" dir="${SYSTEMTEST_ROOT}/openjdk-systemtest" failonerror="false">
+					<arg value="rm" />
+					<arg value="--cached" />
+					<arg value="-r" />
+					<arg value="-q" />
+					<arg value="." />
+				</exec>
+				<exec executable="git" dir="${SYSTEMTEST_ROOT}/openjdk-systemtest" failonerror="false">
+					<arg value="reset" />
+					<arg value="--hard" />
+				</exec>
+			</then>
+		</if>
+	</target>
+	
+	<target name="clone_openj9-systemtest">
+		<exec executable="git" failonerror="false" dir="${SYSTEMTEST_ROOT}">
+			<arg value="clone" />
+			<arg value="--depth" />
+			<arg value="1" />
+			<arg value="--single-branch" />
+			<arg value="${git-prefix}://github.com/eclipse/openj9-systemtest.git" />
+		</exec>
+		<if>
+			<isset property="isZOS" />
+			<then>
+				<delete includeemptydirs="true" failonerror="false">
+				   <fileset dir="${SYSTEMTEST_ROOT}/openj9-systemtest/.git/info" includes="**/*"/>
+				</delete>  
+				<mkdir dir="${SYSTEMTEST_ROOT}/openj9-systemtest/.git/info" />
+				<move file="${SYSTEMTEST_ROOT}/openj9-systemtest/.gitattributes.zos" tofile="${SYSTEMTEST_ROOT}/openj9-systemtest/.git/info/attributes" /> 
+				<exec executable="git" dir="${SYSTEMTEST_ROOT}/openj9-systemtest" failonerror="false">
+					<arg value="rm" />
+					<arg value="--cached" />
+					<arg value="-r" />
+					<arg value="-q" />
+					<arg value="." />
+				</exec>
+				<exec executable="git" dir="${SYSTEMTEST_ROOT}/openj9-systemtest" failonerror="false">
+					<arg value="reset" />
+					<arg value="--hard" />
+				</exec>
+			</then>
+		</if>
+	</target>
+
+	<target name="check_systemtest" depends="common_init">
+		<if>
+			<not>
+				<available file="${SYSTEMTEST_ROOT}/stf" type="dir" />
+			</not>
+			<then>
+				<echo message="${SYSTEMTEST_ROOT}/stf does not exist, clone from GitHub" />
+				<antcall target="clone_stf" inheritall="true" />
+			</then>
+			<else>
+				<echo message="${SYSTEMTEST_ROOT}/stf exists, skip cloning" />
+			</else>
+		</if>
+		<if>
+			<not>
+				<available file="${SYSTEMTEST_ROOT}/openjdk-systemtest" type="dir" />
+			</not>
+			<then>
+				<echo message="${SYSTEMTEST_ROOT}/openjdk-systemtest does not exist, clone from GitHub" />
+				<antcall target="clone_systemtest" inheritall="true" />
+			</then>
+			<else>
+				<echo message="${SYSTEMTEST_ROOT}/openjdk-systemtest exists, skip cloning" />
+			</else>
+		</if>
+		<if>
+			<contains string="${JVM_VERSION}" substring="openj9"/>
+			<then>
+				<if>
+					<not>
+						<available file="${SYSTEMTEST_ROOT}/openj9-systemtest" type="dir" />
+					</not>
+					<then>
+						<echo message="${SYSTEMTEST_ROOT}/openj9-systemtest does not exist, clone from GitHub" />
+						<antcall target="clone_openj9-systemtest" inheritall="true" />
+					</then>
+					<else>
+						<echo message="${SYSTEMTEST_ROOT}/openj9-systemtest exists, skip cloning" />
+					</else>
+				</if>
+			</then>
+		</if>
+	</target>
+	
+	<target name="configure_systemtest" depends="check_systemtest">
+		<if>
+			<contains string="${JVM_VERSION}" substring="openj9"/>
+			<then>
+				<ant antfile="${SYSTEMTEST_ROOT}/openj9-systemtest/openj9.build/build.xml" dir="${SYSTEMTEST_ROOT}/openj9-systemtest/openj9.build/" target="configure" inheritAll="false">
+					<property name="java.home" value="${env.JAVA_HOME}"/>
+				</ant>
+			</then>
+			<else>
+				<ant antfile="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build/build.xml" dir="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build/" target="configure" inheritAll="false">
+					<property name="java.home" value="${env.JAVA_HOME}"/>
+				</ant>
+			</else>
+		</if>
+	</target>
+					
+	<target name="common_dist" description="generate the distribution">
+		<copy todir="${SYSTEMTEST_DEST}/stf">
+			<fileset dir="${SYSTEMTEST_ROOT}/stf" includes="**" />
+		</copy>
+		<copy todir="${SYSTEMTEST_DEST}/openjdk-systemtest" failonerror="false">
+			<fileset dir="${SYSTEMTEST_ROOT}/openjdk-systemtest" includes="**" />
+		</copy>
+		<copy todir="${SYSTEMTEST_DEST}/openj9-systemtest" failonerror="false">
+			<fileset dir="${SYSTEMTEST_ROOT}/openj9-systemtest" includes="**" />
+		</copy>
+		<copy todir="${SYSTEMTEST_DEST}/systemtest_prereqs/">
+			<fileset dir="${TEST_ROOT}/systemtest_prereqs/" includes="**" />
+		</copy>
+	</target>
+
+	<!-- target to build all projects in the repository.  -->
+	<!-- dir must be set on the ant task otherwise the basedir property is not set to a new value in the subant task. -->
+	<!-- Also make sure stf is built -->
+	<target name="build-dependencies" depends="configure_systemtest">
+		<if>
+			<contains string="${JVM_VERSION}" substring="openj9"/>
+			<then>
+				<ant antfile="${SYSTEMTEST_ROOT}/openj9-systemtest/openj9.build/build.xml" dir="${SYSTEMTEST_ROOT}/openj9-systemtest/openj9.build" inheritAll="false">
+					<property name="java.home" value="${env.JAVA_HOME}"/>
+				</ant>
+			</then>
+			<else>
+				<ant antfile="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build/build.xml" dir="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build" inheritAll="false">
+					<property name="java.home" value="${env.JAVA_HOME}"/>
+				</ant>
+			</else>
+		</if>
+		<antcall target="common_dist" inheritall="false" />
+	</target>
+	
+	<!-- To make sure common_build target only excute once, the common_build target runs only if common_build.executed value is not set -->
+	<target name="common_build" depends="build-dependencies" unless="common_build.executed">
+		<echo message="target common_build is called....." />
+	</target>
+		
+	<target name="clean">
+		<ant antfile="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build/build.xml" dir="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build" inheritAll="false" target="clean">
+			<property name="java.home" value="${env.JAVA_HOME}"/>
+		</ant>
+		<if>
+			<contains string="${JVM_VERSION}" substring="openj9"/>
+			<then>
+				<ant antfile="${SYSTEMTEST_ROOT}/openj9-systemtest/openj9.build/build.xml" dir="${SYSTEMTEST_ROOT}/openj9-systemtest/openj9.build" inheritAll="false" target="clean">
+					<property name="java.home" value="${env.JAVA_HOME}"/>
+				</ant>
+			</then>
+		</if>		
+		<ant antfile="${SYSTEMTEST_ROOT}/stf/stf.build/build.xml" dir="${SYSTEMTEST_ROOT}/stf/stf.build" inheritAll="false" target="clean">
+			<property name="java.home" value="${env.JAVA_HOME}"/>
+		</ant>
+	</target>
+</project>

--- a/systemtest/daaLoadTest/build.xml
+++ b/systemtest/daaLoadTest/build.xml
@@ -14,28 +14,21 @@
 # limitations under the License.
 -->
 
-<project name="systemtest" default="build" basedir=".">
+<project name="daaLoadTest" default="build" basedir=".">
 	<taskdef resource="net/sf/antcontrib/antlib.xml" />
-	<description>Build systemtest</description>
+	<description>daaLoadTest</description>
 
-	<import file="./common.xml"/>
-	<!-- set properties for this build -->
-	<property name="SYSTEMTEST_DEST" value="${BUILD_ROOT}/systemtest" />
+	<import file="../common.xml"/>
+
+	<property name="DEST" value="${BUILD_ROOT}/systemtest/daaLoadTest" />
 
 	<target name="init">
-		<mkdir dir="${SYSTEMTEST_DEST}" />
+		<mkdir dir="${DEST}" />
 	</target>
 
-	<target name="build" depends="dist,common_build">
-		<property name="common_build.executed" value="true" />
-		<subant target="" inheritall="true">
-			<fileset dir="." includes="*/build.xml" />
-		</subant>
-	</target>
-	
-	<target name="dist" depends="init">
-		<copy todir="${SYSTEMTEST_DEST}">
-			<fileset dir="." includes="*.mk"/>
+	<target name="build" depends="init, common_build">
+		<copy todir="${DEST}">
+			<fileset dir="." includes="*.mk,*.xml"/>
 		</copy>
 	</target>
 </project>

--- a/systemtest/jlm/build.xml
+++ b/systemtest/jlm/build.xml
@@ -14,28 +14,21 @@
 # limitations under the License.
 -->
 
-<project name="systemtest" default="build" basedir=".">
+<project name="jlm" default="build" basedir=".">
 	<taskdef resource="net/sf/antcontrib/antlib.xml" />
-	<description>Build systemtest</description>
+	<description>jlm</description>
 
-	<import file="./common.xml"/>
-	<!-- set properties for this build -->
-	<property name="SYSTEMTEST_DEST" value="${BUILD_ROOT}/systemtest" />
+	<import file="../common.xml" />
+
+	<property name="DEST" value="${BUILD_ROOT}/systemtest/jlm" />
 
 	<target name="init">
-		<mkdir dir="${SYSTEMTEST_DEST}" />
+		<mkdir dir="${DEST}" />
 	</target>
 
-	<target name="build" depends="dist,common_build">
-		<property name="common_build.executed" value="true" />
-		<subant target="" inheritall="true">
-			<fileset dir="." includes="*/build.xml" />
-		</subant>
-	</target>
-	
-	<target name="dist" depends="init">
-		<copy todir="${SYSTEMTEST_DEST}">
-			<fileset dir="." includes="*.mk"/>
+	<target name="build" depends="init,common_build">
+		<copy todir="${DEST}">
+			<fileset dir="." includes="*.mk,*.xml" />
 		</copy>
 	</target>
 </project>

--- a/systemtest/lambdaLoadTest/build.xml
+++ b/systemtest/lambdaLoadTest/build.xml
@@ -14,28 +14,21 @@
 # limitations under the License.
 -->
 
-<project name="systemtest" default="build" basedir=".">
+<project name="lambdaLoadTest" default="build" basedir=".">
 	<taskdef resource="net/sf/antcontrib/antlib.xml" />
-	<description>Build systemtest</description>
+	<description>lambdaLoadTest</description>
 
-	<import file="./common.xml"/>
-	<!-- set properties for this build -->
-	<property name="SYSTEMTEST_DEST" value="${BUILD_ROOT}/systemtest" />
+	<import file="../common.xml" />
+
+	<property name="DEST" value="${BUILD_ROOT}/systemtest/lambdaLoadTest" />
 
 	<target name="init">
-		<mkdir dir="${SYSTEMTEST_DEST}" />
+		<mkdir dir="${DEST}" />
 	</target>
 
-	<target name="build" depends="dist,common_build">
-		<property name="common_build.executed" value="true" />
-		<subant target="" inheritall="true">
-			<fileset dir="." includes="*/build.xml" />
-		</subant>
-	</target>
-	
-	<target name="dist" depends="init">
-		<copy todir="${SYSTEMTEST_DEST}">
-			<fileset dir="." includes="*.mk"/>
+	<target name="build" depends="init, common_build">
+		<copy todir="${DEST}">
+			<fileset dir="." includes="*.mk,*.xml" />
 		</copy>
 	</target>
 </project>

--- a/systemtest/mathLoadTest/build.xml
+++ b/systemtest/mathLoadTest/build.xml
@@ -14,28 +14,21 @@
 # limitations under the License.
 -->
 
-<project name="systemtest" default="build" basedir=".">
+<project name="mathLoadTest" default="build" basedir=".">
 	<taskdef resource="net/sf/antcontrib/antlib.xml" />
-	<description>Build systemtest</description>
+	<description>mathLoadTest</description>
 
-	<import file="./common.xml"/>
-	<!-- set properties for this build -->
-	<property name="SYSTEMTEST_DEST" value="${BUILD_ROOT}/systemtest" />
+	<import file="../common.xml" />
+
+	<property name="DEST" value="${BUILD_ROOT}/systemtest/mathLoadTest" />
 
 	<target name="init">
-		<mkdir dir="${SYSTEMTEST_DEST}" />
+		<mkdir dir="${DEST}" />
 	</target>
 
-	<target name="build" depends="dist,common_build">
-		<property name="common_build.executed" value="true" />
-		<subant target="" inheritall="true">
-			<fileset dir="." includes="*/build.xml" />
-		</subant>
-	</target>
-	
-	<target name="dist" depends="init">
-		<copy todir="${SYSTEMTEST_DEST}">
-			<fileset dir="." includes="*.mk"/>
+	<target name="build" depends="init, common_build">
+		<copy todir="${DEST}">
+			<fileset dir="." includes="*.mk,*.xml" />
 		</copy>
 	</target>
 </project>

--- a/systemtest/mauveLoadTest/build.xml
+++ b/systemtest/mauveLoadTest/build.xml
@@ -14,28 +14,21 @@
 # limitations under the License.
 -->
 
-<project name="systemtest" default="build" basedir=".">
+<project name="mauveLoadTest" default="build" basedir=".">
 	<taskdef resource="net/sf/antcontrib/antlib.xml" />
-	<description>Build systemtest</description>
+	<description>mauveLoadTest</description>
 
-	<import file="./common.xml"/>
-	<!-- set properties for this build -->
-	<property name="SYSTEMTEST_DEST" value="${BUILD_ROOT}/systemtest" />
+	<import file="../common.xml" />
+
+	<property name="DEST" value="${BUILD_ROOT}/systemtest/mauveLoadTest" />
 
 	<target name="init">
-		<mkdir dir="${SYSTEMTEST_DEST}" />
+		<mkdir dir="${DEST}" />
 	</target>
 
-	<target name="build" depends="dist,common_build">
-		<property name="common_build.executed" value="true" />
-		<subant target="" inheritall="true">
-			<fileset dir="." includes="*/build.xml" />
-		</subant>
-	</target>
-	
-	<target name="dist" depends="init">
-		<copy todir="${SYSTEMTEST_DEST}">
-			<fileset dir="." includes="*.mk"/>
+	<target name="build" depends="init, common_build">
+		<copy todir="${DEST}">
+			<fileset dir="." includes="*.mk,*.xml" />
 		</copy>
 	</target>
 </project>

--- a/systemtest/modularity/build.xml
+++ b/systemtest/modularity/build.xml
@@ -14,28 +14,21 @@
 # limitations under the License.
 -->
 
-<project name="systemtest" default="build" basedir=".">
+<project name="modularity" default="build" basedir=".">
 	<taskdef resource="net/sf/antcontrib/antlib.xml" />
-	<description>Build systemtest</description>
+	<description>modularity</description>
 
-	<import file="./common.xml"/>
-	<!-- set properties for this build -->
-	<property name="SYSTEMTEST_DEST" value="${BUILD_ROOT}/systemtest" />
+	<import file="../common.xml" />
+
+	<property name="DEST" value="${BUILD_ROOT}/systemtest/modularity" />
 
 	<target name="init">
-		<mkdir dir="${SYSTEMTEST_DEST}" />
+		<mkdir dir="${DEST}" />
 	</target>
 
-	<target name="build" depends="dist,common_build">
-		<property name="common_build.executed" value="true" />
-		<subant target="" inheritall="true">
-			<fileset dir="." includes="*/build.xml" />
-		</subant>
-	</target>
-	
-	<target name="dist" depends="init">
-		<copy todir="${SYSTEMTEST_DEST}">
-			<fileset dir="." includes="*.mk"/>
+	<target name="build" depends="init, common_build">
+		<copy todir="${DEST}">
+			<fileset dir="." includes="*.mk,*.xml" />
 		</copy>
 	</target>
 </project>

--- a/systemtest/otherLoadTest/build.xml
+++ b/systemtest/otherLoadTest/build.xml
@@ -14,28 +14,21 @@
 # limitations under the License.
 -->
 
-<project name="systemtest" default="build" basedir=".">
+<project name="otherLoadTest" default="build" basedir=".">
 	<taskdef resource="net/sf/antcontrib/antlib.xml" />
-	<description>Build systemtest</description>
+	<description>otherLoadTest</description>
 
-	<import file="./common.xml"/>
-	<!-- set properties for this build -->
-	<property name="SYSTEMTEST_DEST" value="${BUILD_ROOT}/systemtest" />
+	<import file="../common.xml" />
+
+	<property name="DEST" value="${BUILD_ROOT}/systemtest/otherLoadTest" />
 
 	<target name="init">
-		<mkdir dir="${SYSTEMTEST_DEST}" />
+		<mkdir dir="${DEST}" />
 	</target>
 
-	<target name="build" depends="dist,common_build">
-		<property name="common_build.executed" value="true" />
-		<subant target="" inheritall="true">
-			<fileset dir="." includes="*/build.xml" />
-		</subant>
-	</target>
-	
-	<target name="dist" depends="init">
-		<copy todir="${SYSTEMTEST_DEST}">
-			<fileset dir="." includes="*.mk"/>
+	<target name="build" depends="init, common_build">
+		<copy todir="${DEST}">
+			<fileset dir="." includes="*.mk,*.xml" />
 		</copy>
 	</target>
 </project>

--- a/systemtest/sharedClasses/build.xml
+++ b/systemtest/sharedClasses/build.xml
@@ -14,28 +14,21 @@
 # limitations under the License.
 -->
 
-<project name="systemtest" default="build" basedir=".">
+<project name="sharedClasses" default="build" basedir=".">
 	<taskdef resource="net/sf/antcontrib/antlib.xml" />
-	<description>Build systemtest</description>
+	<description>sharedClasses</description>
 
-	<import file="./common.xml"/>
-	<!-- set properties for this build -->
-	<property name="SYSTEMTEST_DEST" value="${BUILD_ROOT}/systemtest" />
+	<import file="../common.xml" />
+
+	<property name="DEST" value="${BUILD_ROOT}/systemtest/sharedClasses" />
 
 	<target name="init">
-		<mkdir dir="${SYSTEMTEST_DEST}" />
+		<mkdir dir="${DEST}" />
 	</target>
 
-	<target name="build" depends="dist,common_build">
-		<property name="common_build.executed" value="true" />
-		<subant target="" inheritall="true">
-			<fileset dir="." includes="*/build.xml" />
-		</subant>
-	</target>
-	
-	<target name="dist" depends="init">
-		<copy todir="${SYSTEMTEST_DEST}">
-			<fileset dir="." includes="*.mk"/>
+	<target name="build" depends="init, common_build">
+		<copy todir="${DEST}">
+			<fileset dir="." includes="*.mk,*.xml" />
 		</copy>
 	</target>
 </project>


### PR DESCRIPTION
- common.xml is created to have common targets (git clone stf, system
test material, etc)
- it is included in systemtest/build.xml and each systemtest subdirs
build.xml
- flag common_build.executed is created to make sure common.xml will
only be invoked once. That is, if systemtest/build.xml invokes
common.xml, subdirs build.xml should not invoke it (non-parallel runs).
Otherwise, each subdirs build.xml should invoke it (parallel runs).
- once IS_PARALLEL is selected in Grinder, child job will be triggered
per `BUILD_LIST/<subdir>`. The child job will inherit all parameters from
its parent job with modified BUILD_LIST (set to original
`BUILD_LIST/<subdir>`) and IS_PARALLEL (set to false). That is, each child
job is an independent job. It does its own git clone, compilation, test
execution and test output archive.

Issue: #747

Signed-off-by: lanxia <lan_xia@ca.ibm.com>