### PR TITLE
Enable Thorntail MicroProfile TCKs instead of Thorntail Mircorprofile tests

### DIFF
--- a/thirdparty_containers/thorntail-mp-tck/dockerfile/thorntail-mp-tck.sh
+++ b/thirdparty_containers/thorntail-mp-tck/dockerfile/thorntail-mp-tck.sh
@@ -38,10 +38,12 @@ cd ${THORNTAIL_HOME}/
 
 #Build Thorntail 
 cd ${THORNTAIL_HOME}/thorntail/ 
-mvn clean install -Dmaven.test.skip=true
+mvn clean install -Pmicroprofile-tck -Dmaven.test.skip=true
 echo "build finished"
 
 set -e
-mvn test $TEST_OPTIONS
+echo "microprofile tck testsuite start"
+mvn test -Pmicroprofile-tck $TEST_OPTIONS
 set +e
+echo "microprofile tck testsuite finish"
 find ./ -type d -name 'surefire-reports' -exec cp -r "{}" /testResults \;

--- a/thirdparty_containers/thorntail-mp-tck/playlist.xml
+++ b/thirdparty_containers/thorntail-mp-tck/playlist.xml
@@ -16,7 +16,7 @@
 	<test>
 		<testCaseName>thorntail_microprofile_tck</testCaseName>
 		<command>docker run --name thorntail-mp-tck $(EXTRA_DOCKER_ARGS) adoptopenjdk-thorntail-mp-tck:latest \
-			 "-pl testsuite/testsuite-microprofile-jwt,testsuite/testsuite-microprofile-fault-tolerance,testsuite/testsuite-microprofile-metrics,testsuite/testsuite-microprofile-openapi,testsuite/testsuite-microprofile-restclient"; \
+			 "-pl testsuite/microprofile-tcks,testsuite/microprofile-tcks/config,testsuite/microprofile-tcks/fault-tolerance,testsuite/microprofile-tcks/health,testsuite/microprofile-tcks/jwt-auth,testsuite/microprofile-tcks/metrics,testsuite/microprofile-tcks/openapi,testsuite/microprofile-tcks/opentracing,testsuite/microprofile-tcks/restclient"; \
 			 $(TEST_STATUS); \
 			 docker cp thorntail-mp-tck:/testResults/surefire-reports $(REPORTDIR)/external_test_reports; \
 			 docker rm -f thorntail-mp-tck; \

--- a/thirdparty_containers/wycheproof/dockerfile/wycheproof.sh
+++ b/thirdparty_containers/wycheproof/dockerfile/wycheproof.sh
@@ -40,10 +40,11 @@ TEST_OPTIONS=$1
 
 cd ${WYCHEPROOF_HOME}/wycheproof
 
+set -e
 #Run OpenJDKAllTests 
 bazel test OpenJDKTest --genrule_strategy=standalone --spawn_strategy=standalone --verbose_failures
 
 #Run BouncyCastleAllTests tests 
 bazel test BouncyCastleTest --genrule_strategy=standalone --spawn_strategy=standalone --verbose_failures
-
+set +e
 find /root/.cache -type d -name 'testlogs' -exec cp -r "{}" /testResults \;


### PR DESCRIPTION
Thorntail is one of projects which provide a good test environment to demonstrate if JDK binaries are a good foundation for MicroProfile by running tests taken from the MicroProfile TCKs instead of any other MicroProfile test. Current enabled tests are actually part of Thorntail's own Mircorprofile tests. 

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>