### PR TITLE
Fix openjdk11-openj9 elastic test setup failure

### DIFF
--- a/thirdparty_containers/elasticsearch/playlist.xml
+++ b/thirdparty_containers/elasticsearch/playlist.xml
@@ -14,7 +14,7 @@
 -->
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
 	<test>
-		<testCaseName>elasticsearch_test_openj9</testCaseName>
+		<testCaseName>elasticsearch_test_openj9_jdk8</testCaseName>
 		<command>docker run --name elasticsearch-test $(EXTRA_DOCKER_ARGS) adoptopenjdk-elasticsearch-test:latest \
 		 "--exclude-task :core:test \
 		 --exclude-task :client:rest:test \
@@ -31,6 +31,36 @@
 		<levels>
 			<level>extended</level>
 		</levels>
+		<subsets>
+			<subset>8</subset>
+		</subsets>
+		<groups>
+			<group>external</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+		</impls>
+	</test>
+	<test>
+		<testCaseName>elasticsearch_test_openj9_latest</testCaseName>
+		<command>docker run --name elasticsearch-test $(EXTRA_DOCKER_ARGS) adoptopenjdk-elasticsearch-test:latest \
+		 "--exclude-task :client:rest:test \
+		 --exclude-task :modules:reindex:test \
+		 --exclude-task :client:transport:test \
+		 --exclude-task :client:sniffer:test \
+		 --exclude-task :test:framework:test \
+		 --exclude-task :modules:lang-painless:test"; \
+			$(TEST_STATUS); \
+			docker cp elasticsearch-test:/testResults/testJunit $(REPORTDIR)/external_test_reports; \
+			docker rm -f elasticsearch-test; \
+			docker rmi -f adoptopenjdk-elasticsearch-test
+		</command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<subsets>
+			<subset>10+</subset>
+		</subsets>
 		<groups>
 			<group>external</group>
 		</groups>


### PR DESCRIPTION
Build failed msg 'Project 'core' not found in root project at 
'elasticsearch' at the beginning of the tests, which is tests setup issue.

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>