### PR TITLE
Enable wildfly & kafka

### DIFF
--- a/thirdparty_containers/kafka/dockerfile/Dockerfile
+++ b/thirdparty_containers/kafka/dockerfile/Dockerfile
@@ -35,10 +35,6 @@ FROM $IMAGE_NAME:$IMAGE_VERSION
 RUN apt-get update \
 	&& apt-get -y install \
 	ant \
-	apt-transport-https \
-	ca-certificates \
-	dirmngr \
-	curl \
 	git \
 	make \
 	unzip \
@@ -74,4 +70,4 @@ RUN git checkout $KAFKA_VERSION
 WORKDIR /
 
 ENTRYPOINT ["/bin/bash", "/kafka-test.sh"]
-CMD ["--version"]
+CMD [""]

--- a/thirdparty_containers/kafka/dockerfile/kafka-test.sh
+++ b/thirdparty_containers/kafka/dockerfile/kafka-test.sh
@@ -19,13 +19,11 @@ if [ -d /java/jre/bin ];then
 	export JAVA_BIN=/java/jre/bin
 	export JAVA_HOME=/java
 	export PATH=$JAVA_BIN:$PATH
-	java -version
 elif [ -d /java/bin ]; then
 	echo "Using mounted Java9"
 	export JAVA_BIN=/java/bin
 	export JAVA_HOME=/java
 	export PATH=$JAVA_BIN:$PATH
-	java -version
 else
 	echo "Using docker image default Java"
 	java_path=$(type -p java)
@@ -33,33 +31,25 @@ else
 	java_root=${java_path%$suffix}
 	export JAVA_BIN="$java_root"
 	echo "JAVA_BIN is: $JAVA_BIN"
-	$JAVA_BIN/java -version
 	export JAVA_HOME="${java_root%/bin}"
 fi
 
 TEST_SUITE=$1
 
-echo "PATH is : $PATH"
-echo "JAVA_HOME is : $JAVA_HOME"
-echo "type -p java is :"
-type -p java
-echo "java -version is: \n"
 java -version
 
 # Initial command to trigger the execution of kafka test
 cd /kafka
-ls .
-pwd
 
 set -e
-echo "Building kafka  using gradle" && \
+echo "Building kafka  using gradle"
 gradle -q
-./gradlew jar
+./gradlew -q jar
 
 echo "Kafka Build - Completed"
 
 echo "Running (ALL) Kafka tests :"
 
-./gradlew testAll
+./gradlew -q test
 set +e
 echo "Kafka tests - Completed:"

--- a/thirdparty_containers/kafka/playlist.xml
+++ b/thirdparty_containers/kafka/playlist.xml
@@ -24,6 +24,5 @@
 		<groups>
 			<group>external</group>
 		</groups>
-		<disabled>https://github.com/AdoptOpenJDK/openjdk-tests/issues/855</disabled>
 	</test>
 </playlist>

--- a/thirdparty_containers/wildfly/playlist.xml
+++ b/thirdparty_containers/wildfly/playlist.xml
@@ -25,6 +25,5 @@
 		<groups>
 			<group>external</group>
 		</groups>
-		<disabled>https://github.com/AdoptOpenJDK/openjdk-tests/issues/855</disabled>
 	</test>
 </playlist>


### PR DESCRIPTION
As #834 is done, we should enable those tests

Also run kafka test against default scala version instead of all scala
versions

Close #855 

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>