### PR TITLE
openliberty_microprofile_tck updates

### DIFF
--- a/thirdparty_containers/elasticsearch/dockerfile/Dockerfile
+++ b/thirdparty_containers/elasticsearch/dockerfile/Dockerfile
@@ -34,15 +34,8 @@ RUN groupadd -g 1000 elasticsearch && useradd elasticsearch -u 1000 -g 1000
 # Install test dependent executable files
 RUN apt-get update \
 	&& apt-get -y install \
-	ant \
-	apt-transport-https \
-	ca-certificates \
-	dirmngr \
-	curl \
 	git \
-	make \
 	unzip \
-	vim \
 	wget
 
 VOLUME ["/java"]
@@ -58,7 +51,7 @@ RUN git clone -q https://github.com/elastic/elasticsearch.git
 #default is HEAD
 ARG ELASTIC_VERSION=.
 WORKDIR elasticsearch
-RUN git checkout $ELASTIC_VERSION
+RUN git checkout -q $ELASTIC_VERSION
 
 WORKDIR /
 RUN mkdir testResults

--- a/thirdparty_containers/elasticsearch/dockerfile/elasticsearch-test.sh
+++ b/thirdparty_containers/elasticsearch/dockerfile/elasticsearch-test.sh
@@ -40,17 +40,14 @@ java -version
 
 # Initial command to trigger the execution of elasticsearch test 
 cd /elasticsearch
-ls .
-pwd
 
 echo "Building elasticsearch  using gradlew \"gradlew assemble\"" && \
-./gradlew -g /tmp assemble
+./gradlew -q -g /tmp assemble
 
 
 echo "Elasticsearch Build - Completed"
 
 echo "Running elasticsearch tests :"
 
-./gradlew -g /tmp test -Dtests.haltonfailure=false $TEST_OPTIONS
-
+./gradlew -q -g /tmp test -Dtests.haltonfailure=false $TEST_OPTIONS
 find ./ -type d -name 'testJunit' -exec cp -r "{}" /testResults \;

--- a/thirdparty_containers/openliberty-mp-tck/dockerfile/Dockerfile
+++ b/thirdparty_containers/openliberty-mp-tck/dockerfile/Dockerfile
@@ -37,9 +37,7 @@ RUN apt-get update \
 	dirmngr \
 	curl \
 	git \
-	make \
 	unzip \
-	vim \
 	wget
 	
 # Install openliberty-mp-tck tests dependent
@@ -50,6 +48,7 @@ RUN apt-get update \
 
 WORKDIR /
 ENV OPENLIBERTY_HOME $WORKDIR
+RUN mkdir testResults
 
 VOLUME ["/java"]
 ENV JAVA_HOME=/java \
@@ -59,7 +58,7 @@ ENV JAVA_HOME=/java \
 COPY ./dockerfile/openliberty-mp-tck.sh /openliberty-mp-tck.sh
 
 #Clone openliberty repo 
-RUN git clone git://github.com/OpenLiberty/open-liberty
+RUN git clone -q git://github.com/OpenLiberty/open-liberty
 
 ENTRYPOINT ["/bin/bash", "/openliberty-mp-tck.sh"]
-CMD ["--version"]
+CMD [""]

--- a/thirdparty_containers/openliberty-mp-tck/dockerfile/openliberty-mp-tck.sh
+++ b/thirdparty_containers/openliberty-mp-tck/dockerfile/openliberty-mp-tck.sh
@@ -17,13 +17,11 @@ if [ -d /java/jre/bin ];then
 	export JAVA_BIN=/java/jre/bin
 	export JAVA_HOME=/java
 	export PATH=$JAVA_BIN:$PATH
-	java -version
 elif [ -d /java/bin ]; then
 	echo "Using mounted Java"
 	export JAVA_BIN=/java/bin
 	export JAVA_HOME=/java
 	export PATH=$JAVA_BIN:$PATH
-	java -version
 else
 	echo "Using docker image default Java"
 	java_path=$(type -p java)
@@ -31,34 +29,44 @@ else
 	java_root=${java_path%$suffix}
 	export JAVA_BIN="$java_root"
 	echo "JAVA_BIN is: $JAVA_BIN"
-	$JAVA_BIN/java -version
 	export JAVA_HOME="${java_root%/bin}"
 fi
 
+java -version
 cd ${OPENLIBERTY_HOME}/open-liberty/dev
 
 #Build all projects and create the open-liberty image
-./gradlew cnf:initialize
-./gradlew releaseNeeded
+./gradlew -q cnf:initialize
+./gradlew -q releaseNeeded
 
+echo "Build projects and create images done"
+
+#Following are not enabled tests, may need to enable later
+#com.ibm.ws.microprofile.reactive.streams.operators_fat_tck
+#com.ibm.ws.concurrent.mp_fat_tck
+#com.ibm.ws.microprofile.config_git_fat_tck
+#com.ibm.ws.security.mp.jwt_fat_tck
+#com.ibm.ws.microprofile.faulttolerance_git_fat_tck
 
 #Exclude Metrics TCK
 #Start MicroProfile Metrics TCK
-#./gradlew com.ibm.ws.microprofile.metrics.1.1_fat_tck:clean
-./gradlew com.ibm.ws.microprofile.metrics.1.1_fat_tck:buildandrun
+./gradlew -q com.ibm.ws.microprofile.metrics_fat_tck:clean
+./gradlew -q com.ibm.ws.microprofile.metrics_fat_tck:buildandrun
 
 #Start MicroProfile Config TCK
