### PR TITLE
Reset pulling from openj9:latest instead of nightly

### DIFF
--- a/thirdparty_containers/elasticsearch/dockerfile/Dockerfile
+++ b/thirdparty_containers/elasticsearch/dockerfile/Dockerfile
@@ -24,9 +24,7 @@
  
 ARG SDK=openjdk8
 ARG IMAGE_NAME=adoptopenjdk/$SDK
-# Using nightly temporately util https://github.com/AdoptOpenJDK/openjdk-docker/issues/122 is fix
-#ARG IMAGE_VERSION=latest
-ARG IMAGE_VERSION=nightly
+ARG IMAGE_VERSION=latest
 FROM $IMAGE_NAME:$IMAGE_VERSION
 
 RUN groupadd -g 1000 elasticsearch && useradd elasticsearch -u 1000 -g 1000


### PR DESCRIPTION
The error 'ps executable not found; ensure that you're running Gradle
with the JDK rather than the JRE' can't reproduce. Reset pulling from
latest to be same as other container tests.

Close #974 

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>