### PR TITLE
Enable JCK runtime lang LMBD tests for Java 8

### DIFF
--- a/jck/runtime.lang/playlist.xml
+++ b/jck/runtime.lang/playlist.xml
@@ -169,9 +169,6 @@
 		<groups>
 			<group>jck</group>
 		</groups>
-		<subsets>
-			<subset>10+</subset>
-		</subsets>
 	</test>
 
 </playlist>


### PR DESCRIPTION
Enable `JCK runtime lang LMBD` tests for `Java 8`

Increase `Java 8 JCK` sanity test coverage.
Note: this is as per request of @pshipton 

Reviewer: @ShelleyLambert 
FYI: @DanHeidinga 


Signed-off-by: Jason Feng <fengj@ca.ibm.com>