### PR TITLE
Update MBCS_Tests playlist.xml to jdkVersion+

### DIFF
--- a/functional/MBCS_Tests/Compiler/playlist.xml
+++ b/functional/MBCS_Tests/Compiler/playlist.xml
@@ -24,12 +24,6 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_Compiler_ko_KR_linux</testCaseName>
@@ -42,12 +36,6 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_Compiler_Ja_JP_aix</testCaseName>
@@ -61,7 +49,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -77,7 +65,7 @@ limitations under the License.
 		</groups>
 		<subsets>
 			<subset>8</subset>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 		<disabled>bugs.openjdk.java.net/browse/JDK-8212794</disabled>
 	</test>
@@ -92,12 +80,6 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_Compiler_ko_KR_aix</testCaseName>
@@ -112,7 +94,7 @@ limitations under the License.
 		</groups>
 		<subsets>
 			<subset>8</subset>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -126,11 +108,5 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 </playlist>

--- a/functional/MBCS_Tests/IDN/playlist.xml
+++ b/functional/MBCS_Tests/IDN/playlist.xml
@@ -24,12 +24,6 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_IDN_ko_KR_linux</testCaseName>
@@ -42,12 +36,6 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_IDN_Ja_JP_aix</testCaseName>
@@ -61,7 +49,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -77,7 +65,7 @@ limitations under the License.
 		</groups>
 		<subsets>
 			<subset>8</subset>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 		<disabled>bugs.openjdk.java.net/browse/JDK-8212794</disabled>
 	</test>
@@ -92,12 +80,6 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_IDN_ko_KR_aix</testCaseName>
@@ -112,7 +94,7 @@ limitations under the License.
 		</groups>
 		<subsets>
 			<subset>8</subset>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 		<disabled>bugs.openjdk.java.net/browse/JDK-8213618</disabled>
 	</test>
@@ -127,11 +109,5 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 </playlist>

--- a/functional/MBCS_Tests/StAX/playlist.xml
+++ b/functional/MBCS_Tests/StAX/playlist.xml
@@ -26,9 +26,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
+			<subset>9+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -44,9 +42,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
+			<subset>9+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -62,7 +58,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 		<disabled>bugs.openjdk.java.net/browse/JDK-8212794</disabled>
 	</test>
@@ -79,7 +75,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -95,9 +91,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
+			<subset>9+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -113,7 +107,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -129,9 +123,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
+			<subset>9+</subset>
 		</subsets>
 	</test>
 </playlist>

--- a/functional/MBCS_Tests/charsets/playlist.xml
+++ b/functional/MBCS_Tests/charsets/playlist.xml
@@ -29,11 +29,5 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 </playlist>

--- a/functional/MBCS_Tests/codepage/playlist.xml
+++ b/functional/MBCS_Tests/codepage/playlist.xml
@@ -24,12 +24,6 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_codepage_ko_KR_linux</testCaseName>
@@ -42,12 +36,6 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_codepage_Ja_JP_aix</testCaseName>
@@ -61,7 +49,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -77,7 +65,7 @@ limitations under the License.
 		</groups>
 		<subsets>
 			<subset>8</subset>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 		<disabled>bugs.openjdk.java.net/browse/JDK-8212794</disabled>
 	</test>
@@ -92,12 +80,6 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_codepage_ko_KR_aix</testCaseName>
@@ -112,7 +94,7 @@ limitations under the License.
 		</groups>
 		<subsets>
 			<subset>8</subset>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -126,11 +108,5 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 </playlist>

--- a/functional/MBCS_Tests/coin/playlist.xml
+++ b/functional/MBCS_Tests/coin/playlist.xml
@@ -26,12 +26,6 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_coin_ko_KR_linux</testCaseName>
@@ -45,12 +39,6 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_coin_ja_JP_aix</testCaseName>
@@ -66,7 +54,7 @@ limitations under the License.
 		</groups>
 		<subsets>
 			<subset>8</subset>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 		<disabled>bugs.openjdk.java.net/browse/JDK-8212794</disabled>
 	</test>
