### PR TITLE
Force delete containers and images when test finished

### DIFF
--- a/thirdparty_containers/derby/playlist.xml
+++ b/thirdparty_containers/derby/playlist.xml
@@ -16,6 +16,7 @@
 	<test>
 		<testCaseName>derby_test_junit_all</testCaseName>
 	<command>docker run --rm $(EXTRA_DOCKER_ARGS) adoptopenjdk-derby-test:latest ; \
+		docker rmi -f adoptopenjdk-derby-test; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>

--- a/thirdparty_containers/elasticsearch/playlist.xml
+++ b/thirdparty_containers/elasticsearch/playlist.xml
@@ -15,7 +15,7 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
 	<test>
 		<testCaseName>elasticsearch_test</testCaseName>
-		<command>docker run --name elasticsearch-test --rm $(EXTRA_DOCKER_ARGS) adoptopenjdk-elasticsearch-test:latest; \
+		<command>docker run --name elasticsearch-test $(EXTRA_DOCKER_ARGS) adoptopenjdk-elasticsearch-test:latest; \
 			$(TEST_STATUS); \
 			docker cp elasticsearch-test:/elasticsearch/core/build/reports/testJunit $(REPORTDIR)/external_test_reports; \
 			docker cp elasticsearch-test:/elasticsearch/modules/transport-netty4/build/reports/testJunit $(REPORTDIR)/external_test_reports; \
@@ -26,7 +26,8 @@
 			docker cp elasticsearch-test:/elasticsearch/test/framework/build/reports/testJunit $(REPORTDIR)/external_test_reports; \
 			docker cp elasticsearch-test:/elasticsearch/test/logger-usage/build/reports/testJunit $(REPORTDIR)/external_test_reports; \
 			docker cp elasticsearch-test:/elasticsearch/client/rest/build/reports/testJunit $(REPORTDIR)/external_test_reports; \
-			docker rm elasticsearch-test
+			docker rm -f elasticsearch-test; \
+			docker rmi -f adoptopenjdk-elasticsearch-test
 		</command>
 		<levels>
 			<level>sanity</level>

--- a/thirdparty_containers/example-test/playlist.xml
+++ b/thirdparty_containers/example-test/playlist.xml
@@ -19,7 +19,9 @@
 	<test>
 		<testCaseName>example_test</testCaseName>
 	<command>docker run --rm $(EXTRA_DOCKER_ARGS) adoptopenjdk-example-test:latest ; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		docker rmi -f adoptopenjdk-example-test
+	</command>
 		<subsets>
 			<subset>8</subset>
 		</subsets>

--- a/thirdparty_containers/functional-test/playlist.xml
+++ b/thirdparty_containers/functional-test/playlist.xml
@@ -18,8 +18,8 @@
 		<variations>
 			<variation>-XX:+UseContainerSupport</variation>
 		</variations>
-		<command>docker run --name functional-test adoptopenjdk-functional-test:latest ; \
-		 docker rm functional-test; \
+		<command>docker run --name functional-test --rm adoptopenjdk-functional-test:latest ; \
+		 docker rmi -f adoptopenjdk-functional-test; \
 		$(TEST_STATUS)</command>
 		<subsets>
 			<subset>8</subset>

--- a/thirdparty_containers/jenkins/playlist.xml
+++ b/thirdparty_containers/jenkins/playlist.xml
@@ -15,11 +15,12 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
 	<test>
 		<testCaseName>jenkins_test</testCaseName>
-		<command>docker run --name jenkins-test --rm $(EXTRA_DOCKER_ARGS) adoptopenjdk-jenkins-test:latest; \
+		<command>docker run --name jenkins-test $(EXTRA_DOCKER_ARGS) adoptopenjdk-jenkins-test:latest; \
 			 $(TEST_STATUS); \
 			 docker cp jenkins-test:/jenkins/cli/target/surefire-reports $(REPORTDIR)/external_test_reports; \
 			 docker cp jenkins-test:/jenkins/core/target/surefire-reports $(REPORTDIR)/external_test_reports; \
-			 docker rm jenkins-test
+			 docker rm -f jenkins-test; \
+			 docker rmi -f adoptopenjdk-jenkins-test
 		</command>
 		<levels>
 			<level>sanity</level>

--- a/thirdparty_containers/kafka/playlist.xml
+++ b/thirdparty_containers/kafka/playlist.xml
@@ -16,6 +16,7 @@
 	<test>
 		<testCaseName>kafka_test</testCaseName>
 	<command>docker run --rm $(EXTRA_DOCKER_ARGS) adoptopenjdk-kafka-test:latest ; \
