### PR TITLE
Run parallel tests out of node block

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -109,7 +109,7 @@ def setupParallelEnv() {
 				testSubDirSize = testSubDirs.size()
 			}
 			echo "testSubDirSize is ${testSubDirSize}, testSubDirs is ${testSubDirs}, running test in parallel mode"
-			def parallel_tests = [:]
+			parallel_tests = [:]
 
 			for (int i = 0; i < testSubDirSize; i++) {
 				def testSubDir = testSubDirs[i].trim().replace("/","");
@@ -150,7 +150,7 @@ def setupParallelEnv() {
 					]
 				}
 			}
-			parallel parallel_tests
+			// return to top level pipeline file in order to exit node block before running tests in parallel
 		}
 	}
 }
@@ -458,7 +458,7 @@ def getJenkinsDomain() {
 	def match = m[0][1]
 	def domainName = "undefined"
 	if (match) {
-	    domainName = match
+		domainName = match
 	}
 	return domainName
 }
@@ -493,6 +493,14 @@ def uploadToArtifactory() {
 		currentBuild.description += "<br><a href=${uploadUrl}>Artifacts</a>"
 	} else {
 		echo "ARTIFACTORY_SERVER is not set. Artifacts are not uploaded onto artifactory server."
+	}
+}
+
+def run_parallel_tests() {
+	if (params.IS_PARALLEL == true) {
+		stage ("Parallel Tests") {
+			parallel parallel_tests
+		}
 	}
 }
 

--- a/buildenv/jenkins/openjdk_aarch32_linux
+++ b/buildenv/jenkins/openjdk_aarch32_linux
@@ -7,7 +7,8 @@ stage('Queue') {
         SDK_RESOURCE = 'upstream'
         SPEC='linux_arm'
         checkout scm
-        def jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
+        jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
         jenkinsfile.testBuild()
     }
 }
+jenkinsfile.run_parallel_tests()

--- a/buildenv/jenkins/openjdk_aarch64_linux
+++ b/buildenv/jenkins/openjdk_aarch64_linux
@@ -7,7 +7,8 @@ stage('Queue') {
         SDK_RESOURCE = 'upstream'
         SPEC='linux_aarch64_cmprssptrs'
         checkout scm
-        def jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
+        jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
         jenkinsfile.testBuild()
     }
 }
+jenkinsfile.run_parallel_tests()

--- a/buildenv/jenkins/openjdk_ppc64_aix
+++ b/buildenv/jenkins/openjdk_ppc64_aix
@@ -7,7 +7,8 @@ stage('Queue') {
         SDK_RESOURCE = 'upstream'
         SPEC='aix_ppc-64_cmprssptrs'
         checkout scm
-        def jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
+        jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
         jenkinsfile.testBuild()
     }
 }
+jenkinsfile.run_parallel_tests()

--- a/buildenv/jenkins/openjdk_ppc64le_linux
+++ b/buildenv/jenkins/openjdk_ppc64le_linux
@@ -12,7 +12,8 @@ stage('Queue') {
         SDK_RESOURCE = 'upstream'
         SPEC='linux_ppc-64_cmprssptrs_le'
         checkout scm
-        def jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
+        jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
         jenkinsfile.testBuild()
     }
 }
+jenkinsfile.run_parallel_tests()

--- a/buildenv/jenkins/openjdk_s390x_linux
+++ b/buildenv/jenkins/openjdk_s390x_linux
@@ -13,7 +13,8 @@ stage('Queue') {
         SDK_RESOURCE = 'upstream'
         SPEC='linux_390-64_cmprssptrs'
         checkout scm
-        def jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
+        jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
         jenkinsfile.testBuild()
     }
 }
+jenkinsfile.run_parallel_tests()

--- a/buildenv/jenkins/openjdk_s390x_zos
+++ b/buildenv/jenkins/openjdk_s390x_zos
@@ -11,7 +11,8 @@ stage('Queue') {
         SDK_RESOURCE = 'upstream'
         SPEC='zos_390-64_cmprssptrs'
         checkout scm
-        def jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
+        jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
         jenkinsfile.testBuild()
     }
 }
+jenkinsfile.run_parallel_tests()

