### PR TITLE
WIP: archive work/scratch folder to capture dmp/trc files

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -342,7 +342,7 @@ def post(output_name) {
 				def jtr_output_tar_name = "jtr_test_output${suffix}"
 				def core_output_tar_name = "core_dmp_test_output${suffix}"
 				sh "${tar_cmd} ${test_output_tar_name} ${pax_opt} ./openjdk-tests/TestConfig/test_output_*"
-				sh "${tar_cmd} ${core_output_tar_name} ./jvmtest/${env.BUILD_LIST}/work/scratch"
+				sh "find ./jvmtest/${env.BUILD_LIST}/work/scratch -name '*.dmp' -o -name '*.trc' -o -iname 'javacore.*' | ${tar_cmd} ${core_output_tar_name} ${tar_opt} ${pax_opt}"
 				sh "find ./jvmtest/${env.BUILD_LIST}/work -name '*.jtr' | ${tar_cmd} ${jtr_output_tar_name} ${tar_opt} ${pax_opt}"
 				
 				if (!params.ARTIFACTORY_SERVER) {

--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -340,14 +340,16 @@ def post(output_name) {
 			if (currentBuild.result == 'UNSTABLE' || params.ARCHIVE_TEST_RESULTS) {
 				def test_output_tar_name = "${output_name}_test_output${suffix}"
 				def jtr_output_tar_name = "jtr_test_output${suffix}"
+				def core_output_tar_name = "core_dmp_test_output${suffix}"
 				sh "${tar_cmd} ${test_output_tar_name} ${pax_opt} ./openjdk-tests/TestConfig/test_output_*"
-				sh "${tar_cmd} ${test_output_tar_name} ./jvmtest/${env.BUILD_LIST}/work/scratch"
-				sh "find ./jvmtest/${env.BUILD_LIST}/work -name \( -iname \*.jtr -o -iname \*.dmp -o -iname \*.trc -o -iname \*.txt \) | ${tar_cmd} ${jtr_output_tar_name} ${tar_opt} ${pax_opt}"
+				sh "${tar_cmd} ${core_output_tar_name} ./jvmtest/${env.BUILD_LIST}/work/scratch"
+				sh "find ./jvmtest/${env.BUILD_LIST}/work -name '*.jtr' | ${tar_cmd} ${jtr_output_tar_name} ${tar_opt} ${pax_opt}"
 				
 				if (!params.ARTIFACTORY_SERVER) {
 					echo "ARTIFACTORY_SERVER is not set. Saving artifacts on jenkins."
 					archiveArtifacts artifacts: test_output_tar_name, fingerprint: true, allowEmptyArchive: true
 					archiveArtifacts artifacts: jtr_output_tar_name, fingerprint: true, allowEmptyArchive: true
+					archiveArtifacts artifacts: core_output_tar_name, fingerprint: true, allowEmptyArchive: true
 				}
 			}
 			//for performance test, achive regardless the build result

--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -341,8 +341,9 @@ def post(output_name) {
 				def test_output_tar_name = "${output_name}_test_output${suffix}"
 				def jtr_output_tar_name = "jtr_test_output${suffix}"
 				sh "${tar_cmd} ${test_output_tar_name} ${pax_opt} ./openjdk-tests/TestConfig/test_output_*"
-				sh "find ./jvmtest/${env.BUILD_LIST}/work -name '*.jtr' | ${tar_cmd} ${jtr_output_tar_name} ${tar_opt} ${pax_opt}"
-
+				sh "${tar_cmd} ${test_output_tar_name} ./jvmtest/${env.BUILD_LIST}/work/scratch"
+				sh "find ./jvmtest/${env.BUILD_LIST}/work -name \( -iname \*.jtr -o -iname \*.dmp -o -iname \*.trc -o -iname \*.txt \) | ${tar_cmd} ${jtr_output_tar_name} ${tar_opt} ${pax_opt}"
+				
 				if (!params.ARTIFACTORY_SERVER) {
 					echo "ARTIFACTORY_SERVER is not set. Saving artifacts on jenkins."
 					archiveArtifacts artifacts: test_output_tar_name, fingerprint: true, allowEmptyArchive: true


### PR DESCRIPTION
If a test crashes during execution, cores get created inside of work/scratch/ dir.  This PR checks for javacore/dmp/trc files and archives them if present.