### PR TITLE
Exit immediately if tests steps exit with a non-zero exit status

### DIFF
--- a/thirdparty_containers/derby/build.xml
+++ b/thirdparty_containers/derby/build.xml
@@ -9,7 +9,6 @@
 	<property name="DEST" value="${BUILD_ROOT}/thirdparty_containers/derby-test" />
 	<property name="dist" location="${DEST}/${JDK_VERSION}" />
 	<property name="src" location="." />
-	<property name="jvm_version" location="${JVM_VERSION}" />
 
 	<target name="init">
 		<mkdir dir="${dist}"/>

--- a/thirdparty_containers/derby/dockerfile/derby-test.sh
+++ b/thirdparty_containers/derby/dockerfile/derby-test.sh
@@ -19,24 +19,22 @@ if [ -d /java/jre/bin ];then
 	export JAVA_BIN=/java/jre/bin
 	export JAVA_HOME=/java
 	export PATH=$JAVA_BIN:$PATH
-	java -version
 elif [ -d /java/bin ]; then
 	echo "Using mounted Java"
 	export JAVA_BIN=/java/bin
 	export JAVA_HOME=/java
 	export PATH=$JAVA_BIN:$PATH
-	java -version
 else
 	echo "Using docker image default Java"
 	java_path=$(type -p java)
 	suffix="/java"
 	java_root=${java_path%$suffix}
 	export JAVA_BIN="$java_root"
-	echo "JAVA_BIN is: $JAVA_BIN"
 	$JAVA_BIN/java -version
 	export JAVA_HOME="${java_root%/bin}"
 fi
 
+java -version
 cd ${DERBY_HOME}
 
 pwd
@@ -56,9 +54,10 @@ export CLASSPATH "${jardir}/derbyrun.jar:${jardir}/derbyTesting.jar:${tstjardir}
 
 java -jar ${DERBY_HOME}/jars/sane/derbyrun.jar sysinfo
 
+set -e
 #Run all tests
 ant -Dderby.tests.basePort=1690 -Dderby.system.durability=test -DderbyTesting.oldReleasePath=${DERBY_HOME}/jars junit-all
-
+set +e
 #Run only derbylang suite
 #java -Dverbose=true -cp ${jardir}/derbyrun.jar:${jardir}/derbyTesting.jar:$tstjardir/junit.jar org.apache.derbyTesting.functionTests.harness.RunSuite #derbylang
 

--- a/thirdparty_containers/elasticsearch/build.xml
+++ b/thirdparty_containers/elasticsearch/build.xml
@@ -8,7 +8,6 @@
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/thirdparty_containers/elasticsearch-test" />
 	<property name="src" location="." />
-	<property name="jvm_version" location="${JVM_VERSION}" />
 
 	<target name="init">
 		<mkdir dir="${DEST}"/>

--- a/thirdparty_containers/example-test/build.xml
+++ b/thirdparty_containers/example-test/build.xml
@@ -9,7 +9,6 @@
 	<property name="DEST" value="${BUILD_ROOT}/thirdparty_containers/example-test" />
 	<property name="dist" location="${DEST}/${JDK_VERSION}" />
 	<property name="src" location="." />
-	<property name="jvm_version" location="${JVM_VERSION}" />
 
 	<target name="init">
 		<mkdir dir="${dist}"/>

--- a/thirdparty_containers/example-test/dockerfile/example-test.sh
+++ b/thirdparty_containers/example-test/dockerfile/example-test.sh
@@ -19,13 +19,11 @@ if [ -d /java/jre/bin ];then
 	export JAVA_BIN=/java/jre/bin
 	export JAVA_HOME=/java
 	export PATH=$JAVA_BIN:$PATH
-	java -version
 elif [ -d /java/bin ]; then
 	echo "Using mounted Java9"
 	export JAVA_BIN=/java/bin
 	export JAVA_HOME=/java
 	export PATH=$JAVA_BIN:$PATH
-	java -version
 else
 	echo "Using docker image default Java"
 	java_path=$(type -p java)
