### PR TITLE
Fix example in doc/userGuide.md

### DIFF
--- a/doc/userGuide.md
+++ b/doc/userGuide.md
@@ -121,6 +121,7 @@ $ export JAVA_BIN=$OPENJDK_BUILD/jre/bin
 $ export BUILD_LIST=openjdk
 $ export BUILD_ROOT=$TOP_DIR/test-results
 $ export JRE_IMAGE=$OPENJDK_BUILD/../j2re-image
+$ export TEST_JDK_HOME=$OPENJDK_BUILD
 $ ./get.sh -t $TEST_DIR
 $ ./maketest.sh $TEST_DIR
 $ OPENJDK_DIR=$OPENJDK_SOURCES ./maketest.sh $TEST_DIR _sanity.openjdk


### PR DESCRIPTION
TEST_JDK_HOME is required which isn't being
set in the example.

Without it running the tests fails early with:

```
/tmp/tmp.KOKDEmgcEN/openjdk-tests
Run /bin/java -version
openjdk version "1.8.0_212"
OpenJDK Runtime Environment (build 1.8.0_212-b04)
OpenJDK 64-Bit Server VM (build 25.212-b04, mixed mode)
get testKitGen and functional test material...
git clone  https://github.com/eclipse/openj9.git
run_configure.mk:31: *** Please provide TEST_JDK_HOME value..  Stop.
make: Entering directory '/tmp/tmp.KOKDEmgcEN/openjdk-tests'
make: autoGen.mk: No such file or directory
make: *** No rule to make target 'autoGen.mk'.  Stop.
make: Leaving directory '/tmp/tmp.KOKDEmgcEN/openjdk-tests'
```