### PR TITLE
Enable StringCoding Tests

### DIFF
--- a/openjdk_regression/ProblemList_openjdk11-openj9.txt
+++ b/openjdk_regression/ProblemList_openjdk11-openj9.txt
@@ -322,7 +322,6 @@ jdk/internal/reflect/constantPool/ConstantPoolTest.java	https://github.com/Adopt
 sun/misc/SunMiscSignalTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 sun/net/www/protocol/file/DirPermissionDenied.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/760 windows-all
 sun/nio/ch/TestMaxCachedBufferSize.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
-sun/nio/cs/TestStringCoding.java https://github.com/eclipse/openj9/issues/5208 linux-s390x
 com/sun/net/httpserver/Test1.java https://github.com/eclipse/openj9/issues/4125 windows-all
 
 vm/verifier/VerifyProtectedConstructor.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all

--- a/openjdk_regression/ProblemList_openjdk12-openj9.txt
+++ b/openjdk_regression/ProblemList_openjdk12-openj9.txt
@@ -333,7 +333,6 @@ jdk/internal/reflect/constantPool/ConstantPoolTest.java	https://github.com/Adopt
 sun/misc/SunMiscSignalTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 sun/net/www/protocol/file/DirPermissionDenied.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/760 windows-all
 sun/nio/ch/TestMaxCachedBufferSize.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
-sun/nio/cs/TestStringCoding.java https://github.com/eclipse/openj9/issues/5208 linux-s390x
 com/sun/net/httpserver/Test1.java https://github.com/eclipse/openj9/issues/4125 windows-all
 
 vm/verifier/VerifyProtectedConstructor.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all


### PR DESCRIPTION
A bug exposed by TestStringCoding.java on linux-s390x was recently resolved (see #5208 in eclipse/openj9) so we can now re-enable these tests on the platform.