@@ -33,24 +31,20 @@ else
 	java_root=${java_path%$suffix}
 	export JAVA_BIN="$java_root"
 	echo "JAVA_BIN is: $JAVA_BIN"
-	$JAVA_BIN/java -version
 	export JAVA_HOME="${java_root%/bin}"
 fi
 
 TEST_SUITE=$1
-
-echo "PATH is : $PATH"
-echo "JAVA_HOME is : $JAVA_HOME"
-echo "type -p java is :"
-type -p java
-echo "java -version is: \n"
 java -version
 
 # Replace the following with the initial command lines that trigger execution of your test
 # For this example, we will simply compile and run the ExampleTest class
 cd /tpc-example
-ls .
+
 pwd
+
+set -e
 echo "Compile and execute example-test" && \
 javac src/net/adoptopenjdk/example/test/ExampleTest.java && \
 java -cp ./src net.adoptopenjdk.example.test.ExampleTest
+set +e

--- a/thirdparty_containers/functional-test/build.xml
+++ b/thirdparty_containers/functional-test/build.xml
@@ -8,7 +8,6 @@
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/thirdparty_containers/functional-test" />
 	<property name="src" location="." />
-	<property name="jvm_version" location="${JVM_VERSION}" />
 
 	<target name="init">
 		<mkdir dir="${DEST}"/>

--- a/thirdparty_containers/jenkins/build.xml
+++ b/thirdparty_containers/jenkins/build.xml
@@ -8,7 +8,6 @@
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/thirdparty_containers/jenkins-test" />
 	<property name="src" location="." />
-	<property name="jvm_version" location="${JVM_VERSION}" />
 
 	<target name="init">
 		<mkdir dir="${DEST}"/>

--- a/thirdparty_containers/jenkins/dockerfile/Dockerfile
+++ b/thirdparty_containers/jenkins/dockerfile/Dockerfile
@@ -57,7 +57,7 @@ COPY ./dockerfile/jenkins-test.sh /jenkins-test.sh
 
 # Clone jenkins src to /jenkins
 WORKDIR /
-RUN pwd
+RUN mkdir testResults
 RUN git clone https://github.com/jenkinsci/jenkins.git
 
 ENTRYPOINT ["/bin/bash", "/jenkins-test.sh"]

--- a/thirdparty_containers/jenkins/dockerfile/jenkins-test.sh
+++ b/thirdparty_containers/jenkins/dockerfile/jenkins-test.sh
@@ -17,13 +17,11 @@ if [ -d /java/jre/bin ];then
 	export JAVA_BIN=/java/jre/bin
 	export JAVA_HOME=/java
 	export PATH=$JAVA_BIN:$PATH
-	java -version
 elif [ -d /java/bin ]; then
 	echo "Using mounted Java"
 	export JAVA_BIN=/java/bin
 	export JAVA_HOME=/java
 	export PATH=$JAVA_BIN:$PATH
-	java -version
 else
 	echo "Using docker image default Java"
 	java_path=$(type -p java)
@@ -31,16 +29,16 @@ else
 	java_root=${java_path%$suffix}
 	export JAVA_BIN="$java_root"
 	echo "JAVA_BIN is: $JAVA_BIN"
-	$JAVA_BIN/java -version
 	export JAVA_HOME="${java_root%/bin}"
 fi
 
+java -version
 export JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
 #begin jenkins test
 
 cd /jenkins
-ls .
-pwd
+
+set -e
 echo "Build jenkins by using mvn \"mvn clean install -pl war -am -DskipTests\"" && \
 mvn clean install -pl war -am -DskipTests -Denforcer.fail=false
 
@@ -48,5 +46,6 @@ echo "Building jenkins completed"
 
 echo "Run jenkins test phase alone with cmd: \"mvn surefire:test\"" && \
 mvn surefire:test -Denforcer.fail=false
-
+set +e
 echo "Executing jenkins tests alone completed"
+find ./ -type d -name 'surefire-reports' -exec cp -r "{}" /testResults \;

