### PR TITLE
Support elastic test with different jdk version

### DIFF
--- a/thirdparty_containers/elasticsearch/build.xml
+++ b/thirdparty_containers/elasticsearch/build.xml
@@ -21,8 +21,24 @@
 	</target>
 
 	<target name="build_image" depends="clean_image" description="build elasticsearch test docker image">
+		<if>
+			<contains string="${JVM_VERSION}" substring="8" />
+			<then>
+				<property name="ELASTIC_VERSION" value="v6.1.3" />
+			</then>
+			<elseif>
+				<contains string="${JVM_VERSION}" substring="11" />
+				<then>
+					<property name="ELASTIC_VERSION" value="v6.6.2" />
+				</then>
+			</elseif>
+			<else>
+				<echo message="Checkout lastest ELASTIC " />
+				<property name="ELASTIC_VERSION" value="." />
+			</else>
+		</if>
 		<exec executable="docker"  failonerror="true">
-			<arg line="build -t adoptopenjdk-elasticsearch-test -f dockerfile/Dockerfile --pull . --build-arg SDK=${JVM_VERSION}" />
+			<arg line="build -t adoptopenjdk-elasticsearch-test -f dockerfile/Dockerfile --pull . --build-arg SDK=${JVM_VERSION} --build-arg ELASTIC_VERSION=${ELASTIC_VERSION}"/>
 		</exec>
 	</target>
 

--- a/thirdparty_containers/elasticsearch/dockerfile/Dockerfile
+++ b/thirdparty_containers/elasticsearch/dockerfile/Dockerfile
@@ -27,7 +27,6 @@ ARG IMAGE_NAME=adoptopenjdk/$SDK
 # Using nightly temporately util https://github.com/AdoptOpenJDK/openjdk-docker/issues/122 is fix
 #ARG IMAGE_VERSION=latest
 ARG IMAGE_VERSION=nightly
-
 FROM $IMAGE_NAME:$IMAGE_VERSION
 
 RUN groupadd -g 1000 elasticsearch && useradd elasticsearch -u 1000 -g 1000
@@ -54,14 +53,12 @@ ENV JAVA_HOME=/java \
 # This is the main script to run Elasticsarch tests.
 COPY ./dockerfile/elasticsearch-test.sh /elasticsearch-test.sh
 
-# Clone the Elasticsearch test repo
-WORKDIR /
-RUN pwd
-
 RUN git clone -q https://github.com/elastic/elasticsearch.git
 
-RUN cd elasticsearch \
-&& git checkout v6.1.3
+#default is HEAD
+ARG ELASTIC_VERSION=.
+WORKDIR elasticsearch
+RUN git checkout $ELASTIC_VERSION
 
 RUN chown -R elasticsearch /elasticsearch
 RUN chown -R elasticsearch /elasticsearch-test.sh


### PR DESCRIPTION
Elastic requires different gradle version and gradle version requires
different JDK version

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>