+		docker rmi -f adoptopenjdk-kafka-test; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>

--- a/thirdparty_containers/lucene-solr/playlist.xml
+++ b/thirdparty_containers/lucene-solr/playlist.xml
@@ -15,10 +15,11 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
 	<test>
 		<testCaseName>lucene_solr_nightly_smoketest</testCaseName>
-		<command>docker run --name lucene-solr-test --rm $(EXTRA_DOCKER_ARGS) adoptopenjdk-lucene-solr-test:latest; \
+		<command>docker run --name lucene-solr-test $(EXTRA_DOCKER_ARGS) adoptopenjdk-lucene-solr-test:latest; \
 			 $(TEST_STATUS); \
 			 docker cp lucene-solr-test:/lucene-solr/lucene/build/core/test $(REPORTDIR)/external_test_reports; \
-			 docker rm lucene-solr-test
+			 docker rm -f lucene-solr-test; \
+			 docker rmi -f adoptopenjdk-lucene-solr-test
 		</command>
 		<levels>
 			<level>sanity</level>
@@ -34,10 +35,11 @@
 	<!-- Temporarily exclude lucene-solr tests from running on OpenJ9 JDK11 until fixed: https://github.com/eclipse/openj9/issues/3213 -->
 	<test>
 		<testCaseName>lucene_solr_nightly_smoketest_OpenJ9</testCaseName>
-		<command>docker run -v $(JDK_HOME):/java --name lucene-solr-test adoptopenjdk-lucene-solr-test:latest; \
+		<command>docker run --name lucene-solr-test $(EXTRA_DOCKER_ARGS) adoptopenjdk-lucene-solr-test:latest; \
 			 $(TEST_STATUS); \
 			 docker cp lucene-solr-test:/lucene-solr/lucene/build/core/test $(REPORTDIR)/external_test_reports; \
-			 docker rm lucene-solr-test
+			 docker rm -f lucene-solr-test
+			 docker rmi -f adoptopenjdk-lucene-solr-test
 		</command>
 		<levels>
 			<level>sanity</level>

--- a/thirdparty_containers/openliberty-mp-tck/playlist.xml
+++ b/thirdparty_containers/openliberty-mp-tck/playlist.xml
@@ -15,14 +15,15 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
 	<test>
 		<testCaseName>openliberty_microprofile_tck</testCaseName>
-		<command>docker run --name openliberty-mp-tck --rm $(EXTRA_DOCKER_ARGS) adoptopenjdk-openliberty-mp-tck:latest; \
+		<command>docker run --name openliberty-mp-tck $(EXTRA_DOCKER_ARGS) adoptopenjdk-openliberty-mp-tck:latest; \
 			$(TEST_STATUS); \
 			docker cp openliberty-mp-tck:/open-liberty/dev/com.ibm.ws.microprofile.metrics.1.1_fat_tck/build/libs/autoFVT/results/tck/surefire-reports $(REPORTDIR)/external_test_reports; \
 			docker cp openliberty-mp-tck:/open-liberty/dev/com.ibm.ws.microprofile.config_fat_tck/build/libs/autoFVT/results/tck/surefire-reports $(REPORTDIR)/external_test_reports; \
 			docker cp openliberty-mp-tck:/open-liberty/dev/com.ibm.ws.microprofile.faulttolerance_fat_tck/build/libs/autoFVT/results/tck/surefire-reports $(REPORTDIR)/external_test_reports; \
 			docker cp openliberty-mp-tck:/open-liberty/dev/com.ibm.ws.microprofile.rest.client_fat_tck/build/libs/autoFVT/results/tck/surefire-reports $(REPORTDIR)/external_test_reports; \
 			docker cp openliberty-mp-tck:/open-liberty/dev/com.ibm.ws.microprofile.openapi_fat_tck/build/libs/autoFVT/results/tck/surefire-reports $(REPORTDIR)/external_test_reports; \
-			docker rm openliberty-mp-tck
+			docker rm -f openliberty-mp-tck; \
+			docker rmi -f adoptopenjdk-openliberty-mp-tck
 		</command>
 		<levels>
 			<level>extended</level>

--- a/thirdparty_containers/payara-mp-tck/playlist.xml
+++ b/thirdparty_containers/payara-mp-tck/playlist.xml
@@ -15,13 +15,14 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
 	<test>
 		<testCaseName>payara_microprofile_tck</testCaseName>