--- a/thirdparty_containers/jenkins/playlist.xml
+++ b/thirdparty_containers/jenkins/playlist.xml
@@ -17,8 +17,7 @@
 		<testCaseName>jenkins_test</testCaseName>
 		<command>docker run --name jenkins-test $(EXTRA_DOCKER_ARGS) adoptopenjdk-jenkins-test:latest; \
 			 $(TEST_STATUS); \
-			 docker cp jenkins-test:/jenkins/cli/target/surefire-reports $(REPORTDIR)/external_test_reports; \
-			 docker cp jenkins-test:/jenkins/core/target/surefire-reports $(REPORTDIR)/external_test_reports; \
+			 docker cp jenkins-test:/testResults/surefire-reports $(REPORTDIR)/external_test_reports; \
 			 docker rm -f jenkins-test; \
 			 docker rmi -f adoptopenjdk-jenkins-test
 		</command>

--- a/thirdparty_containers/kafka/build.xml
+++ b/thirdparty_containers/kafka/build.xml
@@ -8,7 +8,6 @@
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/thirdparty_containers/kafka-test" />
 	<property name="src" location="." />
-	<property name="jvm_version" location="${JVM_VERSION}" />
 
 	<target name="init">
 		<mkdir dir="${DEST}"/>

--- a/thirdparty_containers/kafka/dockerfile/kafka-test.sh
+++ b/thirdparty_containers/kafka/dockerfile/kafka-test.sh
@@ -51,6 +51,7 @@ cd /kafka
 ls .
 pwd
 
+set -e
 echo "Building kafka  using gradle" && \
 gradle -q
 ./gradlew jar
@@ -60,3 +61,5 @@ echo "Kafka Build - Completed"
 echo "Running (ALL) Kafka tests :"
 
 ./gradlew testAll
+set +e
+echo "Kafka tests - Completed:"

--- a/thirdparty_containers/lucene-solr/build.xml
+++ b/thirdparty_containers/lucene-solr/build.xml
@@ -8,7 +8,6 @@
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/thirdparty_containers/lucene-solr-test" />
 	<property name="src" location="." />
-	<property name="jvm_version" location="${JVM_VERSION}" />
 
 	<target name="init">
 		<mkdir dir="${DEST}"/>

--- a/thirdparty_containers/lucene-solr/dockerfile/lucene-solr-test.sh
+++ b/thirdparty_containers/lucene-solr/dockerfile/lucene-solr-test.sh
@@ -34,9 +34,13 @@ fi
 
 java -version
 cd ${LUCENE_SOLR_HOME}/lucene-solr
-ls .
+
 pwd
+set -e
+
 echo "Compile and execute lucene-solr test" && \
 ${ANT_HOME}/bin/ant -Divy_install_path=${ANT_HOME}/lib -lib ${ANT_HOME}/lib ivy-bootstrap && \
 ${ANT_HOME}/bin/ant -Divy_install_path=${ANT_HOME}/lib -lib ${ANT_HOME}/lib -f ${LUCENE_SOLR_HOME}/lucene-solr/build.xml -Duser.home=${LUCENE_SOLR_HOME} -Dcommon.dir=${LUCENE_SOLR_HOME}/lucene-solr/lucene compile && \
 ${ANT_HOME}/bin/ant -Divy_install_path=${ANT_HOME}/lib -lib ${ANT_HOME}/lib -f ${LUCENE_SOLR_HOME}/lucene-solr/build.xml -Duser.home=${LUCENE_SOLR_HOME} -Dcommon.dir=${LUCENE_SOLR_HOME}/lucene-solr/lucene test
+
+set +e

--- a/thirdparty_containers/openliberty-mp-tck/build.xml
+++ b/thirdparty_containers/openliberty-mp-tck/build.xml
@@ -8,7 +8,6 @@
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/thirdparty_containers/openliberty-mp-tck" />
 	<property name="src" location="." />
-	<property name="jvm_version" location="${JVM_VERSION}" />
 
 	<target name="init">
 		<mkdir dir="${DEST}"/>

