### PR TITLE
Add artifactory info into the test job template

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -474,8 +474,8 @@ def uploadToArtifactory() {
 	if (params.ARTIFACTORY_SERVER) {
 		def server = Artifactory.server params.ARTIFACTORY_SERVER
 		def artifactoryRepo = params.ARTIFACTORY_REPO ? params.ARTIFACTORY_REPO : "sys-rt-generic-local"
-		def jenkinsDomain = params.JENKINS_DOMAIN ? params.JENKINS_DOMAIN : getJenkinsDomain()
-		def artifactoryUploadDir = "${artifactoryRepo}/${jenkinsDomain}/${JOB_NAME}/${BUILD_ID}/"
+		def artifactoryRoorDir = params.ARTIFACTORY_ROOT_DIR ? params.ARTIFACTORY_ROOT_DIR : getJenkinsDomain()
+		def artifactoryUploadDir = "${artifactoryRepo}/${artifactoryRoorDir}/${JOB_NAME}/${BUILD_ID}/"
 
 		def uploadSpec = """{
 			"files":[

--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -20,6 +20,8 @@
 
 if (!binding.hasVariable('JDK_IMPL')) JDK_IMPL = "openj9"
 if (!binding.hasVariable('ARTIFACTORY_SERVER')) ARTIFACTORY_SERVER = ""
+if (!binding.hasVariable('ARTIFACTORY_REPO')) ARTIFACTORY_REPO = ""
+if (!binding.hasVariable('ARTIFACTORY_ROOT_DIR')) ARTIFACTORY_ROOT_DIR = ""
 if (!binding.hasVariable('TIME_LIMIT')) TIME_LIMIT = "10"
 if (!binding.hasVariable('SUFFIX')) SUFFIX = ""
 if (!binding.hasVariable('BUILDS_TO_KEEP')) {
@@ -135,6 +137,8 @@ SPECS.each { SPEC ->
 							stringParam('SSH_AGENT_CREDENTIAL', "", "Optional. Only use when ssh credentials are needed")
 							booleanParam('KEEP_WORKSPACE', false, "Keep workspace on the machine")
 							stringParam('ARTIFACTORY_SERVER', ARTIFACTORY_SERVER, "Optional. Default is to upload test output (failed build) onto artifactory only. By unset this value, test output will be archived to Jenkins")
+							stringParam('ARTIFACTORY_REPO', ARTIFACTORY_REPO, "Optional. It should be used with ARTIFACTORY_SERVER")
+							stringParam('ARTIFACTORY_ROOT_DIR', ARTIFACTORY_ROOT_DIR, "Optional. It should be used with ARTIFACTORY_SERVER and ARTIFACTORY_REPO. Default is to set root dir to be the same as the current Jenkins domain")
 							booleanParam('PERSONAL_BUILD', false, "Is this a personal build?")
 							booleanParam('IS_PARALLEL', false, "Should tests run in parallel?")
 							stringParam('USER_CREDENTIALS_ID', "", "Optional. User credential ID")


### PR DESCRIPTION
- add ARTIFACTORY_REPO and ARTIFACTORY_ROOT_DIR
- rename JENKINS_DOMAIN to ARTIFACTORY_ROOT_DIR in Jenkins base to avoid
confusion. This value defaults to jenkins domain, but it can be set to
other value.

Issue: https://github.com/eclipse/openj9/issues/5198

Signed-off-by: lanxia <lan_xia@ca.ibm.com>