### PR TITLE
Make JRE_IMAGE parameter workspace relative

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -47,7 +47,7 @@ def setupEnv() {
 	}
 
 	env.TEST_JDK_HOME = "$WORKSPACE/openjdkbinary/j2sdk-image"
-	env.JRE_IMAGE = "$WORKSPACE/openjdkbinary/j2jre-image"
+	env.JRE_IMAGE = params.JRE_IMAGE ? "${WORKSPACE}/${params.JRE_IMAGE}" : "$WORKSPACE/openjdkbinary/j2jre-image"
 	env.JVM_VERSION = params.JVM_VERSION ? params.JVM_VERSION : ""
 	env.JVM_OPTIONS = params.JVM_OPTIONS ? params.JVM_OPTIONS : ""
 	env.EXTRA_OPTIONS = params.EXTRA_OPTIONS ? params.EXTRA_OPTIONS : ""
@@ -94,9 +94,6 @@ def setupEnv() {
 		env.DIAGNOSTICLEVEL ='noDetails'
 	}
 
-	if (params.JRE_IMAGE) {
-		env.JRE_IMAGE = params.JRE_IMAGE
-	}
 	// Optional parameter RELEASE_TAG and it is only used in openjdk regression test
 	if( params.RELEASE_TAG ) {
 		env.RELEASE_TAG = params.RELEASE_TAG


### PR DESCRIPTION
Prior to this patch it was already possible to pass `JRE_IMAGE` path via a
Jenkins parameter. However, string parameters won't get String-interpolated.
That means a param value of `${WORKSPACE}/foo/bar` results in a literal
`${WORKSPACE}` which isn't the user's intention.

This patch modifies the JRE_IMAGE environment variable to be workspace
relative if it comes from a Jenkins parameter. This solves a test issue we have
been seeing for upstream JDK builds, where math JRE tests would fail for no good
reason. After this patch one can set `JRE_IMAGE=openjdkbinary/j2sdk-image/jre`
and would then have the tests passing. Thoughts?

Tested with a sandbox grinder here:
https://ci.adoptopenjdk.net/view/Test_grinder/job/Grinder_Sandbox/387/