### PR TITLE
Update MicroProfile TCK Runners against Payara

### DIFF
--- a/thirdparty_containers/payara-mp-tck/dockerfile/Dockerfile
+++ b/thirdparty_containers/payara-mp-tck/dockerfile/Dockerfile
@@ -32,12 +32,8 @@ FROM $IMAGE_NAME:$IMAGE_VERSION
 RUN apt-get update \
 	&& apt-get -y install \
 	ant \
-	apt-transport-https \
-	ca-certificates \
-	dirmngr \
 	curl \
 	git \
-	make \
 	unzip \
 	vim \
 	wget
@@ -48,6 +44,7 @@ RUN apt-get update \
 	maven
 
 WORKDIR /
+RUN mkdir testResults
 ENV PAYARA_HOME $WORKDIR
 
 VOLUME ["/java"]
@@ -57,14 +54,9 @@ ENV JAVA_HOME=/java \
 
 COPY ./dockerfile/payara-mp-tck.sh /payara-mp-tck.sh
 
-#Download and unzip Payara full distribution
-RUN curl -L -o /tmp/payara-5.182.zip https://search.maven.org/remotecontent?filepath=fish/payara/distributions/payara/5.182/payara-5.182.zip && \
-    unzip /tmp/payara-5.182.zip -d / && \
-    rm -f /tmp/payara-5.182.zip
-
 # Clone the Pyara MicroProfile-TCK-Runners
 RUN pwd
 RUN git clone https://github.com/payara/MicroProfile-TCK-Runners
 
 ENTRYPOINT ["/bin/bash", "/payara-mp-tck.sh"]
-CMD ["--version"]
+CMD [""]

--- a/thirdparty_containers/payara-mp-tck/dockerfile/payara-mp-tck.sh
+++ b/thirdparty_containers/payara-mp-tck/dockerfile/payara-mp-tck.sh
@@ -33,26 +33,10 @@ else
 fi
 
 java -version
-cd ${PAYARA_HOME}/
 
-#Start Payara server
-${PAYARA_HOME}/payara5/bin/asadmin start-domain
+TEST_OPTIONS=$1
 
-#Start MicroProfile-Metrics TCK
-cd ${PAYARA_HOME}/MicroProfile-TCK-Runners/MicroProfile-Metrics/tck-runner
-mvn -Ppayara-server-remote test
+cd ${PAYARA_HOME}/MicroProfile-TCK-Runners
+mvn clean verify -Dpayara.version=5.184 $TEST_OPTIONS
 
-#Start MicroProfile-Fault-Tolerance TCK
-cd ${PAYARA_HOME}/MicroProfile-TCK-Runners/MicroProfile-Fault-Tolerance/tck-runner
-mvn -Ppayara-server-remote test
-
-#Start MicroProfile-Config TCK
-cd ${PAYARA_HOME}/MicroProfile-TCK-Runners/MicroProfile-Config/tck-runner
-mvn -Ppayara-server-remote test
-
-#Start MicroProfile-OpenAPI TCK
-cd ${PAYARA_HOME}/MicroProfile-TCK-Runners/MicroProfile-OpenAPI/tck-runner
-mvn -Ppayara-server-remote test
-
-#Stop Payara server
-${PAYARA_HOME}/payara5/bin/asadmin stop-domain
+find ./ -type d -name 'junitreports' -exec cp -r "{}" /testResults \;

--- a/thirdparty_containers/payara-mp-tck/playlist.xml
+++ b/thirdparty_containers/payara-mp-tck/playlist.xml
@@ -15,12 +15,10 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
 	<test>
 		<testCaseName>payara_microprofile_tck</testCaseName>
-		<command>docker run --name payara-mp-tck $(EXTRA_DOCKER_ARGS) adoptopenjdk-payara-mp-tck:latest; \
+		<command>docker run --name payara-mp-tck $(EXTRA_DOCKER_ARGS) adoptopenjdk-payara-mp-tck:latest \
+			"-pl !MicroProfile-OpenTracing/tck-runner,!MicroProfile-JWT-Auth,!MicroProfile-JWT-Auth/tck-arquillian-extension,!MicroProfile-JWT-Auth/tck-runner"; \
 			 $(TEST_STATUS); \
-			 docker cp payara-mp-tck:/MicroProfile-TCK-Runners/MicroProfile-Metrics/tck-runner/target/surefire-reports $(REPORTDIR)/external_test_reports; \
-			 docker cp payara-mp-tck:/MicroProfile-TCK-Runners/MicroProfile-Fault-Tolerance/tck-runner/target/surefire-reports/junitreports $(REPORTDIR)/external_test_reports; \
-			 docker cp payara-mp-tck:/MicroProfile-TCK-Runners/MicroProfile-Config/tck-runner/target/surefire-reports/junitreports $(REPORTDIR)/external_test_reports; \
-			 docker cp payara-mp-tck:/MicroProfile-TCK-Runners/MicroProfile-OpenAPI/tck-runner/target/surefire-reports/junitreports $(REPORTDIR)/external_test_reports; \
+			 docker cp payara-mp-tck:/testResults/junitreports $(REPORTDIR)/external_test_reports; \
 			 docker rm -f payara-mp-tck; \
 			 docker rmi -f adoptopenjdk-payara-mp-tck
 		</command>


### PR DESCRIPTION
1. remove unnecessary dependent
2. remove pre-install hard-coded payara
3. update to run all the TCKs against a managed server instance
4. cp junit report from docker to hosts
5. Exclude failure projects or modules

Close #1067 

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>