### PR TITLE
Add ARTIFACTORY_VERSION variable

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -1,4 +1,7 @@
 #!groovy
+
+import groovy.json.JsonSlurper;
+
 def getBuildList() {
 	def TESTPROJECTS = [system:'systemtest', perf:'performance', jck:'jck', external:'thirdparty_containers', functional: 'functional', openjdk:'openjdk_regression', jdk:'openjdk_regression', runtest:'', sanity:'', extended:'']
 	String fullTarget="${TARGET}"
@@ -14,7 +17,7 @@ def makeTest(testParam) {
 	String tearDownCmd = "if [ `uname` = AIX ]; then MAKE=gmake; else MAKE=make; fi; \$MAKE -f ./openjdk-tests/TestConfig/testEnv.mk testEnvTeardown"
 	try {
 		sh "$tearDownCmd"
-		sh "./openjdk-tests/maketest.sh $testParam" 
+		sh "./openjdk-tests/maketest.sh $testParam"
 	} finally {
 		sh "$tearDownCmd"
 	}
@@ -29,7 +32,7 @@ def setupEnv() {
 		if (params.ADOPTOPENJDK_REPO.startsWith('git') && params.USER_CREDENTIALS_ID && !SPEC.startsWith('zos')) {
 			remoteConfigParameters.put('credentialsId', "${params.USER_CREDENTIALS_ID}")
 		}
-		
+
 		checkout([
 			$class: 'GitSCM', branches: [[name: "*/${params.ADOPTOPENJDK_BRANCH}"]],
 			extensions: [[$class:'CloneOption', shallow:true, depth:1],[$class: 'CleanBeforeCheckout'],[$class: 'RelativeTargetDirectory', relativeTargetDir: 'openjdk-tests']],
@@ -451,6 +454,8 @@ def uploadToArtifactory() {
 		def artifactoryRepo = params.ARTIFACTORY_REPO ? params.ARTIFACTORY_REPO : "sys-rt-generic-local"
 		def jenkinsDomain = params.JENKINS_DOMAIN ? params.JENKINS_DOMAIN : getJenkinsDomain()
 		def artifactoryUploadDir = "${artifactoryRepo}/${jenkinsDomain}/${JOB_NAME}/${BUILD_ID}/"
+		def artifactoryUrl = server.getUrl()
+		def artifactoryCreds = server.getCredentialsId()
 
 		def uploadSpec = """{
 			"files":[
@@ -461,20 +466,28 @@ def uploadToArtifactory() {
 				]
 			}"""
 
-		if (params.ARTIFACTORY_VERSION == 'ent') {
+		withCredentials([usernamePassword(credentialsId: artifactoryCreds, passwordVariable: 'PASS', usernameVariable: 'USER')]) {
+            json = sh returnStdout: true, script: "curl -u ${USER}:${PASS} ${artifactoryUrl}/api/system/version"
+        }
+        def jsonslurper = new groovy.json.JsonSlurper()
+        def json_parsed = jsonslurper.parseText(json)
+        def artifactoryLicense = json_parsed.license
+
+		if (artifactoryLicense ==~ /^[0-9a-f]+$/) {
+			// Artifactory PRO licesne is a long HEX string
 			def buildInfo = Artifactory.newBuildInfo()
 			// if ARTIFACTORY_NUM_ARTIFACTS is not set, set to keep 20 build artifacts
 			def numArtifacts = params.ARTIFACTORY_NUM_ARTIFACTS ? params.ARTIFACTORY_NUM_ARTIFACTS : 20
 			buildInfo.retention maxBuilds: numArtifacts, deleteBuildArtifacts: true
 			server.upload spec: uploadSpec, buildInfo: buildInfo
 			server.publishBuildInfo buildInfo
-		} else if (params.ARTIFACTORY_VERSION == 'oss') {
+		} else if (artifactoryLicense == 'Artifactory OSS') {
+			// Artifactory OSS doesn't support buildInfo
 			server.upload spec: uploadSpec
 		} else {
-			error "Unknown ARTIFACTORY_VERSION:${ARTIFACTORY_VERSION}"
+			error "Unknown Artifactory License:'${artifactoryLicense}'"
 		}
 
-		def artifactoryUrl = server.getUrl()
 		def uploadUrl = "${artifactoryUrl}/${artifactoryUploadDir}"
 		echo "Test output artifactory URL:'${uploadUrl}'"
 	} else {

--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -66,7 +66,7 @@ def setupEnv() {
 	} else {
 		env.BUILD_LIST = "${getBuildList()}"
 	}
-	
+
 	if( params.PERF_ROOT ) {
 		env.PERF_ROOT = params.PERF_ROOT
 	} else {
@@ -88,11 +88,11 @@ def setupEnv() {
 			echo "params.JCK_GIT_REPO was not defined"
 		}
 	}
-	
+
 	if (env.BUILD_LIST == 'openjdk_regression' ||  env.BUILD_LIST == 'thirdparty_containers') {
 		env.DIAGNOSTICLEVEL ='noDetails'
 	}
-	
+
 	// Optional parameter RELEASE_TAG and it is only used in openjdk regression test
 	if( params.RELEASE_TAG ) {
 		env.RELEASE_TAG = params.RELEASE_TAG
@@ -112,13 +112,13 @@ def setupParallelEnv() {
 			}
 			echo "testSubDirSize is ${testSubDirSize}, testSubDirs is ${testSubDirs}, running test in parallel mode"
 			def parallel_tests = [:]
-			
+
 			for (int i = 0; i < testSubDirSize; i++) {
 				def testSubDir = testSubDirs[i].trim().replace("/","");
 				def TEST_JOB_NAME = "${JOB_NAME}"
 
-				//ToDo: need to find a better way to pass parameters to downstream builds. 
-				//Ideally, we should only need to pass in modified parameters (i.e., 
+				//ToDo: need to find a better way to pass parameters to downstream builds.
+				//Ideally, we should only need to pass in modified parameters (i.e.,
 				//BUILD_LIST, IS_PARALLEL)
 				parallel_tests[testSubDir] = {
 					build job: TEST_JOB_NAME, parameters: [
@@ -179,7 +179,7 @@ def setup() {
 			} else {
 				CUSTOMIZED_SDK_URL_OPTION = ""
 			}
-			
+
 			if (SDK_RESOURCE == 'upstream' && !params.CUSTOMIZED_SDK_URL) {
 				dir('openjdkbinary') {
 					step([$class: 'CopyArtifact',
@@ -236,7 +236,7 @@ def buildTest() {
 	stage('Build') {
 		timestamps{
 			echo 'Building tests...'
-					
+
 			if ( params.PERF_CREDENTIALS_ID ) {
 				withCredentials([usernamePassword(credentialsId: "$params.PERF_CREDENTIALS_ID",
 					passwordVariable: "PASSWORD_VAR", usernameVariable: "USERNAME_VAR")]) {
@@ -251,7 +251,7 @@ def buildTest() {
 			} catch (Exception e) {
 				echo 'Cannot run copyArtifacts from test.getDependency. Skipping copyArtifacts...'
 			}
-			
+
 			try {
 				if (env.BUILD_LIST.startsWith('systemtest') || env.BUILD_LIST.startsWith('jck')) {
 					//get pre-staged test jars from systemtest.getDependency build before system test compilation
@@ -288,7 +288,7 @@ def runTest(subDir) {
 			RUNTEST_CMD = "./openjdk-tests/${subDir} _${params.TARGET} ${CUSTOM_OPTION}"
 			for (i = 0; i < iterations; i++) {
 				if (env.BUILD_LIST == 'openjdk_regression' || env.BUILD_LIST.startsWith('jck')) {
-					if (env.SPEC.startsWith('linux_x86-64')) { 
+					if (env.SPEC.startsWith('linux_x86-64')) {
 						wrap([$class: 'Xvfb', autoDisplayName: true]) {
 							def DISPLAY = sh (
 								script: 'ps -f  | grep \'[X]vfb\' | awk \'{print \$9}\'',
@@ -324,7 +324,7 @@ def post(output_name) {
 				for (String tapFile : tapFiles) {
 					sh "iconv -f ibm-1047 -t iso8859-1 ${tapFile} > ${tapFile}.ascii; rm ${tapFile}; mv ${tapFile}.ascii ${tapFile}"
 				}
-			
+
 				tar_cmd = "pax -wf"
 				suffix = ".pax.Z"
 				pax_opt = "-x pax"
@@ -399,7 +399,7 @@ def testBuild() {
 				cleanWs()
 			}
 		}
-		
+
 	}
 }
 
@@ -426,7 +426,7 @@ def addJobDescription() {
 			currentBuild.displayName = "#${BUILD_NUMBER} - ${BUILD_USER_EMAIL}"
 		}
 	}
-	
+
 	def description = (currentBuild.description) ? currentBuild.description + "<br>" : ""
 	currentBuild.description = description \
 		+ "TARGET: ${params.TARGET}<br/>" \
@@ -461,13 +461,18 @@ def uploadToArtifactory() {
 				]
 			}"""
 
-		def buildInfo = Artifactory.newBuildInfo()
-		// if ARTIFACTORY_NUM_ARTIFACTS is not set, set to keep 20 build artifacts
-		def numArtifacts = params.ARTIFACTORY_NUM_ARTIFACTS ? params.ARTIFACTORY_NUM_ARTIFACTS : 20
-
-		buildInfo.retention maxBuilds: numArtifacts, deleteBuildArtifacts: true
-		server.upload spec: uploadSpec, buildInfo: buildInfo
-		server.publishBuildInfo buildInfo
+		if (params.ARTIFACTORY_VERSION == 'ent') {
+			def buildInfo = Artifactory.newBuildInfo()
+			// if ARTIFACTORY_NUM_ARTIFACTS is not set, set to keep 20 build artifacts
+			def numArtifacts = params.ARTIFACTORY_NUM_ARTIFACTS ? params.ARTIFACTORY_NUM_ARTIFACTS : 20
+			buildInfo.retention maxBuilds: numArtifacts, deleteBuildArtifacts: true
+			server.upload spec: uploadSpec, buildInfo: buildInfo
+			server.publishBuildInfo buildInfo
+		} else if (params.ARTIFACTORY_VERSION == 'oss') {
+			server.upload spec: uploadSpec
+		} else {
+			error "Unknown ARTIFACTORY_VERSION:${ARTIFACTORY_VERSION}"
+		}
 
 		def artifactoryUrl = server.getUrl()
 		def uploadUrl = "${artifactoryUrl}/${artifactoryUploadDir}"


### PR DESCRIPTION
- Only attach buildInfo for artifacts being uploaded
  to an enterprise Artifactory server instance. OSS version
  doesn't support buildInfo

Related eclipse/openj9#4986

Signed-off-by: Adam Brousseau <adam.brousseau@ca.ibm.com>