### PR TITLE
Install dependent perl module via apt-get

### DIFF
--- a/thirdparty_containers/functional-test/dockerfile/Dockerfile
+++ b/thirdparty_containers/functional-test/dockerfile/Dockerfile
@@ -46,10 +46,8 @@ RUN apt-get update \
 
 RUN apt-get -y install \
 	libtext-csv-perl \
-	libjson-perl
-
-# Install Docker module to run test framework
-RUN echo yes | cpan install JSON Text::CSV XML::Parser
+	libjson-perl \
+	libxml-parser-perl
 
 # Install ant
 ENV ANT_VERSION 1.10.5

--- a/thirdparty_containers/system-test/dockerfile/Dockerfile
+++ b/thirdparty_containers/system-test/dockerfile/Dockerfile
@@ -63,7 +63,10 @@ VOLUME ["/java"]
 ENV  JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
 
 # Install Docker module to run test framework
-RUN echo yes | cpan install JSON Text::CSV XML::Parser
+RUN apt-get -y install \
+	libtext-csv-perl \
+	libjson-perl \
+	libxml-parser-perl
 
 # This is the main script to run system tests.  
 COPY ./dockerfile/system-test.sh /system-test.sh


### PR DESCRIPTION
As cpan XML::Parser depends on expat-devel.

Close #937 

Signed-off-by: Salman Rana <salman.rana@ibm.com>