### PR TITLE
Add sleep & retry logic around the curl on the SDK

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -155,14 +155,16 @@ getBinaryOpenjdk()
 	if [ "${download_url}" != "" ]; then
 		for file in $download_url
 		do
-			echo "curl -OLJks ${curl_options} $file"
-			curl -OLJks ${curl_options} $file
+			set +e
+			echo "curl -OLJks --retry 5 --retry-delay 30 ${curl_options} $file"
+			curl -OLJks --retry 5 --retry-delay 30 ${curl_options} $file
 			if [ $? -ne 0 ]; then
 				echo "Failed to retrieve $file, exiting. This is what we received of the file and MD5 sum:"
 				ls -ld $file
 				md5sum $file
 				exit 1
 			fi
+			set -e
 		done
 	fi
 


### PR DESCRIPTION
Set sleep 30 second and retry 5 times
Turn off 'set -e' for curl command to get useful error message as the
command is more likely to fail due to all different reasons.

Fix #1033 

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>