### PR TITLE
Exclude failing jdk/nio/zipfs/ZipFSTester.java test

### DIFF
--- a/openjdk_regression/ProblemList_openjdk11-openj9.txt
+++ b/openjdk_regression/ProblemList_openjdk11-openj9.txt
@@ -226,7 +226,6 @@ java/nio/file/attribute/BasicFileAttributeView/UnixSocketFile.java https://githu
 java/nio/file/Files/CopyAndMove.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/795 macosx-all
 java/nio/channels/AsyncCloseAndInterrupt.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/602	linux-all
 jdk/nio/zipfs/ZipFSTester.java https://github.com/eclipse/openj9/issues/4679 linux-x86-64,macosx-all
-jdk/nio/zipfs/ZipFSTester.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/602 macosx-all
 ############################################################################
 
 # jdk_rmi

--- a/openjdk_regression/ProblemList_openjdk11-openj9.txt
+++ b/openjdk_regression/ProblemList_openjdk11-openj9.txt
@@ -225,6 +225,7 @@ java/nio/channels/spi/SelectorProvider/inheritedChannel/InheritedChannelTest.jav
 java/nio/file/attribute/BasicFileAttributeView/UnixSocketFile.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/602	linux-all
 java/nio/file/Files/CopyAndMove.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/795 macosx-all
 java/nio/channels/AsyncCloseAndInterrupt.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/602	linux-all
+jdk/nio/zipfs/ZipFSTester.java https://github.com/eclipse/openj9/issues/4679 linux-x86-64,macosx-all
 jdk/nio/zipfs/ZipFSTester.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/602 macosx-all
 ############################################################################
 


### PR DESCRIPTION
@sophia-guo I'm adding in an extra entry here for test jdk/nio/zipfs/ZipFSTester.java to reference the OpenJ9 issue that I've raised.