### PR TITLE
No longer shallow clone OpenJ9

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -217,7 +217,7 @@ getTestKitGenAndFunctionalTestMaterial()
 	fi
 
 	echo "git clone $OPENJ9_BRANCH $OPENJ9_REPO"
-	git clone -q --depth 1 $OPENJ9_BRANCH $OPENJ9_REPO
+	git clone -q $OPENJ9_BRANCH $OPENJ9_REPO
 
 	if [ "$OPENJ9_SHA" != "" ]
 	then


### PR DESCRIPTION
When running a test build that passes a custom OpenJ9 SHA,
the current code that clones OpenJ9 does a depth 1
followed by a fetch of the pull refs and a checkout of the
specified SHA. This often fails with 'fatal: reference
is not a tree'. Which means the SHA doesn't exist in the
git data that has been fetched. The situation in which this
occurs is when the SHA you are trying to checkout is not
at the HEAD of the shallow branch that is cloned AND the SHA
also does not exist in any of the pull refs that were fetched.
This occurs in a build when a change is added to the branch
after the compile has started but before it has finished and
laucnhed a test job.
Usually if you are cloning github.com/eclipse/openj9 you
will fetch all the necessary SHAs becasue all the changes
have gone through pulls at that repo. If you are cloning
any other repo, the pull refs will have little to no SHAs
becasue that repo will ave a different set of pull refs.
Removing the depth 1 should allow the clone to fetch all
the SHAs for that repo while the extra fetch of the pull
refs will still allow pull request builds to function.

Signed-off-by: Adam Brousseau <adam.brousseau@ca.ibm.com>