### PR TITLE
Create Test Triage Rotas

### DIFF
--- a/triage/README.md
+++ b/triage/README.md
@@ -1,0 +1,38 @@
+# AdoptOpenJDK Test Triage Rotas
+
+### OpenJ9 Rotas:
+- [OpenJDK8](./openj9_test_triage_rotas.md#8)
+- [OpenJDK11](./openj9_test_triage_rotas.md#11)
+- [OpenJDK12](./openj9_test_triage_rotas.md#12)
+- [OpenJDK Head](./openj9_test_triage_rotas.md#head)
+
+### Hotspot Rotas:
+- [OpenJDK8](./hotspot_test_triage_rotas.md#8)
+- [OpenJDK11](./hotspot_test_triage_rotas.md#11)
+- [OpenJDK12](./hotspot_test_triage_rotas.md#12)
+- [OpenJDK13](./hotspot_test_triage_rotas.md#head)
+
+### Details:
+
+Triage is defined here as "Exclude the failing test, raise a bug against the relevant party, and put the bug URL in the exclude file.".
+
+Triagers named in the rotas linked above are committed to "best effort" triage on test runs which are:
+- That test group.
+- That platform.
+- That release.
+- That Virtual Machine.
+- Run against release streams.
+- Run as part of a predetermined test schedule (e.g. the automated nightlies).
+
+Triagers named above are *not* committed to triaging test runs which are:
+- Run by an individual.
+- Run against private forks/branches.
+- Run outside of the predetermined schedule.
+- Run using any test material other than the primary source for that platform/release/test group.
+- Run without the triager's knowledge.
+
+(Note: These are guidelines only, and do not restrict triagers from committing to perform triage outside of these limits.)
+
+Finally, do note that the triagers in the rotas do not have a monopoly on triaging. 
+
+Non-rota individuals are explicitly welcome to perform triage as and when they can.

--- a/triage/hotspot_test_triage_rotas.md
+++ b/triage/hotspot_test_triage_rotas.md
@@ -1,0 +1,49 @@
+# AdoptOpenJDK Test Triage Rotas for OpenJDK with Hotspot
+
+### <a name="8"></a>OpenJDK8 (Hotspot) - Test Triage Rota
+
+|                    | Monday | Tuesday | Wednesday | Thursday | Friday |
+|--------------------|--------|---------|-----------|----------|--------|
+|*OpenJDK.sanity*    |        |         |           |          |        |
+|*OpenJDK.extended*  |        |         |           |          |        |
+|*SystemTest*        |        |         |           |          |        |
+|*External*          |        |         |           |          |        |
+|*External.extended* |        |         |           |          |        |
+|*Performance*       |        |         |           |          |        |
+|*Functional*        |        |         |           |          |        |
+
+### <a name="11"></a>OpenJDK11 (Hotspot) - Test Triage Rota
+
+|                    | Monday | Tuesday | Wednesday | Thursday | Friday |
+|--------------------|--------|---------|-----------|----------|--------|
+|*OpenJDK.sanity*    |        |         |           |          |        |
+|*OpenJDK.extended*  |        |         |           |          |        |
+|*SystemTest*        |        |         |           |          |        |
+|*External*          |        |         |           |          |        |
+|*External.extended* |        |         |           |          |        |
+|*Performance*       |        |         |           |          |        |
+|*Functional*        |        |         |           |          |        |
+
+### <a name="12"></a>OpenJDK12 (Hotspot) - Test Triage Rota
+
+|                    | Monday | Tuesday | Wednesday | Thursday | Friday |
+|--------------------|--------|---------|-----------|----------|--------|
+|*OpenJDK.sanity*    |        |         |           |          |        |
+|*OpenJDK.extended*  |        |         |           |          |        |
+|*SystemTest*        |        |         |           |          |        |
+|*External*          |        |         |           |          |        |
+|*External.extended* |        |         |           |          |        |
+|*Performance*       |        |         |           |          |        |
+|*Functional*        |        |         |           |          |        |
+
+### <a name="head"></a>OpenJDK Head (Hotspot) - Test Triage Rota
+
+|                    | Monday | Tuesday | Wednesday | Thursday | Friday |
+|--------------------|--------|---------|-----------|----------|--------|
+|*OpenJDK.sanity*    |        |         |           |          |        |
+|*OpenJDK.extended*  |        |         |           |          |        |
+|*SystemTest*        |        |         |           |          |        |
+|*External*          |        |         |           |          |        |
+|*External.extended* |        |         |           |          |        |
+|*Performance*       |        |         |           |          |        |
+|*Functional*        |        |         |           |          |        |

--- a/triage/openj9_test_triage_rotas.md
+++ b/triage/openj9_test_triage_rotas.md
@@ -1,0 +1,49 @@
+# AdoptOpenJDK Test Triage Rotas for OpenJDK with OpenJ9
+
+### <a name="8"></a>OpenJDK8 (OpenJ9) - Test Triage Rota
+
+|                    | Monday | Tuesday | Wednesday | Thursday | Friday |
+|--------------------|--------|---------|-----------|----------|--------|
+|*OpenJDK.sanity*    |        |         |           |          |        |
+|*OpenJDK.extended*  |        |         |           |          |        |
+|*SystemTest*        |        |         |           |          |        |
+|*External*          |        |         |           |          |        |
+|*External.extended* |        |         |           |          |        |
+|*Performance*       |        |         |           |          |        |
+|*Functional*        |        |         |           |          |        |
+
+### <a name="11"></a>OpenJDK11 (OpenJ9) - Test Triage Rota
+
+|                    | Monday | Tuesday | Wednesday | Thursday | Friday |
+|--------------------|--------|---------|-----------|----------|--------|
+|*OpenJDK.sanity*    |        |         |           |          |        |
+|*OpenJDK.extended*  |        |         |           |          |        |
+|*SystemTest*        |        |         |           |          |        |
+|*External*          |        |         |           |          |        |
+|*External.extended* |        |         |           |          |        |
+|*Performance*       |        |         |           |          |        |
+|*Functional*        |        |         |           |          |        |
+
+### <a name="12"></a>OpenJDK12 (OpenJ9) - Test Triage Rota
+
+|                    | Monday | Tuesday | Wednesday | Thursday | Friday |
+|--------------------|--------|---------|-----------|----------|--------|
+|*OpenJDK.sanity*    |        |         |           |          |        |
+|*OpenJDK.extended*  |        |         |           |          |        |
+|*SystemTest*        |        |         |           |          |        |
+|*External*          |        |         |           |          |        |
+|*External.extended* |        |         |           |          |        |
+|*Performance*       |        |         |           |          |        |
+|*Functional*        |        |         |           |          |        |
+
+### <a name="head"></a>OpenJDK Head (OpenJ9) - Test Triage Rota
+
+|                    | Monday | Tuesday | Wednesday | Thursday | Friday |
+|--------------------|--------|---------|-----------|----------|--------|
+|*OpenJDK.sanity*    |        |         |           |          |        |
+|*OpenJDK.extended*  |        |         |           |          |        |
+|*SystemTest*        |        |         |           |          |        |
+|*External*          |        |         |           |          |        |
+|*External.extended* |        |         |           |          |        |
+|*Performance*       |        |         |           |          |        |
+|*Functional*        |        |         |           |          |        |


### PR DESCRIPTION
These rotas will enable us to determine which areas of testing
are being monitored and triaged on a regular basis, and which
areas are not, for the purpose of ensuring consistent quality.

This enables individuals to recognise gaps in areas of testing
that are important to them, so they can most efficiently allocate
their time.

It also prevents effort duplication between triagers actively working
on the same area of testing.

Review requested: @andrew-m-leonard @ben-walsh @smlambert 

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>