-		<command>docker run --name payara-mp-tck --rm $(EXTRA_DOCKER_ARGS) adoptopenjdk-payara-mp-tck:latest; \
+		<command>docker run --name payara-mp-tck $(EXTRA_DOCKER_ARGS) adoptopenjdk-payara-mp-tck:latest; \
 			 $(TEST_STATUS); \
 			 docker cp payara-mp-tck:/MicroProfile-TCK-Runners/MicroProfile-Metrics/tck-runner/target/surefire-reports $(REPORTDIR)/external_test_reports; \
 			 docker cp payara-mp-tck:/MicroProfile-TCK-Runners/MicroProfile-Fault-Tolerance/tck-runner/target/surefire-reports/junitreports $(REPORTDIR)/external_test_reports; \
 			 docker cp payara-mp-tck:/MicroProfile-TCK-Runners/MicroProfile-Config/tck-runner/target/surefire-reports/junitreports $(REPORTDIR)/external_test_reports; \
 			 docker cp payara-mp-tck:/MicroProfile-TCK-Runners/MicroProfile-OpenAPI/tck-runner/target/surefire-reports/junitreports $(REPORTDIR)/external_test_reports; \
-			 docker rm payara-mp-tck
+			 docker rm -f payara-mp-tck; \
+			 docker rmi -f adoptopenjdk-payara-mp-tck
 		</command>
 		<subsets>
 			<subset>8</subset>

--- a/thirdparty_containers/scala/playlist.xml
+++ b/thirdparty_containers/scala/playlist.xml
@@ -16,7 +16,9 @@
 	<test>
 		<testCaseName>scala_test</testCaseName>
 	<command>docker run --rm $(EXTRA_DOCKER_ARGS) adoptopenjdk-scala-test:latest; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		docker rmi -f adoptopenjdk-scala-test
+	</command>
 		<levels>
 			<level>sanity</level>
 		</levels>

--- a/thirdparty_containers/thorntail-mp-tck/playlist.xml
+++ b/thirdparty_containers/thorntail-mp-tck/playlist.xml
@@ -15,14 +15,15 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
 	<test>
 		<testCaseName>thorntail_microprofile_tck</testCaseName>
-		<command>docker run --name thorntail-mp-tck --rm $(EXTRA_DOCKER_ARGS) adoptopenjdk-thorntail-mp-tck:latest; \
+		<command>docker run --name thorntail-mp-tck $(EXTRA_DOCKER_ARGS) adoptopenjdk-thorntail-mp-tck:latest; \
 			 $(TEST_STATUS); \
 			 docker cp thorntail-mp-tck:/thorntail/testsuite/testsuite-microprofile-metrics/target/surefire-reports $(REPORTDIR)/external_test_reports; \
 			 docker cp thorntail-mp-tck:/thorntail/testsuite/testsuite-microprofile-fault-tolerance/target/surefire-reports $(REPORTDIR)/external_test_reports; \
 			 docker cp thorntail-mp-tck:/thorntail/testsuite/testsuite-microprofile-restclient/target/surefire-reports $(REPORTDIR)/external_test_reports; \
 			 docker cp thorntail-mp-tck:/thorntail/testsuite/testsuite-microprofile-openapi/target/surefire-reports $(REPORTDIR)/external_test_reports; \
 			 docker cp thorntail-mp-tck:/thorntail/testsuite//testsuite-microprofile-jwt/target/surefire-reports $(REPORTDIR)/external_test_reports; \
-			 docker rm thorntail-mp-tck
+			 docker rm -f thorntail-mp-tck; \
+			 docker rmi -f adoptopenjdk-thorntail-mp-tck
 		</command>
 		<subsets>
 			<subset>8</subset>

--- a/thirdparty_containers/tomcat/playlist.xml
+++ b/thirdparty_containers/tomcat/playlist.xml
@@ -16,7 +16,9 @@
 	<test>
 		<testCaseName>tomcat_test</testCaseName>
 	<command>docker run --rm $(EXTRA_DOCKER_ARGS) adoptopenjdk-tomcat-test:latest ; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		docker rmi -adoptopenjdk-tomcat-test
+	</command>
 		<levels>
 			<level>sanity</level>
 		</levels>

--- a/thirdparty_containers/wildfly/playlist.xml
+++ b/thirdparty_containers/wildfly/playlist.xml
@@ -16,7 +16,9 @@
 	<test>
 		<testCaseName>wildfly_test</testCaseName>
 	<command>docker run --rm $(EXTRA_DOCKER_ARGS) adoptopenjdk-wildfly-test:latest; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		docker rmi -f adoptopenjdk-wildfly-test
+	</command>
 		<levels>
 			<level>sanity</level>
 		</levels>


### PR DESCRIPTION
Force delete containers and images when test finished
Delete containers only when docker cp finished
Remove leftover volume map and add EXTRA_DOCKER_ARGS

related #915 

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>