### PR TITLE
Enable sun/rmi/rmic/manifestClassPath/run.sh

### DIFF
--- a/openjdk_regression/ProblemList_openjdk8-openj9.txt
+++ b/openjdk_regression/ProblemList_openjdk8-openj9.txt
@@ -218,7 +218,6 @@ java/rmi/server/RemoteServer/AddrInUse.java	https://github.com/AdoptOpenJDK/open
 java/rmi/activation/Activatable/checkAnnotations/CheckAnnotations.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/830	macosx-all
 java/rmi/activation/Activatable/nestedActivate/NestedActivate.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/830	macosx-all
 java/rmi/server/RMISocketFactory/useSocketFactory/activatable/UseCustomSocketFactory.java	https://github.com/eclipse/openj9/issues/4685	linux-ppc64le
-sun/rmi/rmic/manifestClassPath/run.sh	https://github.com/eclipse/openj9/issues/5061	mocosx-all
 java/rmi/activation/Activatable/checkActivateRef/CheckActivateRef.java	https://github.com/eclipse/openj9/issues/5049	macosx-all
 java/rmi/activation/Activatable/createPrivateActivable/CreatePrivateActivatable.java	https://github.com/eclipse/openj9/issues/5049	macosx-all
 ############################################################################


### PR DESCRIPTION
Enable `sun/rmi/rmic/manifestClassPath/run.sh` for `Java 8 mocosx-all`

The failure can't be reproduced in grinders, re-enable the test for `Java8 macosx-all`.

Related: https://github.com/eclipse/openj9/issues/5061

Reviewer: @ShelleyLambert 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>