### PR TITLE
Support openjdknext build

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -38,7 +38,7 @@ def setupEnv() {
 	}
 
 	if ( params.JDK_VERSION ) {
-		env.JDK_VERSION = params.JDK_VERSION
+		env.JDK_VERSION = params.JDK_VERSION.equalsIgnoreCase("next") ? "" : params.JDK_VERSION
 	} else if ( params.JAVA_VERSION ) { // temporarily support JAVA_VERSION
 		env.JDK_VERSION = (params.JAVA_VERSION.trim())[2..-2];
 	}
@@ -193,7 +193,8 @@ def setup() {
 			OPENJ9_REPO_OPTION = (params.OPENJ9_REPO) ? "--openj9_repo ${params.OPENJ9_REPO}" : "--openj9_repo https://github.com/eclipse/openj9.git"
 			OPENJ9_BRANCH_OPTION = (params.OPENJ9_BRANCH) ? "--openj9_branch ${params.OPENJ9_BRANCH}" : ""
 			OPENJ9_SHA_OPTION = (params.OPENJ9_SHA) ? "--openj9_sha ${params.OPENJ9_SHA}" : ""
-
+			JDK_VERSION_OPTION = env.JDK_VERSION ? "-j ${env.JDK_VERSION}" : ""
+			JDK_IMPL_OPTION = env.JDK_IMPL ? "-i ${env.JDK_IMPL}" : ""
 			// system test repository exports to be used by systemtest/common.xml
 			if (params.ADOPTOPENJDK_SYSTEMTEST_REPO) {
 				env.ADOPTOPENJDK_SYSTEMTEST_REPO = params.ADOPTOPENJDK_SYSTEMTEST_REPO
@@ -225,7 +226,7 @@ def setup() {
 			VENDOR_TEST_BRANCHES = (params.VENDOR_TEST_BRANCHES) ? "--vendor_branches \"${params.VENDOR_TEST_BRANCHES}\"" : ""
 			VENDOR_TEST_DIRS = (params.VENDOR_TEST_DIRS) ? "--vendor_dirs \"${params.VENDOR_TEST_DIRS}\"" : ""
 			VENDOR_TEST_SHAS = (params.VENDOR_TEST_SHAS) ? "--vendor_shas \"${params.VENDOR_TEST_SHAS}\"" : ""
-			GET_SH_CMD = "./openjdk-tests/get.sh -s `pwd` -t `pwd`/openjdk-tests -p $PLATFORM -r ${SDK_RESOURCE} -j ${JDK_VERSION} -i ${JDK_IMPL} ${CUSTOMIZED_SDK_URL_OPTION} ${OPENJ9_REPO_OPTION} ${OPENJ9_BRANCH_OPTION} ${OPENJ9_SHA_OPTION} ${VENDOR_TEST_REPOS} ${VENDOR_TEST_BRANCHES} ${VENDOR_TEST_DIRS} ${VENDOR_TEST_SHAS}"
+			GET_SH_CMD = "./openjdk-tests/get.sh -s `pwd` -t `pwd`/openjdk-tests -p $PLATFORM -r ${SDK_RESOURCE} ${JDK_VERSION_OPTION} ${JDK_IMPL_OPTION} ${CUSTOMIZED_SDK_URL_OPTION} ${OPENJ9_REPO_OPTION} ${OPENJ9_BRANCH_OPTION} ${OPENJ9_SHA_OPTION} ${VENDOR_TEST_REPOS} ${VENDOR_TEST_BRANCHES} ${VENDOR_TEST_DIRS} ${VENDOR_TEST_SHAS}"
 
 			dir( WORKSPACE) {
 				// use sshagent with Jenkins credentials ID for all platforms except zOS

--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -100,9 +100,6 @@ ARCH_OS_LIST.each { ARCH_OS ->
 	}
 
 	JDK_VERSIONS.each { JDK_VERSION ->
-		// if JDK_VERSION is Next, set JDK_VERSION_VALUE to empty. Otherwise, set JDK_VERSION_VALUE = JDK_VERSION
-		JDK_VERSION_VALUE = JDK_VERSION == "Next" ? "" : JDK_VERSION
-
 		LEVELS.each { LEVEL ->
 			GROUPS.each { GROUP ->
 				def TEST_JOB_NAME = "Test_openjdk${JDK_VERSION}_${JDK_IMPL_SN}_${LEVEL}.${GROUP}_${ARCH_OS}${SUFFIX}"
@@ -121,7 +118,7 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							stringParam('OPENJ9_REPO', OPENJ9_REPO, "OpenJ9 git repo. Please use ssh for zos.")
 							stringParam('OPENJ9_BRANCH', "master", "OpenJ9 branch")
 							stringParam('OPENJ9_SHA', "", "OpenJ9 sha")
-							stringParam('JDK_VERSION', "${JDK_VERSION_VALUE}", "JDK version. i.e., 8, 11")
+							stringParam('JDK_VERSION', "${JDK_VERSION}", "JDK version. i.e., 8, 11")
 							stringParam('JDK_IMPL', JDK_IMPL, "JDK implementation, e.g. hotspot, openj9, sap")
 							stringParam('BUILD_LIST', BUILD_LIST, "Specific test directory to compile, set blank for all projects to be compiled")
 							stringParam('TARGET', "${LEVEL}.${GROUP}", "Test TARGET to execute")


### PR DESCRIPTION
- make JDK_VERSION and JDK_IMPL optional parameters
- if JDK_VERSION=next, then set JDK_VERSION to empty string in
Jenkinsfilebase
- Remove the check of JDK_VERSION in test job template. The value is
handled in Jenkinsfilebase

Closes: #1018

Signed-off-by: lanxia <lan_xia@ca.ibm.com>