@@ -83,7 +71,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -98,12 +86,6 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_coin_ko_KR_aix</testCaseName>
@@ -119,7 +101,7 @@ limitations under the License.
 		</groups>
 		<subsets>
 			<subset>8</subset>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -134,11 +116,5 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 </playlist>

--- a/functional/MBCS_Tests/datetime/playlist.xml
+++ b/functional/MBCS_Tests/datetime/playlist.xml
@@ -32,9 +32,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
+			<subset>9+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -55,7 +53,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 </playlist>

--- a/functional/MBCS_Tests/env/playlist.xml
+++ b/functional/MBCS_Tests/env/playlist.xml
@@ -24,12 +24,6 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_env_ko_KR_linux</testCaseName>
@@ -42,12 +36,6 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_env_Ja_JP_aix</testCaseName>
@@ -61,7 +49,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -77,7 +65,7 @@ limitations under the License.
 		</groups>
 		<subsets>
 			<subset>8</subset>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 		<disabled>bugs.openjdk.java.net/browse/JDK-8212794</disabled>
 	</test>
@@ -92,12 +80,6 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_env_ko_KR_aix</testCaseName>
@@ -112,7 +94,7 @@ limitations under the License.
 		</groups>
 		<subsets>
 			<subset>8</subset>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -126,11 +108,5 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 </playlist>

--- a/functional/MBCS_Tests/file/playlist.xml
+++ b/functional/MBCS_Tests/file/playlist.xml
@@ -25,12 +25,6 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_file_ko_KR_linux</testCaseName>
@@ -43,12 +37,6 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_file_ja_JP.aix</testCaseName>
@@ -63,7 +51,7 @@ limitations under the License.
 		</groups>
 		<subsets>
 			<subset>8</subset>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 		<disabled>bugs.openjdk.java.net/browse/JDK-8212794</disabled>
 	</test>
@@ -79,7 +67,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -93,12 +81,6 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_file_ko_KR.aix</testCaseName>
@@ -113,7 +95,7 @@ limitations under the License.
 		</groups>
 		<subsets>
 			<subset>8</subset>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -127,11 +109,5 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 </playlist>

--- a/functional/MBCS_Tests/formatter_11/playlist.xml
+++ b/functional/MBCS_Tests/formatter_11/playlist.xml
@@ -25,7 +25,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -40,7 +40,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -55,7 +55,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -70,7 +70,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 		<disabled>bugs.openjdk.java.net/browse/JDK-8212794</disabled>
 	</test>
@@ -86,7 +86,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -101,7 +101,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -116,7 +116,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 </playlist>

--- a/functional/MBCS_Tests/i18n/playlist.xml
+++ b/functional/MBCS_Tests/i18n/playlist.xml
@@ -26,9 +26,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
+			<subset>9+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -43,9 +41,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
+			<subset>9+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -60,7 +56,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 		<disabled>bugs.openjdk.java.net/browse/JDK-8212794</disabled>
 	</test>
@@ -76,7 +72,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -91,9 +87,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
+			<subset>9+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -108,7 +102,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -123,9 +117,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
+			<subset>9+</subset>
 		</subsets>
 	</test>
 </playlist>

--- a/functional/MBCS_Tests/jaxp14_11/playlist.xml
+++ b/functional/MBCS_Tests/jaxp14_11/playlist.xml
@@ -25,7 +25,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -40,7 +40,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -55,7 +55,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -70,7 +70,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 		<disabled>bugs.openjdk.java.net/browse/JDK-8212794</disabled>
 	</test>
@@ -86,7 +86,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -101,7 +101,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -116,7 +116,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 </playlist>

--- a/functional/MBCS_Tests/jdbc41/playlist.xml
+++ b/functional/MBCS_Tests/jdbc41/playlist.xml
@@ -27,7 +27,7 @@ limitations under the License.
 		</groups>
 		<subsets>
 			<subset>8</subset>
