### PR TITLE
Add machine info target

### DIFF
--- a/systemtest/daaLoadTest/playlist.xml
+++ b/systemtest/daaLoadTest/playlist.xml
@@ -1,6 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
 	<include>../systemtest.mk</include>
+
+	<!-- 
+	Special target to get machine information. This target is in each subfolder playlist.xml.
+	To avoid test target duplication, this belongs to sanity, extended and special. Regular test should only belong to one level -->
+	<test>
+		<testCaseName>MachineInfo</testCaseName>
+		<command>$(JAVA_COMMAND) -cp $(JVM_TEST_ROOT)$(D)TestConfig$(D)src$(D)EnvDetector.jar org.openj9.envInfo.EnvDetector MachineInfo; \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+			<level>extended</level>
+			<level>special</level>
+		</levels>
+		<groups>
+			<group>system</group>
+		</groups>
+	</test>
+
 	<!--  The following tests are specific to openj9 only -->
 	<test>
 		<testCaseName>DaaLoadTest_daa1</testCaseName>

--- a/systemtest/jlm/playlist.xml
+++ b/systemtest/jlm/playlist.xml
@@ -1,6 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
 	<include>../systemtest.mk</include>
+	
+	<!-- 
+	Special target to get machine information. This target is in each subfolder playlist.xml.
+	To avoid test target duplication, this belongs to sanity, extended and special. Regular test should only belong to one level -->
+	<test>
+		<testCaseName>MachineInfo</testCaseName>
+		<command>$(JAVA_COMMAND) -cp $(JVM_TEST_ROOT)$(D)TestConfig$(D)src$(D)EnvDetector.jar org.openj9.envInfo.EnvDetector MachineInfo; \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+			<level>extended</level>
+			<level>special</level>
+		</levels>
+		<groups>
+			<group>system</group>
+		</groups>
+	</test>
+	
 	<!-- Excluding the following test for Hotspot & OpenJDK10-OpenJ9 and JDK11 for eclipse/openj9/issues/1566  -->
 	<test>
 		<testCaseName>TestJlmLocal</testCaseName>

--- a/systemtest/lambdaLoadTest/playlist.xml
+++ b/systemtest/lambdaLoadTest/playlist.xml
@@ -1,6 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
 	<include>../systemtest.mk</include>
+	<!-- 
+	Special target to get machine information. This target is in each subfolder playlist.xml.
+	To avoid test target duplication, this belongs to sanity, extended and special. Regular test should only belong to one level -->
+	<test>
+		<testCaseName>MachineInfo</testCaseName>
+		<command>$(JAVA_COMMAND) -cp $(JVM_TEST_ROOT)$(D)TestConfig$(D)src$(D)EnvDetector.jar org.openj9.envInfo.EnvDetector MachineInfo; \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+			<level>extended</level>
+			<level>special</level>
+		</levels>
+		<groups>
+			<group>system</group>
+		</groups>
+	</test>
+	
 	<!-- Exclude LambdaLoad test on Linux x64 non-compressedrefs sdks for OpenJ9 builds only,
 		Reason: https://github.com/eclipse/openj9/issues/2209)-->
 	<test>

--- a/systemtest/mathLoadTest/playlist.xml
+++ b/systemtest/mathLoadTest/playlist.xml
@@ -2,6 +2,23 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
 	<include>../systemtest.mk</include>
 
+	<!-- 
+	Special target to get machine information. This target is in each subfolder playlist.xml.
+	To avoid test target duplication, this belongs to sanity, extended and special. Regular test should only belong to one level -->
+	<test>
+		<testCaseName>MachineInfo</testCaseName>
+		<command>$(JAVA_COMMAND) -cp $(JVM_TEST_ROOT)$(D)TestConfig$(D)src$(D)EnvDetector.jar org.openj9.envInfo.EnvDetector MachineInfo; \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+			<level>extended</level>
+			<level>special</level>
+		</levels>
+		<groups>
+			<group>system</group>
+		</groups>
+	</test>
+	
 	<test>
 		<testCaseName>MathLoadTest_all</testCaseName>
 		<variations>