--- a/buildenv/jenkins/openjdk_x86-32_windows
+++ b/buildenv/jenkins/openjdk_x86-32_windows
@@ -12,7 +12,8 @@ stage('Queue') {
         SDK_RESOURCE = 'upstream'
         SPEC='win_x86'
         checkout scm
-        def jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
+        jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
         jenkinsfile.testBuild()
     }
 }
+jenkinsfile.run_parallel_tests()

--- a/buildenv/jenkins/openjdk_x86-64_linux
+++ b/buildenv/jenkins/openjdk_x86-64_linux
@@ -12,7 +12,8 @@ stage('Queue') {
         SDK_RESOURCE = 'upstream'
         SPEC='linux_x86-64_cmprssptrs'
         checkout scm
-        def jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
+        jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
         jenkinsfile.testBuild()
     }
 }
+jenkinsfile.run_parallel_tests()

--- a/buildenv/jenkins/openjdk_x86-64_linux_largeHeap
+++ b/buildenv/jenkins/openjdk_x86-64_linux_largeHeap
@@ -12,7 +12,8 @@ stage('Queue') {
         SDK_RESOURCE = 'upstream'
         SPEC='linux_x86-64'
         checkout scm
-        def jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
+        jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
         jenkinsfile.testBuild()
     }
 }
+jenkinsfile.run_parallel_tests()

--- a/buildenv/jenkins/openjdk_x86-64_linux_xl
+++ b/buildenv/jenkins/openjdk_x86-64_linux_xl
@@ -7,7 +7,8 @@ stage('Queue') {
         SDK_RESOURCE = 'upstream'
         SPEC='linux_x86-64'
         checkout scm
-        def jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
+        jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
         jenkinsfile.testBuild()
     }
 }
+jenkinsfile.run_parallel_tests()

--- a/buildenv/jenkins/openjdk_x86-64_mac
+++ b/buildenv/jenkins/openjdk_x86-64_mac
@@ -7,7 +7,8 @@ stage('Queue') {
         SDK_RESOURCE = 'upstream'
         SPEC='osx_x86-64_cmprssptrs'
         checkout scm
-        def jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
+        jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
         jenkinsfile.testBuild()
     }
 }
+jenkinsfile.run_parallel_tests()

--- a/buildenv/jenkins/openjdk_x86-64_mac_xl
+++ b/buildenv/jenkins/openjdk_x86-64_mac_xl
@@ -7,7 +7,8 @@ stage('Queue') {
         SDK_RESOURCE = 'upstream'
         SPEC='osx_x86-64'
         checkout scm
-        def jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
+        jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
         jenkinsfile.testBuild()
     }
 }
+jenkinsfile.run_parallel_tests()

--- a/buildenv/jenkins/openjdk_x86-64_osx
+++ b/buildenv/jenkins/openjdk_x86-64_osx
@@ -12,7 +12,8 @@ stage('Queue') {
         SDK_RESOURCE = 'upstream'
         SPEC='osx_x86-64_cmprssptrs'
         checkout scm
-        def jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
+        jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
         jenkinsfile.testBuild()
     }
 }
+jenkinsfile.run_parallel_tests()

--- a/buildenv/jenkins/openjdk_x86-64_osx_largeHeap
+++ b/buildenv/jenkins/openjdk_x86-64_osx_largeHeap
@@ -11,7 +11,8 @@ stage('Queue') {
         SDK_RESOURCE = 'upstream'
         SPEC='osx_x86-64'
         checkout scm
-        def jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
+        jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
         jenkinsfile.testBuild()
     }
 }
+jenkinsfile.run_parallel_tests()

--- a/buildenv/jenkins/openjdk_x86-64_windows
+++ b/buildenv/jenkins/openjdk_x86-64_windows
@@ -7,7 +7,8 @@ stage('Queue') {
         SDK_RESOURCE = 'upstream'
         SPEC='win_x86-64_cmprssptrs'
         checkout scm
-        def jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
+        jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
         jenkinsfile.testBuild()
     }
 }
+jenkinsfile.run_parallel_tests()


### PR DESCRIPTION
- When running tests in parallel it is not necessary for the
  top level build to hold onto a node while the downstream
  jobs execute. In order to exit out of the node block we need
  to return back to the top level pipeline file and then call
  a new parallel function. Some definitions need to be global
  in order for variables to propagate around.

Fixes #994

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>