--- a/thirdparty_containers/openliberty-mp-tck/dockerfile/openliberty-mp-tck.sh
+++ b/thirdparty_containers/openliberty-mp-tck/dockerfile/openliberty-mp-tck.sh
@@ -35,6 +35,7 @@ fi
 java -version
 cd ${OPENLIBERTY_HOME}/open-liberty/dev
 
+set -e
 #Build all projects and create the open-liberty image
 ./gradlew -q cnf:initialize
 ./gradlew -q releaseNeeded
@@ -69,4 +70,5 @@ echo "Build projects and create images done"
 ./gradlew -q com.ibm.ws.microprofile.openapi_fat_tck:clean
 ./gradlew -q com.ibm.ws.microprofile.openapi_fat_tck:buildandrun
 
+set +e
 find ./ -type d -name 'surefire-reports' -exec cp -r "{}" /testResults \;

--- a/thirdparty_containers/payara-mp-tck/build.xml
+++ b/thirdparty_containers/payara-mp-tck/build.xml
@@ -8,7 +8,6 @@
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/thirdparty_containers/payara-mp-tck" />
 	<property name="src" location="." />
-	<property name="jvm_version" location="${JVM_VERSION}" />
 
 	<target name="init">
 		<mkdir dir="${DEST}"/>

--- a/thirdparty_containers/payara-mp-tck/dockerfile/payara-mp-tck.sh
+++ b/thirdparty_containers/payara-mp-tck/dockerfile/payara-mp-tck.sh
@@ -37,6 +37,7 @@ java -version
 TEST_OPTIONS=$1
 
 cd ${PAYARA_HOME}/MicroProfile-TCK-Runners
+set -e
 mvn clean verify -Dpayara.version=5.184 $TEST_OPTIONS
-
+set +e
 find ./ -type d -name 'junitreports' -exec cp -r "{}" /testResults \;

--- a/thirdparty_containers/scala/dockerfile/scala-test.sh
+++ b/thirdparty_containers/scala/dockerfile/scala-test.sh
@@ -17,13 +17,11 @@ if [ -d /java/jre/bin ];then
 	export JAVA_BIN=/java/jre/bin
 	export JAVA_HOME=/java
 	export PATH=$JAVA_BIN:$PATH
-	java -version
 elif [ -d /java/bin ]; then
 	echo "Using mounted Java9"
 	export JAVA_BIN=/java/bin
 	export JAVA_HOME=/java
 	export PATH=$JAVA_BIN:$PATH
-	java -version
 else
 	echo "Using docker image default Java"
 	java_path=$(type -p java)
@@ -31,25 +29,22 @@ else
 	java_root=${java_path%$suffix}
 	export JAVA_BIN="$java_root"
 	echo "JAVA_BIN is: $JAVA_BIN"
-	$JAVA_BIN/java -version
 	export JAVA_HOME="${java_root%/bin}"
 fi
 
+java -version
 TEST_SUITE=$1
 export JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
 #begin scala test
-echo "PATH is : $PATH"
-echo "JAVA_HOME is : $JAVA_HOME"
-echo "type -p java is :"
-type -p java
-echo "java -version is: \n"
-java -version
 cd /scala
-ls .
 pwd
+
+set -e
 echo "Begin to execute Scala test with cmd: sbt \"partest $TEST_SUITE\"" && \
 echo "Try to echo Scala version by using sbt \"scala -version\"" && \
 sbt "scala -version"
 
 echo "Begin to execute Scala test with cmd: sbt \"partest $TEST_SUITE\"" && \
 sbt "partest $TEST_SUITE"
+
+set +e

--- a/thirdparty_containers/system-test/build.xml
+++ b/thirdparty_containers/system-test/build.xml
@@ -8,7 +8,6 @@
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/thirdparty_containers/system-test" />
 	<property name="src" location="." />
-	<property name="jvm_version" location="${JVM_VERSION}" />
 
 	<target name="init">
 		<mkdir dir="${DEST}"/>

--- a/thirdparty_containers/thorntail-mp-tck/build.xml
+++ b/thirdparty_containers/thorntail-mp-tck/build.xml
@@ -8,7 +8,6 @@
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/thirdparty_containers/thorntail-mp-tck" />
 	<property name="src" location="." />