--- a/systemtest/mauveLoadTest/playlist.xml
+++ b/systemtest/mauveLoadTest/playlist.xml
@@ -1,6 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
 	<include>../systemtest.mk</include>
+
+	<!-- 
+	Special target to get machine information. This target is in each subfolder playlist.xml.
+	To avoid test target duplication, this belongs to sanity, extended and special. Regular test should only belong to one level -->
+	<test>
+		<testCaseName>MachineInfo</testCaseName>
+		<command>$(JAVA_COMMAND) -cp $(JVM_TEST_ROOT)$(D)TestConfig$(D)src$(D)EnvDetector.jar org.openj9.envInfo.EnvDetector MachineInfo; \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+			<level>extended</level>
+			<level>special</level>
+		</levels>
+		<groups>
+			<group>system</group>
+		</groups>
+	</test>
+	
 	<!-- Disabled from OpenJ9 on osx due to : https://github.com/eclipse/openj9/issues/4091 -->
 	<test>
 		<testCaseName>MauveSingleThreadLoadTest_OpenJ9</testCaseName>

--- a/systemtest/modularity/playlist.xml
+++ b/systemtest/modularity/playlist.xml
@@ -2,6 +2,23 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
 	<include>../systemtest.mk</include>
 
+	<!-- 
+	Special target to get machine information. This target is in each subfolder playlist.xml.
+	To avoid test target duplication, this belongs to sanity, extended and special. Regular test should only belong to one level -->
+	<test>
+		<testCaseName>MachineInfo</testCaseName>
+		<command>$(JAVA_COMMAND) -cp $(JVM_TEST_ROOT)$(D)TestConfig$(D)src$(D)EnvDetector.jar org.openj9.envInfo.EnvDetector MachineInfo; \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+			<level>extended</level>
+			<level>special</level>
+		</levels>
+		<groups>
+			<group>system</group>
+		</groups>
+	</test>
+	
 	<!-- Tests below pertain to Java 9 Modularity -->
 	<test>
 		<testCaseName>CpMpTest_CpMp</testCaseName>

--- a/systemtest/otherLoadTest/playlist.xml
+++ b/systemtest/otherLoadTest/playlist.xml
@@ -2,6 +2,23 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
 	<include>../systemtest.mk</include>
 
+	<!-- 
+	Special target to get machine information. This target is in each subfolder playlist.xml.
+	To avoid test target duplication, this belongs to sanity, extended and special. Regular test should only belong to one level -->
+	<test>
+		<testCaseName>MachineInfo</testCaseName>
+		<command>$(JAVA_COMMAND) -cp $(JVM_TEST_ROOT)$(D)TestConfig$(D)src$(D)EnvDetector.jar org.openj9.envInfo.EnvDetector MachineInfo; \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+			<level>extended</level>
+			<level>special</level>
+		</levels>
+		<groups>
+			<group>system</group>
+		</groups>
+	</test>
+	
 	<test>
 		<testCaseName>ClassLoadingTest</testCaseName>
 		<variations>

--- a/systemtest/sharedClasses/playlist.xml
+++ b/systemtest/sharedClasses/playlist.xml
@@ -2,6 +2,23 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
 	<include>../systemtest.mk</include>
 
+	<!-- 
+	Special target to get machine information. This target is in each subfolder playlist.xml.
+	To avoid test target duplication, this belongs to sanity, extended and special. Regular test should only belong to one level -->
+	<test>
+		<testCaseName>MachineInfo</testCaseName>
+		<command>$(JAVA_COMMAND) -cp $(JVM_TEST_ROOT)$(D)TestConfig$(D)src$(D)EnvDetector.jar org.openj9.envInfo.EnvDetector MachineInfo; \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+			<level>extended</level>
+			<level>special</level>
+		</levels>
+		<groups>
+			<group>system</group>
+		</groups>
+	</test>
+	
 	<test>
 		<testCaseName>SharedClassesAPI</testCaseName>
 		<variations>


### PR DESCRIPTION
add MachineInfo target into all system test subfolder playlist.xml 
- to get machine info
- to avoid parallel build failure when there is no test executed

Signed-off-by: lanxia <lan_xia@ca.ibm.com>