-./gradlew com.ibm.ws.microprofile.config_fat_tck:clean
-./gradlew com.ibm.ws.microprofile.config_fat_tck:buildandrun
+./gradlew -q com.ibm.ws.microprofile.config.1.4_fat_tck:clean
+./gradlew -q com.ibm.ws.microprofile.config.1.4_fat_tck:buildandrun
 
 #Start MicroProfile FaultTolerance TCK
-./gradlew com.ibm.ws.microprofile.faulttolerance_fat_tck:clean
-./gradlew com.ibm.ws.microprofile.faulttolerance_fat_tck:buildandrun
+./gradlew -q com.ibm.ws.microprofile.faulttolerance_fat_tck:clean
+./gradlew -q com.ibm.ws.microprofile.faulttolerance_fat_tck:buildandrun
 
 #Start MicroProfile Rest Client TCK
-./gradlew com.ibm.ws.microprofile.rest.client_fat_tck:clean
-./gradlew com.ibm.ws.microprofile.rest.client_fat_tck:buildandrun
+./gradlew -q com.ibm.ws.microprofile.rest.client_fat_tck:clean
+./gradlew -q com.ibm.ws.microprofile.rest.client_fat_tck:buildandrun
 
 #Start MicroProfile OpenAPI TCK
-./gradlew com.ibm.ws.microprofile.openapi_fat_tck:clean
-./gradlew com.ibm.ws.microprofile.openapi_fat_tck:buildandrun
+./gradlew -q com.ibm.ws.microprofile.openapi_fat_tck:clean
+./gradlew -q com.ibm.ws.microprofile.openapi_fat_tck:buildandrun
+
+find ./ -type d -name 'surefire-reports' -exec cp -r "{}" /testResults \;

--- a/thirdparty_containers/openliberty-mp-tck/playlist.xml
+++ b/thirdparty_containers/openliberty-mp-tck/playlist.xml
@@ -17,11 +17,7 @@
 		<testCaseName>openliberty_microprofile_tck</testCaseName>
 		<command>docker run --name openliberty-mp-tck $(EXTRA_DOCKER_ARGS) adoptopenjdk-openliberty-mp-tck:latest; \
 			$(TEST_STATUS); \
-			docker cp openliberty-mp-tck:/open-liberty/dev/com.ibm.ws.microprofile.metrics.1.1_fat_tck/build/libs/autoFVT/results/tck/surefire-reports $(REPORTDIR)/external_test_reports; \
-			docker cp openliberty-mp-tck:/open-liberty/dev/com.ibm.ws.microprofile.config_fat_tck/build/libs/autoFVT/results/tck/surefire-reports $(REPORTDIR)/external_test_reports; \
-			docker cp openliberty-mp-tck:/open-liberty/dev/com.ibm.ws.microprofile.faulttolerance_fat_tck/build/libs/autoFVT/results/tck/surefire-reports $(REPORTDIR)/external_test_reports; \
-			docker cp openliberty-mp-tck:/open-liberty/dev/com.ibm.ws.microprofile.rest.client_fat_tck/build/libs/autoFVT/results/tck/surefire-reports $(REPORTDIR)/external_test_reports; \
-			docker cp openliberty-mp-tck:/open-liberty/dev/com.ibm.ws.microprofile.openapi_fat_tck/build/libs/autoFVT/results/tck/surefire-reports $(REPORTDIR)/external_test_reports; \
+			docker cp openliberty-mp-tck:/testResults/surefire-reports $(REPORTDIR)/external_test_reports; \
 			docker rm -f openliberty-mp-tck; \
 			docker rmi -f adoptopenjdk-openliberty-mp-tck
 		</command>

--- a/thirdparty_containers/thorntail-mp-tck/dockerfile/Dockerfile
+++ b/thirdparty_containers/thorntail-mp-tck/dockerfile/Dockerfile
@@ -58,7 +58,7 @@ ENV JAVA_HOME=/java \
 COPY ./dockerfile/thorntail-mp-tck.sh /thorntail-mp-tck.sh
 
 #Clone thorntail repo 
-RUN git clone git://github.com/thorntail/thorntail 
+RUN git clone -q git://github.com/thorntail/thorntail 
 
 ENTRYPOINT ["/bin/bash", "/thorntail-mp-tck.sh"]
 CMD ["--version"]

--- a/thirdparty_containers/thorntail-mp-tck/dockerfile/thorntail-mp-tck.sh
+++ b/thirdparty_containers/thorntail-mp-tck/dockerfile/thorntail-mp-tck.sh
@@ -17,13 +17,11 @@ if [ -d /java/jre/bin ];then
 	export JAVA_BIN=/java/jre/bin
 	export JAVA_HOME=/java
 	export PATH=$JAVA_BIN:$PATH
-	java -version
 elif [ -d /java/bin ]; then
 	echo "Using mounted Java"
 	export JAVA_BIN=/java/bin
 	export JAVA_HOME=/java
 	export PATH=$JAVA_BIN:$PATH
-	java -version
 else
 	echo "Using docker image default Java"
 	java_path=$(type -p java)
@@ -31,10 +29,10 @@ else
 	java_root=${java_path%$suffix}
 	export JAVA_BIN="$java_root"
 	echo "JAVA_BIN is: $JAVA_BIN"
-	$JAVA_BIN/java -version
 	export JAVA_HOME="${java_root%/bin}"
 fi
 
+java -version
 cd ${THORNTAIL_HOME}/
 
 #Build Thorntail 


### PR DESCRIPTION
1. Update config_fat_tck to config.1.4_fat_tck as there is no
config_fat_tck package
2. Copy test result in script automatically instead of hard-code
loactions
3. Using gradlew and git quiet option to reduce unnecessary output
4. remove unnecessary dependency in docker

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>