### PR TITLE
Remove the mount point /java

### DIFF
--- a/thirdparty_containers/derby/dockerfile/Dockerfile
+++ b/thirdparty_containers/derby/dockerfile/Dockerfile
@@ -43,10 +43,7 @@ RUN apt-get update \
 	wget \
 	ant
 
-VOLUME ["/java"]
-ENV JAVA_HOME=/java \
-    PATH=/java/bin:$PATH \
-    JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
+ENV  JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
 
 WORKDIR /
 ENV DERBY_HOME ${WORKDIR}/derby

--- a/thirdparty_containers/elasticsearch/dockerfile/Dockerfile
+++ b/thirdparty_containers/elasticsearch/dockerfile/Dockerfile
@@ -36,10 +36,7 @@ RUN apt-get update \
 	unzip \
 	wget
 
-VOLUME ["/java"]
-ENV JAVA_HOME=/java \
-    PATH=/java/bin:$PATH \
-    JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
+ENV  JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
 
 # This is the main script to run Elasticsarch tests.
 COPY ./dockerfile/elasticsearch-test.sh /elasticsearch-test.sh

--- a/thirdparty_containers/example-test/dockerfile/Dockerfile
+++ b/thirdparty_containers/example-test/dockerfile/Dockerfile
@@ -44,10 +44,7 @@ RUN apt-get update \
 	vim \
 	wget
 
-VOLUME ["/java"]
-ENV JAVA_HOME=/java \
-    PATH=/java/bin:$PATH \
-    JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
+ENV  JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
 
 # This is the main script to run example tests. Replace this with the script for your own third party test 
 COPY ./dockerfile/example-test.sh /example-test.sh

--- a/thirdparty_containers/functional-test/dockerfile/Dockerfile
+++ b/thirdparty_containers/functional-test/dockerfile/Dockerfile
@@ -51,10 +51,7 @@ RUN apt-get update \
 	libjson-perl \
 	libxml-parser-perl
 
-VOLUME ["/java"]
-ENV JAVA_HOME=/java \
-    PATH=/java/bin:$PATH \
-    JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
+ENV  JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
 
 
 # This is the main script to run functional tests.  

--- a/thirdparty_containers/jenkins/dockerfile/Dockerfile
+++ b/thirdparty_containers/jenkins/dockerfile/Dockerfile
@@ -47,10 +47,7 @@ RUN apt-get update \
 	&& apt-get -y install \
 	maven
 	
-VOLUME ["/java"]
-ENV JAVA_HOME=/java \
-    PATH=/java/bin:$PATH \
-    JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
+ENV  JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
 
 # This is the main script to run jenkins tests
 COPY ./dockerfile/jenkins-test.sh /jenkins-test.sh

--- a/thirdparty_containers/kafka/dockerfile/Dockerfile
+++ b/thirdparty_containers/kafka/dockerfile/Dockerfile
@@ -52,10 +52,7 @@ RUN mkdir -p /usr/share/gradle \
 
 RUN cd .
 
-VOLUME ["/java"]
-ENV JAVA_HOME=/java \
-    PATH=/java/bin:$PATH \
-    JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
+ENV  JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
 
 # This is the main script to run kafka tests. 
 COPY ./dockerfile/kafka-test.sh /kafka-test.sh

--- a/thirdparty_containers/lucene-solr/dockerfile/Dockerfile
+++ b/thirdparty_containers/lucene-solr/dockerfile/Dockerfile
@@ -58,10 +58,7 @@ RUN wget --no-check-certificate --no-cookies https://archive.apache.org/dist/ant
     cp apache-ivy-${IVY_VERSION}/ivy-${IVY_VERSION}.jar $WORKDIR/apache-ant-${ANT_VERSION}/lib/
 ENV ANT_HOME ${WORKDIR}/apache-ant-${ANT_VERSION}
 
-VOLUME ["/java"]
-ENV JAVA_HOME=/java \
-    PATH=/java/bin:$PATH \
-    JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
+ENV  JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
 
 COPY ./dockerfile/lucene-solr-test.sh /lucene-solr-test.sh
 

