### PR TITLE
No longer setup on master node

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -437,12 +437,6 @@ def getJDKImpl(jvm_version) {
 	return jdk_impl
 }
 
-def setLabelParam() {
-	if( params.LABEL ) {
-		LABEL = params.LABEL
-	}
-}
-
 def addJobDescription() {
 	if (params.PERSONAL_BUILD) {
 		// update build name if personal build

--- a/buildenv/jenkins/openjdk_aarch32_linux
+++ b/buildenv/jenkins/openjdk_aarch32_linux
@@ -1,15 +1,8 @@
 #!groovy
 LABEL='ci.role.test&&sw.os.linux&&hw.arch.aarch32'
 
-node ("master") {
-    checkout scm
-    def jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
-    jenkinsfile.setLabelParam()
-    cleanWs()
-}
-
 stage('Queue') {
-    node("$LABEL") {
+    node((params.LABEL) ? params.LABEL : LABEL) {
         PLATFORM = 'aarch32_linux'
         SDK_RESOURCE = 'upstream'
         SPEC='linux_arm'

--- a/buildenv/jenkins/openjdk_aarch64_linux
+++ b/buildenv/jenkins/openjdk_aarch64_linux
@@ -1,15 +1,8 @@
 #!groovy
 LABEL='ci.role.test&&sw.os.linux&&hw.arch.aarch64'
 
-node ("master") {
-    checkout scm
-    def jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
-    jenkinsfile.setLabelParam()
-    cleanWs()
-}
-
 stage('Queue') {
-    node("$LABEL") {
+    node((params.LABEL) ? params.LABEL : LABEL) {
         PLATFORM = 'aarch64_linux'
         SDK_RESOURCE = 'upstream'
         SPEC='linux_aarch64_cmprssptrs'

--- a/buildenv/jenkins/openjdk_ppc64_aix
+++ b/buildenv/jenkins/openjdk_ppc64_aix
@@ -1,15 +1,8 @@
 #!groovy
 LABEL='ci.role.test&&hw.arch.ppc64&&sw.os.aix'
 
-node ("master") {
-    checkout scm
-    def jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
-    jenkinsfile.setLabelParam()
-    cleanWs()
-}
-
 stage('Queue') {
-    node("$LABEL") {
+    node((params.LABEL) ? params.LABEL : LABEL) {
         PLATFORM = 'ppc64_aix'
         SDK_RESOURCE = 'upstream'
         SPEC='aix_ppc-64_cmprssptrs'

--- a/buildenv/jenkins/openjdk_ppc64le_linux
+++ b/buildenv/jenkins/openjdk_ppc64le_linux
@@ -6,15 +6,8 @@ if (params.DOCKER_REQUIRED) {
     LABEL='ci.role.test&&hw.arch.ppc64le&&sw.os.linux'
 }
 
-node ("master") {
-    checkout scm
-    def jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
-    jenkinsfile.setLabelParam()
-    cleanWs()
-}
-
 stage('Queue') {
-    node("$LABEL") { //ppc64le build use "fedora" too, for now leave as is
+    node((params.LABEL) ? params.LABEL : LABEL) { //ppc64le build use "fedora" too, for now leave as is
         PLATFORM = 'ppc64le_linux'
         SDK_RESOURCE = 'upstream'
         SPEC='linux_ppc-64_cmprssptrs_le'

--- a/buildenv/jenkins/openjdk_s390x_linux
+++ b/buildenv/jenkins/openjdk_s390x_linux
@@ -7,15 +7,8 @@ if (params.DOCKER_REQUIRED) {
     LABEL='ci.role.test&&hw.arch.s390x&&sw.os.linux'
 }
 
-node ("master") {
-    checkout scm
-    def jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
-    jenkinsfile.setLabelParam()
-    cleanWs()
-}
-
 stage('Queue') {
-    node("$LABEL") {
+    node((params.LABEL) ? params.LABEL : LABEL) {
         PLATFORM = 's390x_linux'
         SDK_RESOURCE = 'upstream'
         SPEC='linux_390-64_cmprssptrs'

--- a/buildenv/jenkins/openjdk_s390x_zos
+++ b/buildenv/jenkins/openjdk_s390x_zos
@@ -5,15 +5,8 @@
     Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
 LABEL='ci.role.test&&hw.arch.s390x&&sw.os.zos'
 
-node ("master") {
-    checkout scm
-    def jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
-    jenkinsfile.setLabelParam()
-    cleanWs()
-}
-
 stage('Queue') {
-    node("$LABEL") {
+    node((params.LABEL) ? params.LABEL : LABEL) {
         PLATFORM = 's390x_zos'
         SDK_RESOURCE = 'upstream'
         SPEC='zos_390-64_cmprssptrs'

--- a/buildenv/jenkins/openjdk_x86-32_windows
+++ b/buildenv/jenkins/openjdk_x86-32_windows
@@ -5,15 +5,8 @@
 	Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
 LABEL='hw.arch.x86&&sw.os.windows'
 
-node ("master") {
-	checkout scm
-	def jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
-	jenkinsfile.setLabelParam()
-	cleanWs()
-}
-
 stage('Queue') {
-    node("$LABEL") {
+    node((params.LABEL) ? params.LABEL : LABEL) {
         PLATFORM = 'x32_windows'
         JAVA_VERSION = 'SE80'
         SDK_RESOURCE = 'upstream'

--- a/buildenv/jenkins/openjdk_x86-64_linux
+++ b/buildenv/jenkins/openjdk_x86-64_linux
@@ -6,15 +6,8 @@ if (params.DOCKER_REQUIRED) {
     LABEL='ci.role.test&&hw.arch.x86&&sw.os.linux'
 }
 
-node ("master") {
-    checkout scm
-    def jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
-    jenkinsfile.setLabelParam()
-    cleanWs()
-}
-
 stage('Queue') {
-    node("$LABEL") {
+    node((params.LABEL) ? params.LABEL : LABEL) {
         PLATFORM = 'x64_linux'
         SDK_RESOURCE = 'upstream'
         SPEC='linux_x86-64_cmprssptrs'

--- a/buildenv/jenkins/openjdk_x86-64_linux_largeHeap
+++ b/buildenv/jenkins/openjdk_x86-64_linux_largeHeap
@@ -6,15 +6,8 @@
 
 LABEL='ci.role.test&&hw.arch.x86&&sw.os.linux'
 
-node ("master") {
-    checkout scm
-    def jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
-    jenkinsfile.setLabelParam()
-    cleanWs()
-}
-
 stage('Queue') {
-    node("$LABEL") {
+    node((params.LABEL) ? params.LABEL : LABEL) {
         PLATFORM = 'x64_linux_largeHeap'
         SDK_RESOURCE = 'upstream'
         SPEC='linux_x86-64'

--- a/buildenv/jenkins/openjdk_x86-64_linux_xl
+++ b/buildenv/jenkins/openjdk_x86-64_linux_xl
@@ -1,15 +1,8 @@
 #!groovy
 LABEL='ci.role.test&&hw.arch.x86&&sw.os.linux'
 
-node ("master") {
-    checkout scm
-    def jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
-    jenkinsfile.setLabelParam()
-    cleanWs()
-}
-
 stage('Queue') {
-    node("$LABEL") {
+    node((params.LABEL) ? params.LABEL : LABEL) {
         PLATFORM = 'x64_linux_largeHeap'
         SDK_RESOURCE = 'upstream'
         SPEC='linux_x86-64'

--- a/buildenv/jenkins/openjdk_x86-64_mac
+++ b/buildenv/jenkins/openjdk_x86-64_mac
@@ -1,15 +1,8 @@
 #!groovy
 LABEL='ci.role.test&&hw.arch.x86&&sw.os.osx'
 
-node ("master") {
-    checkout scm
-    def jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
-    jenkinsfile.setLabelParam()
-    cleanWs()
-}
-
 stage('Queue') {
-    node("$LABEL") {
+    node((params.LABEL) ? params.LABEL : LABEL) {
         PLATFORM = 'x64_mac'
         SDK_RESOURCE = 'upstream'
         SPEC='osx_x86-64_cmprssptrs'

--- a/buildenv/jenkins/openjdk_x86-64_mac_xl
+++ b/buildenv/jenkins/openjdk_x86-64_mac_xl
@@ -1,15 +1,8 @@
 #!groovy
 LABEL='ci.role.test&&hw.arch.x86&&sw.os.osx'
 
-node ("master") {
-    checkout scm
-    def jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
-    jenkinsfile.setLabelParam()
-    cleanWs()
-}
-
 stage('Queue') {
-    node("$LABEL") {
+    node((params.LABEL) ? params.LABEL : LABEL) {
         PLATFORM = 'x64_mac_largeHeap'
         SDK_RESOURCE = 'upstream'
         SPEC='osx_x86-64'

--- a/buildenv/jenkins/openjdk_x86-64_osx
+++ b/buildenv/jenkins/openjdk_x86-64_osx
@@ -6,15 +6,8 @@
 
 LABEL='ci.role.test&&hw.arch.x86&&sw.os.osx'
 
-node ("master") {
-    checkout scm
-    def jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
-    jenkinsfile.setLabelParam()
-    cleanWs()
-}
-
 stage('Queue') {
-    node("$LABEL") {
+    node((params.LABEL) ? params.LABEL : LABEL) {
         PLATFORM = 'x64_mac'
         SDK_RESOURCE = 'upstream'
         SPEC='osx_x86-64_cmprssptrs'

--- a/buildenv/jenkins/openjdk_x86-64_osx_largeHeap
+++ b/buildenv/jenkins/openjdk_x86-64_osx_largeHeap
@@ -5,15 +5,8 @@ LABEL='ci.role.test&&hw.arch.x86&&sw.os.osx'
 // This is a copy of openjdk_x86-64_mac_xl
 // Remove this file once all related test jobs are regenerated or updated to use openjdk_x86-64_mac_xl
 
-node ("master") {
-    checkout scm
-    def jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
-    jenkinsfile.setLabelParam()
-    cleanWs()
-}
-
 stage('Queue') {
-    node("$LABEL") {
+    node((params.LABEL) ? params.LABEL : LABEL) {
         PLATFORM = 'x64_mac_largeHeap'
         SDK_RESOURCE = 'upstream'
         SPEC='osx_x86-64'

--- a/buildenv/jenkins/openjdk_x86-64_windows
+++ b/buildenv/jenkins/openjdk_x86-64_windows
@@ -1,15 +1,8 @@
 #!groovy
 LABEL='ci.role.test&&hw.arch.x86&&sw.os.windows'
 
-node ("master") {
-    checkout scm
-    def jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
-    jenkinsfile.setLabelParam()
-    cleanWs()
-}
-
 stage('Queue') {
-    node("$LABEL") {
+    node((params.LABEL) ? params.LABEL : LABEL) {
         PLATFORM = 'x64_windows'
         SDK_RESOURCE = 'upstream'
         SPEC='win_x86-64_cmprssptrs'


### PR DESCRIPTION
Every test job is running a 'setup' step on master
which loads the repo in order to load and call a
function which sets up the LABEL param. I've moved
the function directly into the node call as a ternary
operation which saves the load on master. This should
improve build times and lighten the load on master.
The tradeoff being that the code is duplicated on
each file.

Signed-off-by: Adam Brousseau <adam.brousseau@ca.ibm.com>