### PR TITLE
Update thorntail microprofile tests running

### DIFF
--- a/thirdparty_containers/thorntail-mp-tck/dockerfile/Dockerfile
+++ b/thirdparty_containers/thorntail-mp-tck/dockerfile/Dockerfile
@@ -48,6 +48,7 @@ RUN apt-get update \
 	maven
 
 WORKDIR /
+RUN mkdir testResults
 ENV THORNTAIL_HOME $WORKDIR
 
 VOLUME ["/java"]
@@ -61,4 +62,4 @@ COPY ./dockerfile/thorntail-mp-tck.sh /thorntail-mp-tck.sh
 RUN git clone -q git://github.com/thorntail/thorntail 
 
 ENTRYPOINT ["/bin/bash", "/thorntail-mp-tck.sh"]
-CMD ["--version"]
+CMD [""]

--- a/thirdparty_containers/thorntail-mp-tck/dockerfile/thorntail-mp-tck.sh
+++ b/thirdparty_containers/thorntail-mp-tck/dockerfile/thorntail-mp-tck.sh
@@ -33,28 +33,13 @@ else
 fi
 
 java -version
+TEST_OPTIONS=$1
 cd ${THORNTAIL_HOME}/
 
 #Build Thorntail 
 cd ${THORNTAIL_HOME}/thorntail/ 
-mvn clean install
+mvn clean install -Dmaven.test.skip=true
+echo "build finished"
 
-#Start MicroProfile Metrics TCK
-cd ${THORNTAIL_HOME}/thorntail/testsuite/testsuite-microprofile-metrics
-mvn integration-test
-
-#Start MicroProfile Fault-Tolerance TCK
-cd ${THORNTAIL_HOME}/thorntail/testsuite/testsuite-microprofile-fault-tolerance
-mvn integration-test
-
-#Start MicroProfile Rest Client TCK
-cd ${THORNTAIL_HOME}/thorntail/testsuite/testsuite-microprofile-restclient 
-mvn integration-test
-
-#Start MicroProfile OpenAPI TCK
-cd ${THORNTAIL_HOME}/thorntail/testsuite/testsuite-microprofile-openapi
-mvn integration-test
-
-#Start MicroProfile JWT TCK
-cd ${THORNTAIL_HOME}/thorntail/testsuite/testsuite-microprofile-jwt
-mvn integration-test
+mvn test $TEST_OPTIONS
+find ./ -type d -name 'surefire-reports' -exec cp -r "{}" /testResults \;

--- a/thirdparty_containers/thorntail-mp-tck/playlist.xml
+++ b/thirdparty_containers/thorntail-mp-tck/playlist.xml
@@ -15,13 +15,10 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
 	<test>
 		<testCaseName>thorntail_microprofile_tck</testCaseName>
-		<command>docker run --name thorntail-mp-tck $(EXTRA_DOCKER_ARGS) adoptopenjdk-thorntail-mp-tck:latest; \
+		<command>docker run --name thorntail-mp-tck $(EXTRA_DOCKER_ARGS) adoptopenjdk-thorntail-mp-tck:latest \
+			 "-pl testsuite/testsuite-microprofile-jwt,testsuite/testsuite-microprofile-fault-tolerance,testsuite/testsuite-microprofile-metrics,testsuite/testsuite-microprofile-openapi,testsuite/testsuite-microprofile-restclient"; \
 			 $(TEST_STATUS); \
-			 docker cp thorntail-mp-tck:/thorntail/testsuite/testsuite-microprofile-metrics/target/surefire-reports $(REPORTDIR)/external_test_reports; \
-			 docker cp thorntail-mp-tck:/thorntail/testsuite/testsuite-microprofile-fault-tolerance/target/surefire-reports $(REPORTDIR)/external_test_reports; \
-			 docker cp thorntail-mp-tck:/thorntail/testsuite/testsuite-microprofile-restclient/target/surefire-reports $(REPORTDIR)/external_test_reports; \
-			 docker cp thorntail-mp-tck:/thorntail/testsuite/testsuite-microprofile-openapi/target/surefire-reports $(REPORTDIR)/external_test_reports; \
-			 docker cp thorntail-mp-tck:/thorntail/testsuite//testsuite-microprofile-jwt/target/surefire-reports $(REPORTDIR)/external_test_reports; \
+			 docker cp thorntail-mp-tck:/testResults/surefire-reports $(REPORTDIR)/external_test_reports; \
 			 docker rm -f thorntail-mp-tck; \
 			 docker rmi -f adoptopenjdk-thorntail-mp-tck
 		</command>


### PR DESCRIPTION
1. Skip the whole project tests build and running to avoid duplicate
tests running, reduce unexpected exceptions and running time
2. Specify test projects, which can be updated easily later
3. Auto grab unit tests result

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>