### PR TITLE
Re-include all working mauve tests as failing sub-tests are disabled

### DIFF
--- a/systemtest/mauveLoadTest/playlist.xml
+++ b/systemtest/mauveLoadTest/playlist.xml
@@ -1,36 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
 	<include>../systemtest.mk</include>
-
-	<!-- exclude on JDK8 openj9 on osx https://github.com/eclipse/openj9/issues/4091 -->
-	<test>
-		<testCaseName>MauveSingleThreadLoadTest_OpenJ9_JDK8</testCaseName>
-		<variations>
-			<variation>NoOptions</variation>
-		</variations>
-		<command>export JAVA_HOME=$(JDK_HOME)$(D)  $(AND_IF_SUCCESS) \
-	perl $(SYSTEMTEST_RESROOT)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
-	-test-root=$(Q)$(SYSTEMTEST_RESROOT)$(D)stf;$(SYSTEMTEST_RESROOT)$(D)openjdk-systemtest$(Q) \
-	-systemtest-prereqs=$(Q)$(SYSTEMTEST_RESROOT)$(D)systemtest_prereqs$(Q)  \
-	-java-args=$(Q)$(JVM_OPTIONS)$(Q) \
-	-results-root=$(REPORTDIR)  \
-	-test=MauveSingleThreadLoadTest; \
-	$(TEST_STATUS)</command>
-		<levels>
-			<level>sanity</level>
-		</levels>
-		<groups>
-			<group>system</group>
-		</groups>
-		<subsets>
-			<subset>8</subset>
-		</subsets>
-		<impls>
-			<impl>openj9</impl>
-		</impls>
-		<platformRequirements>^os.osx</platformRequirements>
-	</test>
-	<!-- exclude from all platforms due to https://github.com/eclipse/openj9/issues/234 -->
+	<!-- Disabled from OpenJ9 on osx due to : https://github.com/eclipse/openj9/issues/4091 -->
 	<test>
 		<testCaseName>MauveSingleThreadLoadTest_OpenJ9</testCaseName>
 		<variations>
@@ -50,17 +21,13 @@
 		<groups>
 			<group>system</group>
 		</groups>
-		<subsets>
-			<subset>11+</subset>
-		</subsets>
-		<impls>
-			<impl>openj9</impl>
+		<impls>	
+			<impl>openj9</impl>	
 		</impls>
-		<disabled>AdoptOpenJDK/openjdk-systemtest/issues/234</disabled>
-	</test>	
-	<!-- exclude from all platforms due to https://github.com/eclipse/openj9/issues/234 -->
+		<platformRequirements>^os.osx</platformRequirements>
+	</test>
 	<test>
-		<testCaseName>MauveSingleThreadLoadTest_HS</testCaseName>
+		<testCaseName>MauveSingleThreadLoadTest_HotSpot</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -78,41 +45,12 @@
 		<groups>
 			<group>system</group>
 		</groups>
-		<impls>
-			<impl>hotspot</impl>
+		<impls>	
+			<impl>hotspot</impl>	
 		</impls>
-		<disabled>AdoptOpenJDK/openjdk-systemtest/issues/234</disabled>
 	</test>
 
-	<!-- exclude on JDK8 openj9 on osx https://github.com/eclipse/openj9/issues/4091 -->
-	<test>
-		<testCaseName>MauveSingleInvocationLoadTest_OpenJ9_JDK8</testCaseName>
-		<variations>
-			<variation>NoOptions</variation>
-		</variations>
-		<command>export JAVA_HOME=$(JDK_HOME)$(D)  $(AND_IF_SUCCESS) \
-	perl $(SYSTEMTEST_RESROOT)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
-	-test-root=$(Q)$(SYSTEMTEST_RESROOT)$(D)stf;$(SYSTEMTEST_RESROOT)$(D)openjdk-systemtest$(Q) \
-	-systemtest-prereqs=$(Q)$(SYSTEMTEST_RESROOT)$(D)systemtest_prereqs$(Q)  \
-	-java-args=$(Q)$(JVM_OPTIONS)$(Q) \
-	-results-root=$(REPORTDIR)  \
-	-test=MauveSingleInvocationLoadTest; \
-	$(TEST_STATUS)</command>
-		<levels>
-			<level>sanity</level>
-		</levels>
-		<groups>
-			<group>system</group>
-		</groups>
-		<subsets>
-			<subset>8</subset>
-		</subsets>
-		<impls>
-			<impl>openj9</impl>
-		</impls>
-		<platformRequirements>^os.osx</platformRequirements>
-	</test>
-	<!-- exclude from all platforms due to https://github.com/eclipse/openj9/issues/234 -->
+	<!-- Disabled from OpenJ9 on osx due to : https://github.com/eclipse/openj9/issues/4091 -->
 	<test>
 		<testCaseName>MauveSingleInvocationLoadTest_OpenJ9</testCaseName>
 		<variations>
