### PR TITLE
Enable Apache Tomee MicroProfile TCKs

### DIFF
--- a/thirdparty_containers/tomee/build.xml
+++ b/thirdparty_containers/tomee/build.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<project name="Tomee-Test" default="build" basedir=".">
+	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+	<description>
+		Build Tomee test Docker image
+	</description>
+
+	<!-- set properties for this build -->
+	<property name="DEST" value="${BUILD_ROOT}/thirdparty_containers/tomee-test" />
+	<property name="src" location="." />
+
+	<target name="init">
+		<mkdir dir="${DEST}"/>
+	</target>
+
+	<target name="clean_image" depends="init" description="clean jenkins test docker image if there is one">
+		<exec executable="docker">
+			<arg line="rmi -f adoptopenjdk-tomee-test" />
+		</exec>
+	</target>
+
+	<target name="build_image" depends="clean_image" description="build TomEE test docker image">
+		<exec executable="docker"  failonerror="true">
+			<arg line="build -t adoptopenjdk-tomee-test -f dockerfile/Dockerfile --pull . --build-arg SDK=${JVM_VERSION}" />
+		</exec>
+	</target>
+
+	<target name="dist" depends="build_image" description="generate the distribution">
+		<copy todir="${DEST}">
+			<fileset dir="${src}" includes="*.xml, *.mk"/>
+		</copy>
+	</target>
+
+	<target name="build" >
+		<antcall target="dist" inheritall="true" />
+	</target>
+</project>

--- a/thirdparty_containers/tomee/dockerfile/Dockerfile
+++ b/thirdparty_containers/tomee/dockerfile/Dockerfile
@@ -1,0 +1,57 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This Dockerfile in thirdpart_containers/jenkins/dockerfile dir is used to create an image with
+# AdoptOpenJDK jdk binary installed. Basic test dependent executions
+# are installed during the building process.
+#
+# Build example: `docker build -t adoptopenjdk-jenkins-test -f Dockerfile ../.`
+#
+# This Dockerfile builds image based on adoptopenjdk/openjdk8:latest.
+# If you want to build image based on other images, please use
+# `--build-arg list` to specify your base image
+#
+# Build example: `docker build --build-arg IMAGE_NAME=<image_name> --build-arg IMAGE_VERSION=<image_version >-t adoptopenjdk-jenkins-test .`
+
+ARG SDK=openjdk8
+ARG IMAGE_NAME=adoptopenjdk/$SDK
+ARG IMAGE_VERSION=latest
+
+FROM $IMAGE_NAME:$IMAGE_VERSION
+
+# Install test dependent executable files
+RUN apt-get update \
+	&& apt-get -y install \
+	ant \
+	curl \
+	git \
+	unzip \
+	vim \
+	wget
+
+# Install TomEE tests dependent
+RUN apt-get update \
+	&& apt-get -y install \
+	maven
+	
+ENV  JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
+
+# This is the main script to run jenkins tests
+COPY ./dockerfile/tomee-test.sh /tomee-test.sh
+
+# Clone TomEE src to /tomee
+WORKDIR /
+RUN mkdir testResults
+RUN git clone https://github.com/apache/tomee.git
+
+ENTRYPOINT ["/bin/bash", "/tomee-test.sh"]
+CMD [""]

--- a/thirdparty_containers/tomee/dockerfile/tomee-test.sh
+++ b/thirdparty_containers/tomee/dockerfile/tomee-test.sh
@@ -1,0 +1,50 @@
+#/bin/bash
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if [ -d /java/jre/bin ];then
+	echo "Using mounted Java8"
+	export JAVA_BIN=/java/jre/bin
+	export JAVA_HOME=/java
+	export PATH=$JAVA_BIN:$PATH
+elif [ -d /java/bin ]; then
+	echo "Using mounted Java"
+	export JAVA_BIN=/java/bin
+	export JAVA_HOME=/java
+	export PATH=$JAVA_BIN:$PATH
+else
+	echo "Using docker image default Java"
+	java_path=$(type -p java)
+	suffix="/java"
+	java_root=${java_path%$suffix}
+	export JAVA_BIN="$java_root"
+	echo "JAVA_BIN is: $JAVA_BIN"
+	export JAVA_HOME="${java_root%/bin}"
+fi
+
+java -version
+#begin tomee test
+
+cd /tomee
+
+#set -e
+echo "Build TomEE without running test"
+mvn -Pquick -Dsurefire.useFile=false -DdisableXmlReport=true -DuniqueVersion=false -ff -Dassemble -DskipTests -DfailIfNoTests=false clean install
+echo "Build TomEE completed"
+
+echo "Run Microprofile TCK"
+cd tck/microprofile-tck
+mvn test -Denforcer.fail=false
+set +e
+echo "Tomee Microprofile TCK completed"
+find ./ -type d -name 'surefire-reports' -exec cp -r "{}" /testResults \;

--- a/thirdparty_containers/tomee/playlist.xml
+++ b/thirdparty_containers/tomee/playlist.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+-->
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
+	<test>
+		<testCaseName>tomee_test</testCaseName>
+		<command>docker run --name tomee-test $(EXTRA_DOCKER_ARGS) adoptopenjdk-tomee-test:latest; \
+			 $(TEST_STATUS); \
+			 docker cp tomee-test:/testResults/surefire-reports $(REPORTDIR)/external_test_reports; \
+			 docker rm -f tomee-test; \
+			 docker rmi -f adoptopenjdk-tomee-test
+		</command>
+		<subsets>
+			<subset>8</subset>
+		</subsets>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>external</group>
+		</groups>
+	</test>
+</playlist>


### PR DESCRIPTION
Limit to jdk8 for now as it mentioned that 

> Apache TomEE is built with Apache Maven >= 3.3.9 and Java 8 in https://github.com/apache/tomee

Related with #172 

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>