-	<property name="jvm_version" location="${JVM_VERSION}" />
 
 	<target name="init">
 		<mkdir dir="${DEST}"/>

--- a/thirdparty_containers/thorntail-mp-tck/dockerfile/thorntail-mp-tck.sh
+++ b/thirdparty_containers/thorntail-mp-tck/dockerfile/thorntail-mp-tck.sh
@@ -41,5 +41,7 @@ cd ${THORNTAIL_HOME}/thorntail/
 mvn clean install -Dmaven.test.skip=true
 echo "build finished"
 
+set -e
 mvn test $TEST_OPTIONS
+set +e
 find ./ -type d -name 'surefire-reports' -exec cp -r "{}" /testResults \;

--- a/thirdparty_containers/tomcat/build.xml
+++ b/thirdparty_containers/tomcat/build.xml
@@ -8,7 +8,6 @@
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/thirdparty_containers/tomcat-test" />
 	<property name="src" location="." />
-	<property name="jvm_version" location="${JVM_VERSION}" />
 
 	<target name="init">
 		<mkdir dir="${DEST}"/>

--- a/thirdparty_containers/tomcat/dockerfile/tomcat-test.sh
+++ b/thirdparty_containers/tomcat/dockerfile/tomcat-test.sh
@@ -19,13 +19,11 @@ if [ -d /java/jre/bin ];then
 	export JAVA_BIN=/java/jre/bin
 	export JAVA_HOME=/java
 	export PATH=$JAVA_BIN:$PATH
-	java -version
 elif [ -d /java/bin ]; then
-	echo "Using mounted Java9"
+	echo "Using mounted Java"
 	export JAVA_BIN=/java/bin
 	export JAVA_HOME=/java
 	export PATH=$JAVA_BIN:$PATH
-	java -version
 else
 	echo "Using docker image default Java"
 	java_path=$(type -p java)
@@ -33,22 +31,16 @@ else
 	java_root=${java_path%$suffix}
 	export JAVA_BIN="$java_root"
 	echo "JAVA_BIN is: $JAVA_BIN"
-	$JAVA_BIN/java -version
 	export JAVA_HOME="${java_root%/bin}"
 fi
 
 TEST_SUITE=$1
-
-echo "PATH is : $PATH"
-echo "JAVA_HOME is : $JAVA_HOME"
-echo "type -p java is :"
-type -p java
-echo "java -version is: \n"
 java -version
 
 cd /tomcat
-ls .
 pwd
+
+set -e
 echo "Building tomcat" && \
 cp build.properties.default build.properties && \
 ant && \
@@ -56,3 +48,4 @@ ant && \
 echo "Running tomcat tests" 
 #Run tests
 ant test
+set +e

--- a/thirdparty_containers/wildfly/build.xml
+++ b/thirdparty_containers/wildfly/build.xml
@@ -8,7 +8,6 @@
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/thirdparty_containers/wildfly-test" />
 	<property name="src" location="." />
-	<property name="jvm_version" location="${JVM_VERSION}" />
 
 	<target name="init">
 		<mkdir dir="${DEST}"/>

--- a/thirdparty_containers/wildfly/dockerfile/wildfly-test.sh
+++ b/thirdparty_containers/wildfly/dockerfile/wildfly-test.sh
@@ -38,6 +38,7 @@ java -version
 # Replace the following with the initial command lines that trigger execution of your test
 cd /wildfly
 
+set -e
 echo "Building wildfly  using maven , by invoking build.sh" && \
 ./build.sh
 
@@ -47,3 +48,4 @@ echo "Wildfly Build - Completed"
 echo "Running (ALL) wildfly tests :"
 
 ./mvnw install -DallTests
+set +e


### PR DESCRIPTION
Sets for both test build and test running stages. So exit code can be
consumed by `docker run`, which makes third party contaniner tests
status story identical with other test categories.

Also include some miscellaneous
 
close #950 
close #1084 

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>