-<!-- This testcase works 80, 120, and later due to a regressn -->
+<!-- This testcase works 80, 120, and later due to a regression -->
 		</subsets>
 	</test>
 	<test>
@@ -43,7 +43,7 @@ limitations under the License.
 		</groups>
 		<subsets>
 			<subset>8</subset>
-<!-- This testcase works 80, 120, and later due to a regressn -->
+<!-- This testcase works 80, 120, and later due to a regression -->
 		</subsets>
 	</test>
 	<test>
@@ -59,7 +59,7 @@ limitations under the License.
 		</groups>
 		<subsets>
 			<subset>8</subset>
-<!-- This testcase works 80, 120, and later due to a regressn -->
+<!-- This testcase works 80, 120, and later due to a regression -->
 		</subsets>
 		<disabled>bugs.openjdk.java.net/browse/JDK-8212794</disabled>
 	</test>
@@ -92,7 +92,7 @@ limitations under the License.
 		</groups>
 		<subsets>
 			<subset>8</subset>
-<!-- This testcase works 80, 120, and later due to a regressn -->
+<!-- This testcase works 80, 120, and later due to a regression -->
 		</subsets>
 	</test>
 	<test>
@@ -108,7 +108,7 @@ limitations under the License.
 		</groups>
 		<subsets>
 			<subset>8</subset>
-<!-- This testcase works 80, 120, and later due to a regressn -->
+<!-- This testcase works 80, 120, and later due to a regression -->
 		</subsets>
 	</test>
 	<test>
@@ -124,7 +124,7 @@ limitations under the License.
 		</groups>
 		<subsets>
 			<subset>8</subset>
-<!-- This testcase works 80, 120, and later due to a regressn -->
+<!-- This testcase works 80, 120, and later due to a regression -->
 		</subsets>
 	</test>
 
@@ -141,9 +141,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
+			<subset>9+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -158,9 +156,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
+			<subset>9+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -175,7 +171,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 		<disabled>bugs.openjdk.java.net/browse/JDK-8212794</disabled>
 	</test>
@@ -191,7 +187,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -206,9 +202,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
+			<subset>9+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -223,7 +217,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -238,9 +232,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
+			<subset>9+</subset>
 		</subsets>
 	</test>
 </playlist>

--- a/functional/MBCS_Tests/locale_matching/playlist.xml
+++ b/functional/MBCS_Tests/locale_matching/playlist.xml
@@ -27,7 +27,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -42,7 +42,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -57,7 +57,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -72,7 +72,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 <!-- AIX -->
@@ -88,7 +88,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 		<disabled>bugs.openjdk.java.net/browse/JDK-8212794</disabled>
 	</test>
@@ -104,7 +104,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -119,7 +119,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -134,7 +134,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -149,7 +149,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -164,7 +164,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -179,7 +179,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -194,7 +194,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -209,7 +209,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 		<disabled>bugs.openjdk.java.net/browse/JDK-8212794</disabled>
 	</test>
@@ -225,7 +225,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -240,7 +240,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 </playlist>

--- a/functional/MBCS_Tests/nio/playlist.xml
+++ b/functional/MBCS_Tests/nio/playlist.xml
@@ -24,12 +24,6 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_nio_ko_KR_linux</testCaseName>
@@ -42,12 +36,6 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_nio_Ja_JP_aix</testCaseName>
@@ -61,7 +49,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -77,7 +65,7 @@ limitations under the License.
 		</groups>
 		<subsets>
 			<subset>8</subset>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 		<disabled>bugs.openjdk.java.net/browse/JDK-8212794</disabled>
 	</test>
@@ -92,12 +80,6 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_nio_ko_KR_aix</testCaseName>
@@ -112,7 +94,7 @@ limitations under the License.
 		</groups>
 		<subsets>
 			<subset>8</subset>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 		<disabled>bugs.openjdk.java.net/browse/JDK-8213618</disabled>
 	</test>
@@ -127,11 +109,5 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 </playlist>

