### PR TITLE
Documentation correction: update third party dockerfiles comments with correct build command

### DIFF
--- a/thirdparty_containers/derby/dockerfile/Dockerfile
+++ b/thirdparty_containers/derby/dockerfile/Dockerfile
@@ -14,7 +14,7 @@
 # AdoptOpenJDK jdk binary installed. Basic test dependent executions
 # are installed during the building process.
 #
-# Build example: `docker build -t adoptopenjdk-derby-test .`
+# Build example: `docker build -t adoptopenjdk-derby-test -f Dockerfile ../.`
 #
 # This Dockerfile builds image based on adoptopenjdk/openjdk8:latest.
 # If you want to build image based on other images, please use

--- a/thirdparty_containers/elasticsearch/dockerfile/Dockerfile
+++ b/thirdparty_containers/elasticsearch/dockerfile/Dockerfile
@@ -14,7 +14,7 @@
 # AdoptOpenJDK jdk binary installed. Basic test dependent executions
 # are installed during the building process.
 #
-# Build example: `docker build -t adoptopenjdk-elasticsearch-test .`
+# Build example: `docker build -t adoptopenjdk-elasticsearch-test -f Dockerfile ../.`
 #
 # This Dockerfile builds image based on adoptopenjdk/openjdk8:latest.
 # If you want to build image based on other images, please use

--- a/thirdparty_containers/example-test/dockerfile/Dockerfile
+++ b/thirdparty_containers/example-test/dockerfile/Dockerfile
@@ -14,7 +14,7 @@
 # AdoptOpenJDK jdk binary installed. Basic test dependent executions
 # are installed during the building process.
 #
-# Build example: `docker build -t adoptopenjdk-example-test .`
+# Build example: `docker build -t adoptopenjdk-example-test -f Dockerfile ../.`
 #
 # This Dockerfile builds image based on adoptopenjdk/openjdk8:latest.
 # If you want to build image based on other images, please use

--- a/thirdparty_containers/functional-test/dockerfile/Dockerfile
+++ b/thirdparty_containers/functional-test/dockerfile/Dockerfile
@@ -14,7 +14,7 @@
 # AdoptOpenJDK jdk binary installed. Basic test dependent executions
 # are installed during the building process.
 #
-# Build functional: `docker build -t adoptopenjdk-functional-test .`
+# Build functional: `docker build -t adoptopenjdk-functional-test -f Dockerfile ../.`
 #
 # This Dockerfile builds image based on adoptopenjdk/openjdk8:latest.
 # If you want to build image based on other images, please use

--- a/thirdparty_containers/jenkins/dockerfile/Dockerfile
+++ b/thirdparty_containers/jenkins/dockerfile/Dockerfile
@@ -14,7 +14,7 @@
 # AdoptOpenJDK jdk binary installed. Basic test dependent executions
 # are installed during the building process.
 #
-# Build example: `docker build -t adoptopenjdk-jenkins-test .`
+# Build example: `docker build -t adoptopenjdk-jenkins-test -f Dockerfile ../.`
 #
 # This Dockerfile builds image based on adoptopenjdk/openjdk8:latest.
 # If you want to build image based on other images, please use

--- a/thirdparty_containers/kafka/dockerfile/Dockerfile
+++ b/thirdparty_containers/kafka/dockerfile/Dockerfile
@@ -14,7 +14,7 @@
 # AdoptOpenJDK jdk binary installed. Basic test dependent executions
 # are installed during the building process.
 #
-# Build example: `docker build -t adoptopenjdk-kafka-test .`
+# Build example: `docker build -t adoptopenjdk-kafka-test -f Dockerfile ../.`
 #
 # This Dockerfile builds image based on adoptopenjdk/openjdk8:latest.
 # If you want to build image based on other images, please use

--- a/thirdparty_containers/lucene-solr/dockerfile/Dockerfile
+++ b/thirdparty_containers/lucene-solr/dockerfile/Dockerfile
@@ -14,7 +14,7 @@
 # AdoptOpenJDK jdk binary installed. Basic test dependent executions
 # are installed during the building process.
 #
-# Build example: `docker build -t adoptopenjdk-lucene-solr-test .`
+# Build example: `docker build -t adoptopenjdk-lucene-solr-test -f Dockerfile ../.`
 #
 # This Dockerfile builds image based on adoptopenjdk/openjdk8:latest.
 # If you want to build image based on other images, please use

--- a/thirdparty_containers/openliberty-mp-tck/dockerfile/Dockerfile
+++ b/thirdparty_containers/openliberty-mp-tck/dockerfile/Dockerfile
@@ -14,7 +14,7 @@
 # AdoptOpenJDK jdk binary installed. Basic test dependent executions
 # are installed during the building process.
 #
-# Build example: `docker build -t adoptopenjdk-openliberty-mp-tck .`
+# Build example: `docker build -t adoptopenjdk-openliberty-mp-tck -f Dockerfile ../.`
 #
 # This Dockerfile builds image based on adoptopenjdk/openjdk8:latest.
 # If you want to build image based on other images, please use

