### PR TITLE
Update external elasticsearch tests junit cp story

### DIFF
--- a/thirdparty_containers/elasticsearch/dockerfile/Dockerfile
+++ b/thirdparty_containers/elasticsearch/dockerfile/Dockerfile
@@ -60,13 +60,15 @@ ARG ELASTIC_VERSION=.
 WORKDIR elasticsearch
 RUN git checkout $ELASTIC_VERSION
 
+WORKDIR /
+RUN mkdir testResults
 RUN chown -R elasticsearch /elasticsearch
 RUN chown -R elasticsearch /elasticsearch-test.sh
-
+RUN chown -R elasticsearch /testResults
 RUN chmod -R a+x /elasticsearch
 
 USER elasticsearch
-WORKDIR /
+
 
 #ENTRYPOINT ["/bin/bash", "/example-test.sh"]
 ENTRYPOINT ["/bin/bash", "/elasticsearch-test.sh"]

--- a/thirdparty_containers/elasticsearch/dockerfile/elasticsearch-test.sh
+++ b/thirdparty_containers/elasticsearch/dockerfile/elasticsearch-test.sh
@@ -52,3 +52,5 @@ echo "Elasticsearch Build - Completed"
 echo "Running elasticsearch tests :"
 
 ./gradlew -g /tmp test -Dtests.haltonfailure=false $TEST_OPTIONS
+
+find ./ -type d -name 'testJunit' -exec cp -r "{}" /testResults \;

--- a/thirdparty_containers/elasticsearch/playlist.xml
+++ b/thirdparty_containers/elasticsearch/playlist.xml
@@ -24,11 +24,7 @@
 		 --exclude-task :test:framework:test \
 		 --exclude-task :modules:lang-painless:test"; \
 			$(TEST_STATUS); \
-			docker cp elasticsearch-test:/elasticsearch/modules/transport-netty4/build/reports/testJunit $(REPORTDIR)/external_test_reports; \
-			docker cp elasticsearch-test:/elasticsearch/modules/lang-mustache/build/reports/testJunit $(REPORTDIR)/external_test_reports; \
-			docker cp elasticsearch-test:/elasticsearch/modules/percolator/build/reports/testJunit $(REPORTDIR)/external_test_reports; \
-			docker cp elasticsearch-test:/elasticsearch/modules/parent-join/build/reports/testJunit $(REPORTDIR)/external_test_reports; \
-			docker cp elasticsearch-test:/elasticsearch/test/logger-usage/build/reports/testJunit $(REPORTDIR)/external_test_reports; \
+			docker cp elasticsearch-test:/testResults/testJunit $(REPORTDIR)/external_test_reports; \
 			docker rm -f elasticsearch-test; \
 			docker rmi -f adoptopenjdk-elasticsearch-test
 		</command>
@@ -46,15 +42,7 @@
 		<testCaseName>elasticsearch_test_hotspot</testCaseName>
 		<command>docker run --name elasticsearch-test $(EXTRA_DOCKER_ARGS) adoptopenjdk-elasticsearch-test:latest; \
 			$(TEST_STATUS); \
-			docker cp elasticsearch-test:/elasticsearch/core/build/reports/testJunit $(REPORTDIR)/external_test_reports; \
-			docker cp elasticsearch-test:/elasticsearch/modules/transport-netty4/build/reports/testJunit $(REPORTDIR)/external_test_reports; \
-			docker cp elasticsearch-test:/elasticsearch/modules/lang-mustache/build/reports/testJunit $(REPORTDIR)/external_test_reports; \
-			docker cp elasticsearch-test:/elasticsearch/modules/percolator/build/reports/testJunit $(REPORTDIR)/external_test_reports; \
-			docker cp elasticsearch-test:/elasticsearch/modules/reindex/build/reports/testJunit $(REPORTDIR)/external_test_reports; \
-			docker cp elasticsearch-test:/elasticsearch/modules/parent-join/build/reports/testJunit $(REPORTDIR)/external_test_reports; \
-			docker cp elasticsearch-test:/elasticsearch/test/framework/build/reports/testJunit $(REPORTDIR)/external_test_reports; \
-			docker cp elasticsearch-test:/elasticsearch/test/logger-usage/build/reports/testJunit $(REPORTDIR)/external_test_reports; \
-			docker cp elasticsearch-test:/elasticsearch/client/rest/build/reports/testJunit $(REPORTDIR)/external_test_reports; \
+			docker cp elasticsearch-test:/testResults/testJunit $(REPORTDIR)/external_test_reports; \
 			docker rm -f elasticsearch-test; \
 			docker rmi -f adoptopenjdk-elasticsearch-test
 		</command>


### PR DESCRIPTION
Find existing junit reports and cp instead of hard-coded as paths could
always be changing.

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>