### PR TITLE
Access TARGET by env object params

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -281,6 +281,7 @@ def runTest(subDir) {
 				iterations = "${params.ITERATIONS}".toInteger()
 			}
 			def CUSTOM_OPTION = ''
+			TARGET = "${params.TARGET}";
 			if (TARGET.contains('custom')) {
 				CUSTOM_OPTION = "${TARGET.toUpperCase()}_TARGET='${CUSTOM_TARGET}'"
 			}


### PR DESCRIPTION
If parameter is passed in by upstream job jenkins can only recognize
parameters by env params

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>