--- a/thirdparty_containers/payara-mp-tck/dockerfile/Dockerfile
+++ b/thirdparty_containers/payara-mp-tck/dockerfile/Dockerfile
@@ -14,7 +14,7 @@
 # AdoptOpenJDK jdk binary installed. Basic test dependent executions
 # are installed during the building process.
 #
-# Build example: `docker build -t adoptopenjdk-payara-mp-tck .`
+# Build example: `docker build -t adoptopenjdk-payara-mp-tck -f Dockerfile ../.`
 #
 # This Dockerfile builds image based on adoptopenjdk/openjdk8:latest.
 # If you want to build image based on other images, please use

--- a/thirdparty_containers/scala/dockerfile/Dockerfile
+++ b/thirdparty_containers/scala/dockerfile/Dockerfile
@@ -14,7 +14,7 @@
 # AdoptOpenJDK jdk binary installed. Basic test dependent executions
 # are installed during the building process.
 #
-# Build example: `docker build -t adoptopenjdk-scala-test .`
+# Build example: `docker build -t adoptopenjdk-scala-test -f Dockerfile ../.`
 #
 # This Dockerfile builds image based on adoptopenjdk/openjdk8:latest.
 # If you want to build image based on other images, please use

--- a/thirdparty_containers/system-test/dockerfile/Dockerfile
+++ b/thirdparty_containers/system-test/dockerfile/Dockerfile
@@ -14,7 +14,7 @@
 # AdoptOpenJDK jdk binary installed. Basic test dependent executions
 # are installed during the building process.
 #
-# Build system: `docker build -t adoptopenjdk-system-test .`
+# Build system: `docker build -t adoptopenjdk-system-test -f Dockerfile ../.`
 #
 # This Dockerfile builds image based on adoptopenjdk/openjdk8:latest.
 # If you want to build image based on other images, please use

--- a/thirdparty_containers/thorntail-mp-tck/dockerfile/Dockerfile
+++ b/thirdparty_containers/thorntail-mp-tck/dockerfile/Dockerfile
@@ -14,7 +14,7 @@
 # AdoptOpenJDK jdk binary installed. Basic test dependent executions
 # are installed during the building process.
 #
-# Build example: `docker build -t adoptopenjdk-thorntail-mp-tck .`
+# Build example: `docker build -t adoptopenjdk-thorntail-mp-tck -f Dockerfile ../.`
 #
 # This Dockerfile builds image based on adoptopenjdk/openjdk8:latest.
 # If you want to build image based on other images, please use

--- a/thirdparty_containers/tomcat/dockerfile/Dockerfile
+++ b/thirdparty_containers/tomcat/dockerfile/Dockerfile
@@ -14,7 +14,7 @@
 # AdoptOpenJDK jdk binary installed. Basic test dependent executions
 # are installed during the building process.
 #
-# Build tomcat: `docker build -t adoptopenjdk-tomcat-test .`
+# Build tomcat: `docker build -t adoptopenjdk-tomcat-test -f Dockerfile ../.`
 #
 # This Dockerfile builds image based on adoptopenjdk/openjdk8:latest.
 # If you want to build image based on other images, please use

--- a/thirdparty_containers/wildfly/dockerfile/Dockerfile
+++ b/thirdparty_containers/wildfly/dockerfile/Dockerfile
@@ -14,7 +14,7 @@
 # AdoptOpenJDK jdk binary installed. Basic test dependent executions
 # are installed during the building process.
 #
-# Build example: `docker build -t adoptopenjdk-wildfly-test .`
+# Build example: `docker build -t adoptopenjdk-wildfly-test -f Dockerfile ../.`
 #
 # This Dockerfile builds image based on adoptopenjdk/openjdk8:latest.
 # If you want to build image based on other images, please use


### PR DESCRIPTION
### Documentation Update

Minor change to update the build command comments for all the thirdparty containers. Locally building docker results in an error when using the commands given in the docker files.

**The command given:** _`docker build -t adoptopenjdk-example-test .`_ 

This gives the wrong context during the build and results in an error when docker tries to execute any commands that rely on a path. For example the COPY commands are written expecting to find a `dockerfile` directory: _`COPY ./dockerfile/example-test.sh /example-test.sh`_. 

**Building locally fails with the following error:**
`Step 8/13 : COPY ./dockerfile/example-test.sh /example-test.sh
COPY failed: stat /var/lib/docker/tmp/docker-builder053382903/dockerfile/example-test.sh: no such file or directory`

The command assumes that the user is building from _`thirdparty_containers/example-test/dockerfile/`_ directory, whereas the dockerfile is written assuming the dockerfile is built from the parent directory _`thirdparty_containers/example-test/`_. This works fine for Playlists since they build containers from the parent directory:  _`arg line="build -t adoptopenjdk-example-test -f dockerfile/Dockerfile  .......`._ 

**To build locally the following command must executed:** 

`docker build -t adoptopenjdk-example-test -f Dockerfile ../.`

The context is changed to the parent directory _`../.`_ and the dockerfile is made explicit so it can be found in the child directory _`-f Dockerfile`_ 

Signed-off-by: Salman Rana <salman.rana@ibm.com>