@@ -132,17 +70,13 @@
 		<groups>
 			<group>system</group>
 		</groups>
-		<subsets>
-			<subset>11+</subset>
-		</subsets>
-		<impls>
-			<impl>openj9</impl>
+		<impls>	
+			<impl>openj9</impl>	
 		</impls>
-		<disabled>AdoptOpenJDK/openjdk-systemtest/issues/234</disabled>
+		<platformRequirements>^os.osx</platformRequirements>
 	</test>
-	<!-- exclude from all platforms due to https://github.com/eclipse/openj9/issues/234 -->
 	<test>
-		<testCaseName>MauveSingleInvocationLoadTest_HS</testCaseName>
+		<testCaseName>MauveSingleInvocationLoadTest_HotSpot</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -160,41 +94,12 @@
 		<groups>
 			<group>system</group>
 		</groups>
-		<impls>
-			<impl>hotspot</impl>
+		<impls>	
+			<impl>hotspot</impl>	
 		</impls>
-		<disabled>AdoptOpenJDK/openjdk-systemtest/issues/234</disabled>
 	</test>
 	
-	<!-- exclude on JDK8 openj9 on osx https://github.com/eclipse/openj9/issues/4091 -->
-	<test>
-		<testCaseName>MauveMultiThreadLoadTest_OpenJ9_JDK8</testCaseName>
-		<variations>
-			<variation>NoOptions</variation>
-		</variations>
-		<command>export JAVA_HOME=$(JDK_HOME)$(D)  $(AND_IF_SUCCESS) \
-	perl $(SYSTEMTEST_RESROOT)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
-	-test-root=$(Q)$(SYSTEMTEST_RESROOT)$(D)stf;$(SYSTEMTEST_RESROOT)$(D)openjdk-systemtest$(Q) \
-	-systemtest-prereqs=$(Q)$(SYSTEMTEST_RESROOT)$(D)systemtest_prereqs$(Q)  \
-	-java-args=$(Q)$(JVM_OPTIONS)$(Q) \
-	-results-root=$(REPORTDIR)  \
-	-test=MauveMultiThreadLoadTest; \
-	$(TEST_STATUS)</command>
-		<levels>
-			<level>sanity</level>
-		</levels>
-		<groups>
-			<group>system</group>
-		</groups>
-		<subsets>
-			<subset>8</subset>
-		</subsets>
-		<impls>
-			<impl>openj9</impl>
-		</impls>
-		<platformRequirements>^os.osx,^os.linux</platformRequirements>
-	</test>
-	<!-- Disabled from all platforms on JDK11 ands JDK12 due to : https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/235 -->
+	<!-- Disabled from OpenJ9 on osx due to : https://github.com/eclipse/openj9/issues/4091 -->
 	<test>
 		<testCaseName>MauveMultiThreadLoadTest_OpenJ9</testCaseName>
 		<variations>
@@ -214,13 +119,10 @@
 		<groups>
 			<group>system</group>
 		</groups>
-		<subsets>
-			<subset>11+</subset>
-		</subsets>
-		<impls>
-			<impl>openj9</impl>
+		<impls>	
+			<impl>openj9</impl>	
 		</impls>
-		<disabled>https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/235</disabled>
+		<platformRequirements>^os.osx</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>MauveMultiThreadLoadTest_HS</testCaseName>
@@ -241,11 +143,11 @@
 		<groups>
 			<group>system</group>
 		</groups>
-		<impls>
-			<impl>hotspot</impl>
+		<impls>	
+			<impl>hotspot</impl>	
 		</impls>
 	</test>
-
+	
 	<test>
 		<testCaseName>MauveSingleThreadLoadTest_ConcurrentScavenge</testCaseName>
 		<variations>


### PR DESCRIPTION
Re-include all working mauve tests as failing sub-tests are disabled
Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>