### PR TITLE
Remove AND operator between dependent commands

### DIFF
--- a/thirdparty_containers/lucene-solr/dockerfile/lucene-solr-test.sh
+++ b/thirdparty_containers/lucene-solr/dockerfile/lucene-solr-test.sh
@@ -18,7 +18,7 @@ if [ -d /java/jre/bin ];then
 	export JAVA_HOME=/java
 	export PATH=$JAVA_BIN:$PATH
 elif [ -d /java/bin ]; then
-	echo "Using mounted Java9"
+	echo "Using mounted Java"
 	export JAVA_BIN=/java/bin
 	export JAVA_HOME=/java
 	export PATH=$JAVA_BIN:$PATH
@@ -38,9 +38,10 @@ cd ${LUCENE_SOLR_HOME}/lucene-solr
 pwd
 set -e
 
-echo "Compile and execute lucene-solr test" && \
-${ANT_HOME}/bin/ant -Divy_install_path=${ANT_HOME}/lib -lib ${ANT_HOME}/lib ivy-bootstrap && \
-${ANT_HOME}/bin/ant -Divy_install_path=${ANT_HOME}/lib -lib ${ANT_HOME}/lib -f ${LUCENE_SOLR_HOME}/lucene-solr/build.xml -Duser.home=${LUCENE_SOLR_HOME} -Dcommon.dir=${LUCENE_SOLR_HOME}/lucene-solr/lucene compile && \
+${ANT_HOME}/bin/ant -Divy_install_path=${ANT_HOME}/lib -lib ${ANT_HOME}/lib ivy-bootstrap
+echo "Compile and execute lucene-solr test"
+${ANT_HOME}/bin/ant -Divy_install_path=${ANT_HOME}/lib -lib ${ANT_HOME}/lib -f ${LUCENE_SOLR_HOME}/lucene-solr/build.xml -Duser.home=${LUCENE_SOLR_HOME} -Dcommon.dir=${LUCENE_SOLR_HOME}/lucene-solr/lucene compile
+echo "Execute lucene-solr test"
 ${ANT_HOME}/bin/ant -Divy_install_path=${ANT_HOME}/lib -lib ${ANT_HOME}/lib -f ${LUCENE_SOLR_HOME}/lucene-solr/build.xml -Duser.home=${LUCENE_SOLR_HOME} -Dcommon.dir=${LUCENE_SOLR_HOME}/lucene-solr/lucene test
 
 set +e

--- a/thirdparty_containers/tomcat/playlist.xml
+++ b/thirdparty_containers/tomcat/playlist.xml
@@ -19,7 +19,7 @@
 		$(TEST_STATUS); \
 		docker cp tomcat-test:/tomcat/output/build/logs $(REPORTDIR)/external_test_reports; \
 		docker rm tomcat-test; \
-		docker rmi -adoptopenjdk-tomcat-test
+		docker rmi adoptopenjdk-tomcat-test
 	</command>
 		<levels>
 			<level>extended</level>


### PR DESCRIPTION
Docker run status depends on the the shell script return status. Using
the AND operator with ant the failure(non-zero exit) can only be caught
when last command fails.

Separating compile and test step can also make the steps more clear 

Fix lucenesolr test build fake pass. 

```
07:08:47  BUILD FAILED
07:08:47  /lucene-solr/build.xml:21: The following error occurred while executing this line:
07:08:47  /lucene-solr/lucene/common-build.xml:297: Minimum supported Java version is 11.
07:08:47  
07:08:47  Total time: 1 second
07:08:48  
```

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>