--- a/functional/MBCS_Tests/pref/playlist.xml
+++ b/functional/MBCS_Tests/pref/playlist.xml
@@ -24,12 +24,6 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_pref_ko_KR_linux</testCaseName>
@@ -42,12 +36,6 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_pref_Ja_JP_aix</testCaseName>
@@ -61,7 +49,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -77,7 +65,7 @@ limitations under the License.
 		</groups>
 		<subsets>
 			<subset>8</subset>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 		<disabled>bugs.openjdk.java.net/browse/JDK-8212794</disabled>
 	</test>
@@ -92,12 +80,6 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_pref_ko_KR_aix</testCaseName>
@@ -112,7 +94,7 @@ limitations under the License.
 		</groups>
 		<subsets>
 			<subset>8</subset>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -126,11 +108,5 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 </playlist>

--- a/functional/MBCS_Tests/regex/playlist.xml
+++ b/functional/MBCS_Tests/regex/playlist.xml
@@ -24,12 +24,6 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_regex_ko_KR_linux</testCaseName>
@@ -42,12 +36,6 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_regex_Ja_JP_aix</testCaseName>
@@ -61,7 +49,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -77,7 +65,7 @@ limitations under the License.
 		</groups>
 		<subsets>
 			<subset>8</subset>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 		<disabled>bugs.openjdk.java.net/browse/JDK-8212794</disabled>
 	</test>
@@ -92,12 +80,6 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_regex_ko_KR_aix</testCaseName>
@@ -112,7 +94,7 @@ limitations under the License.
 		</groups>
 		<subsets>
 			<subset>8</subset>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -126,11 +108,5 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 </playlist>

--- a/functional/MBCS_Tests/scanner/playlist.xml
+++ b/functional/MBCS_Tests/scanner/playlist.xml
@@ -25,12 +25,6 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_scanner_ko_KR_linux</testCaseName>
@@ -43,12 +37,6 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_scanner_ja_JP_aix</testCaseName>
@@ -63,7 +51,7 @@ limitations under the License.
 		</groups>
 		<subsets>
 			<subset>8</subset>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 		<disabled>bugs.openjdk.java.net/browse/JDK-8212794</disabled>
 	</test>
@@ -79,7 +67,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -93,12 +81,6 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_scanner_ko_KR_aix</testCaseName>
@@ -113,7 +95,7 @@ limitations under the License.
 		</groups>
 		<subsets>
 			<subset>8</subset>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -127,11 +109,5 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 </playlist>

--- a/functional/MBCS_Tests/urlclassloader/playlist.xml
+++ b/functional/MBCS_Tests/urlclassloader/playlist.xml
@@ -25,12 +25,6 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_urlclassloader_ko_KR_linux</testCaseName>
@@ -43,12 +37,6 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_urlclassloader_ja_JP_aix</testCaseName>
@@ -63,7 +51,7 @@ limitations under the License.
 		</groups>
 		<subsets>
 			<subset>8</subset>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 		<disabled>bugs.openjdk.java.net/browse/JDK-8212794</disabled>
 	</test>
@@ -79,7 +67,7 @@ limitations under the License.
 			<group>functional</group>
 		</groups>
 		<subsets>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -93,12 +81,6 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_urlclassloader_ko_KR_aix</testCaseName>
@@ -113,7 +95,7 @@ limitations under the License.
 		</groups>
 		<subsets>
 			<subset>8</subset>
-			<subset>11</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>
@@ -127,11 +109,5 @@ limitations under the License.
 		<groups>
 			<group>functional</group>
 		</groups>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-			<subset>10</subset>
-			<subset>11</subset>
-		</subsets>
 	</test>
 </playlist>


### PR DESCRIPTION
Update MBCS_Tests playlist.xml to jdkVersion+

The following playlists remained as "11" intentionally, because they are version dependent.

- functional/MBCS_Tests/CLDR
- functional/MBCS_Tests/codepoint-10 (Codepoint tests for Unicode version 10)
- functional/MBCS_Tests/unicode-10 (Unicode version 10)
- functional/MBCS_Tests/annotation

Fixes #871