### PR TITLE
Set separate elasticsearch_test for hotspot and openj9

### DIFF
--- a/thirdparty_containers/elasticsearch/dockerfile/Dockerfile
+++ b/thirdparty_containers/elasticsearch/dockerfile/Dockerfile
@@ -70,4 +70,4 @@ WORKDIR /
 
 #ENTRYPOINT ["/bin/bash", "/example-test.sh"]
 ENTRYPOINT ["/bin/bash", "/elasticsearch-test.sh"]
-CMD ["--version"]
+CMD [""]

--- a/thirdparty_containers/elasticsearch/dockerfile/elasticsearch-test.sh
+++ b/thirdparty_containers/elasticsearch/dockerfile/elasticsearch-test.sh
@@ -34,7 +34,7 @@ else
 	export JAVA_HOME="${java_root%/bin}"
 fi
 
-TEST_SUITE=$1
+TEST_OPTIONS=$1
 
 java -version
 
@@ -50,4 +50,5 @@ echo "Building elasticsearch  using gradlew \"gradlew assemble\"" && \
 echo "Elasticsearch Build - Completed"
 
 echo "Running elasticsearch tests :"
-./gradlew -g /tmp test -Dtests.haltonfailure=false
+
+./gradlew -g /tmp test -Dtests.haltonfailure=false $TEST_OPTIONS

--- a/thirdparty_containers/elasticsearch/playlist.xml
+++ b/thirdparty_containers/elasticsearch/playlist.xml
@@ -14,7 +14,36 @@
 -->
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
 	<test>
-		<testCaseName>elasticsearch_test</testCaseName>
+		<testCaseName>elasticsearch_test_openj9</testCaseName>
+		<command>docker run --name elasticsearch-test $(EXTRA_DOCKER_ARGS) adoptopenjdk-elasticsearch-test:latest \
+		 "--exclude-task :core:test \
+		 --exclude-task :client:rest:test \
+		 --exclude-task :modules:reindex:test \
+		 --exclude-task :client:transport:test \
+		 --exclude-task :client:sniffer:test \
+		 --exclude-task :test:framework:test \
+		 --exclude-task :modules:lang-painless:test"; \
+			$(TEST_STATUS); \
+			docker cp elasticsearch-test:/elasticsearch/modules/transport-netty4/build/reports/testJunit $(REPORTDIR)/external_test_reports; \
+			docker cp elasticsearch-test:/elasticsearch/modules/lang-mustache/build/reports/testJunit $(REPORTDIR)/external_test_reports; \
+			docker cp elasticsearch-test:/elasticsearch/modules/percolator/build/reports/testJunit $(REPORTDIR)/external_test_reports; \
+			docker cp elasticsearch-test:/elasticsearch/modules/parent-join/build/reports/testJunit $(REPORTDIR)/external_test_reports; \
+			docker cp elasticsearch-test:/elasticsearch/test/logger-usage/build/reports/testJunit $(REPORTDIR)/external_test_reports; \
+			docker rm -f elasticsearch-test; \
+			docker rmi -f adoptopenjdk-elasticsearch-test
+		</command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>external</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+		</impls>
+	</test>
+	<test>
+		<testCaseName>elasticsearch_test_hotspot</testCaseName>
 		<command>docker run --name elasticsearch-test $(EXTRA_DOCKER_ARGS) adoptopenjdk-elasticsearch-test:latest; \
 			$(TEST_STATUS); \
 			docker cp elasticsearch-test:/elasticsearch/core/build/reports/testJunit $(REPORTDIR)/external_test_reports; \
@@ -35,5 +64,8 @@
 		<groups>
 			<group>external</group>
 		</groups>
+		<impls>
+			<impl>hotspot</impl>
+		</impls>
 	</test>
 </playlist>


### PR DESCRIPTION
1. Set separate testcases so each can run different test tasks
2. Exclude failure tests with openj9, which looks like some of
permissions required are due to the application specific JVM check for
Hotspots.

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>