--- a/thirdparty_containers/openliberty-mp-tck/dockerfile/Dockerfile
+++ b/thirdparty_containers/openliberty-mp-tck/dockerfile/Dockerfile
@@ -50,10 +50,7 @@ WORKDIR /
 ENV OPENLIBERTY_HOME $WORKDIR
 RUN mkdir testResults
 
-VOLUME ["/java"]
-ENV JAVA_HOME=/java \
-    PATH=/java/bin:$PATH \
-    JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
+ENV  JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
 
 COPY ./dockerfile/openliberty-mp-tck.sh /openliberty-mp-tck.sh
 

--- a/thirdparty_containers/payara-mp-tck/dockerfile/Dockerfile
+++ b/thirdparty_containers/payara-mp-tck/dockerfile/Dockerfile
@@ -47,10 +47,7 @@ WORKDIR /
 RUN mkdir testResults
 ENV PAYARA_HOME $WORKDIR
 
-VOLUME ["/java"]
-ENV JAVA_HOME=/java \
-    PATH=/java/bin:$PATH \
-    JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
+ENV JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
 
 COPY ./dockerfile/payara-mp-tck.sh /payara-mp-tck.sh
 

--- a/thirdparty_containers/scala/dockerfile/Dockerfile
+++ b/thirdparty_containers/scala/dockerfile/Dockerfile
@@ -47,10 +47,7 @@ RUN echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.lis
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823
 RUN apt-get update && apt-get install -y sbt
 
-VOLUME ["/java"]
-ENV JAVA_HOME=/java \
-    PATH=/java/bin:$PATH \
-    JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
+ENV  JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
 
 # This is the main script to run scala tests
 COPY ./dockerfile/scala-test.sh /scala-test.sh

--- a/thirdparty_containers/thorntail-mp-tck/dockerfile/Dockerfile
+++ b/thirdparty_containers/thorntail-mp-tck/dockerfile/Dockerfile
@@ -51,10 +51,7 @@ WORKDIR /
 RUN mkdir testResults
 ENV THORNTAIL_HOME $WORKDIR
 
-VOLUME ["/java"]
-ENV JAVA_HOME=/java \
-    PATH=/java/bin:$PATH \
-    JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
+ENV  JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
 
 COPY ./dockerfile/thorntail-mp-tck.sh /thorntail-mp-tck.sh
 

--- a/thirdparty_containers/tomcat/dockerfile/Dockerfile
+++ b/thirdparty_containers/tomcat/dockerfile/Dockerfile
@@ -49,10 +49,7 @@ RUN git clone https://github.com/openssl/openssl.git && cd /openssl && git check
 	&& make \
 	&& make install
 
-VOLUME ["/java"]
-ENV JAVA_HOME=/java \
-    PATH=/java/bin:$PATH \
-    JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
+ENV  JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
 
 # This is the main script to run tomcat tests.  
 COPY ./dockerfile/tomcat-test.sh /tomcat-test.sh

--- a/thirdparty_containers/wildfly/dockerfile/Dockerfile
+++ b/thirdparty_containers/wildfly/dockerfile/Dockerfile
@@ -47,10 +47,7 @@ RUN apt-get update \
 	&& apt-get -y install \
 	maven
 
-VOLUME ["/java"]
-ENV JAVA_HOME=/java \
-    PATH=/java/bin:$PATH \
-    JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
+ENV  JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
 
 # This is the main script to run wildfly tests. 
 COPY ./dockerfile/wildfly-test.sh /wildfly-test.sh

--- a/thirdparty_containers/wycheproof/dockerfile/Dockerfile
+++ b/thirdparty_containers/wycheproof/dockerfile/Dockerfile
@@ -44,10 +44,7 @@ WORKDIR /
 RUN mkdir testResults
 ENV WYCHEPROOF_HOME $WORKDIR
 
-VOLUME ["/java"]
-ENV JAVA_HOME=/java \
-    PATH=/java/bin:$PATH \
-    JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
+ENV  JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
 
 COPY ./dockerfile/wycheproof.sh /wycheproof.sh
 


### PR DESCRIPTION
The VOLUME instruction creates a mount point with the specified name and
marks it as holding externally mounted volumes from native host or other
containers. It is used to get performance without externally mounting
any volumes.The current VOLUME ["/java"] doesn't do anyting but occupy
the Docker area and create as dangling volume, which need docker
management to deal with.

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>