### PR TITLE
Correct jck runtime.vm playlist.xml

### DIFF
--- a/jck/runtime.vm/playlist.xml
+++ b/jck/runtime.vm/playlist.xml
@@ -33,7 +33,6 @@
 		<groups>
 			<group>jck</group>
 		</groups>
-		<subsets>
 	</test>
 	<test>
 		<testCaseName>jck-runtime-vm-constantpool</testCaseName>


### PR DESCRIPTION
- remove additional `<subset>`

Signed-off-by: Renfei Wang <renfeiw@ca.ibm.com>