### PR TITLE
Exclude failing tests

### DIFF
--- a/openjdk_regression/ProblemList_openjdk11-openj9.txt
+++ b/openjdk_regression/ProblemList_openjdk11-openj9.txt
@@ -118,6 +118,7 @@ java/lang/invoke/condy/CondyNestedTest.java https://github.com/eclipse/openj9/is
 java/lang/invoke/lambda/LambdaStackTrace.java	https://github.com/eclipse/openj9/issues/3394	generic-all
 java/lang/invoke/lambda/LogGeneratedClassesTest.java https://github.com/eclipse/openj9/issues/4771 linux-x64
 java/lang/module/AutomaticModulesTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/module/ModuleFinderTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/749	windows-all
 java/lang/ref/CleanerTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 java/lang/ref/EarlyTimeout.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 java/lang/ref/FinalizerHistogramTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
@@ -134,6 +135,7 @@ java/lang/reflect/Proxy/ProxyForMethodHandle.java	https://github.com/AdoptOpenJD
 java/lang/reflect/Proxy/ProxyLayerTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 java/lang/reflect/Proxy/ProxyModuleMapping.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 java/lang/reflect/PublicMethods/PublicMethodsTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+jdk/modules/scenarios/automaticmodules/RunWithAutomaticModules.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/749	windows-all
 
 ############################################################################
 
@@ -246,12 +248,12 @@ java/rmi/activation/Activatable/checkRegisterInLog/CheckRegisterInLog.java https
 java/rmi/activation/CommandEnvironment/SetChildEnv.java https://github.com/eclipse/openj9/issues/4778 windows-all
 java/rmi/dgc/dgcAckFailure/DGCAckFailure.java	https://github.com/eclipse/openj9/issues/3347	generic-all
 java/rmi/dgc/retryDirtyCalls/RetryDirtyCalls.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/rmi/module/ModuleTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/749	windows-all
 java/rmi/server/RemoteServer/AddrInUse.java	https://github.com/eclipse/openj9/issues/3377	generic-all
 java/rmi/server/UnicastRemoteObject/serialFilter/FilterUROTest.java	https://github.com/eclipse/openj9/issues/3347	generic-all
 java/rmi/server/UnicastRemoteObject/unexportObject/UnexportLeak.java https://github.com/eclipse/openj9/issues/4094 generic-all
 java/rmi/server/UnicastServerRef/serialFilter/FilterUSRTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 java/rmi/transport/runtimeThreadInheritanceLeak/RuntimeThreadInheritanceLeak.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
-
 ############################################################################
 
 # jdk_security

--- a/openjdk_regression/ProblemList_openjdk11.txt
+++ b/openjdk_regression/ProblemList_openjdk11.txt
@@ -22,7 +22,9 @@
 
 # jdk_lang
 java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	generic-all
+java/lang/module/ModuleFinderTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/749	windows-all
 java/lang/String/nativeEncoding/StringPlatformChars.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	generic-all
+jdk/modules/scenarios/automaticmodules/RunWithAutomaticModules.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/749	windows-all
 ############################################################################
 
 # jdk_management
@@ -96,7 +98,7 @@ jdk/nio/zipfs/ZipFSTester.java	https://github.com/AdoptOpenJDK/openjdk-tests/iss
 ############################################################################ 
 
 # jdk_rmi
-
+java/rmi/module/ModuleTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/749	windows-all
 ############################################################################
 
 # jdk_security

--- a/openjdk_regression/ProblemList_openjdk12-openj9.txt
+++ b/openjdk_regression/ProblemList_openjdk12-openj9.txt
@@ -130,6 +130,7 @@ java/lang/invoke/condy/CondyTypeValidationTest.java https://github.com/eclipse/o
 java/lang/invoke/lambda/LambdaStackTrace.java	https://github.com/eclipse/openj9/issues/3394	generic-all
 java/lang/invoke/lambda/LogGeneratedClassesTest.java https://github.com/eclipse/openj9/issues/4771 linux-x64
 java/lang/module/AutomaticModulesTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/module/ModuleFinderTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/749	windows-all
 java/lang/ref/CleanerTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 java/lang/ref/EarlyTimeout.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 java/lang/ref/FinalizerHistogramTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
@@ -146,6 +147,8 @@ java/lang/reflect/Proxy/ProxyForMethodHandle.java	https://github.com/AdoptOpenJD
 java/lang/reflect/Proxy/ProxyLayerTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 java/lang/reflect/Proxy/ProxyModuleMapping.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 java/lang/reflect/PublicMethods/PublicMethodsTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+jdk/modules/scenarios/automaticmodules/RunWithAutomaticModules.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/749	windows-all
+vm/JniInvocationTest.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	macosx-all
 
 ############################################################################
 
@@ -256,6 +259,7 @@ java/rmi/activation/Activatable/checkRegisterInLog/CheckRegisterInLog.java https
 java/rmi/activation/CommandEnvironment/SetChildEnv.java https://github.com/eclipse/openj9/issues/4778 windows-all
 java/rmi/dgc/dgcAckFailure/DGCAckFailure.java	https://github.com/eclipse/openj9/issues/3347	generic-all
 java/rmi/dgc/retryDirtyCalls/RetryDirtyCalls.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/rmi/module/ModuleTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/749	windows-all
 java/rmi/server/RemoteServer/AddrInUse.java	https://github.com/eclipse/openj9/issues/3377	generic-all
 java/rmi/server/UnicastRemoteObject/serialFilter/FilterUROTest.java	https://github.com/eclipse/openj9/issues/3347	generic-all
 java/rmi/server/UnicastRemoteObject/unexportObject/UnexportLeak.java https://github.com/eclipse/openj9/issues/4094 generic-all

--- a/openjdk_regression/ProblemList_openjdk12.txt
+++ b/openjdk_regression/ProblemList_openjdk12.txt
@@ -22,7 +22,10 @@
 
 # jdk_lang
 java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	generic-all
+java/lang/module/ModuleFinderTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/749	windows-all
 java/lang/String/nativeEncoding/StringPlatformChars.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	generic-all
+jdk/modules/scenarios/automaticmodules/RunWithAutomaticModules.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/749	windows-all
+vm/JniInvocationTest.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	macosx-all
 ############################################################################
 
 # jdk_management
@@ -96,7 +99,7 @@ jdk/nio/zipfs/ZipFSTester.java	https://github.com/AdoptOpenJDK/openjdk-tests/iss
 ############################################################################ 
 
 # jdk_rmi
-
+java/rmi/module/ModuleTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/749	windows-all
 ############################################################################
 
 # jdk_security


### PR DESCRIPTION
This change covers the exclusion of multiple failing openjdk
regression tests, along with the link to the issues that document
the failures.

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>