### PR TITLE
Accommodate other possible Docker base images

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -98,6 +98,9 @@ def setupEnv() {
 	if( params.RELEASE_TAG ) {
 		env.RELEASE_TAG = params.RELEASE_TAG
 	}
+	if( params.DOCKERIMAGE_TAG ) {
+		env.DOCKERIMAGE_TAG = params.DOCKERIMAGE_TAG
+	}
 	sh 'printenv'
 }
 

--- a/thirdparty_containers/build.xml
+++ b/thirdparty_containers/build.xml
@@ -22,15 +22,25 @@
 
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/thirdparty_containers" />
-
+	<property environment="env" />
+	<if>
+		<isset property="env.DOCKERIMAGE_TAG"/>
+		<then>
+			<property name="dockerImageTag" value="${env.DOCKERIMAGE_TAG}"/>
+		</then>
+		<else>
+			<property name="dockerImageTag" value="latest"/>
+		</else>
+	</if>
 	<target name="init" depends="docker_prune">
 		<mkdir dir="${DEST}" />
 	</target>
 
 	<target name="build" depends="dist">
 		<subant target="">
+			<property name="dockerImageTag" value="${dockerImageTag}"/>
 			<fileset dir="." includes="*/build.xml" />
-		</subant>		
+		</subant>
 	</target>
 	
 	<target name="dist" depends="init">

--- a/thirdparty_containers/derby/build.xml
+++ b/thirdparty_containers/derby/build.xml
@@ -4,14 +4,12 @@
 	<description>
 		Build derby-test docker image
 	</description>
-
+	<import file="${TEST_ROOT}/thirdparty_containers/build.xml"/>
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/thirdparty_containers/derby-test" />
-	<property name="dist" location="${DEST}/${JDK_VERSION}" />
 	<property name="src" location="." />
-
 	<target name="init">
-		<mkdir dir="${dist}"/>
+		<mkdir dir="${DEST}"/>
 	</target>
 
 	<target name="clean_image" depends="init" description="clean derby test docker image if there is one">
@@ -22,7 +20,7 @@
 
 	<target name="build_image" depends="clean_image" description="build derby test docker image">
 		<exec executable="docker"  failonerror="true">
-			<arg line="build -t adoptopenjdk-derby-test -f dockerfile/Dockerfile --pull . --build-arg SDK=${JVM_VERSION}" />
+			<arg line="build -t adoptopenjdk-derby-test -f dockerfile/Dockerfile --pull . --build-arg SDK=${JVM_VERSION} --build-arg IMAGE_VERSION=${dockerImageTag}"/>
 		</exec>
 	</target>
 

--- a/thirdparty_containers/elasticsearch/build.xml
+++ b/thirdparty_containers/elasticsearch/build.xml
@@ -5,6 +5,7 @@
 		Build elasticsearch-test Docker image
 	</description>
 
+	<import file="${TEST_ROOT}/thirdparty_containers/build.xml"/>
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/thirdparty_containers/elasticsearch-test" />
 	<property name="src" location="." />
@@ -37,7 +38,7 @@
 			</else>
 		</if>
 		<exec executable="docker"  failonerror="true">
-			<arg line="build -t adoptopenjdk-elasticsearch-test -f dockerfile/Dockerfile --pull . --build-arg SDK=${JVM_VERSION} --build-arg ELASTIC_VERSION=${ELASTIC_VERSION}"/>
+			<arg line="build -t adoptopenjdk-elasticsearch-test -f dockerfile/Dockerfile --pull . --build-arg SDK=${JVM_VERSION} --build-arg ELASTIC_VERSION=${ELASTIC_VERSION} --build-arg IMAGE_VERSION=${dockerImageTag}"/>
 		</exec>
 	</target>
 

--- a/thirdparty_containers/example-test/build.xml
+++ b/thirdparty_containers/example-test/build.xml
@@ -4,14 +4,14 @@
 	<description>
 		Build example-test Docker image
 	</description>
+	<import file="${TEST_ROOT}/thirdparty_containers/build.xml"/>
 
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/thirdparty_containers/example-test" />
-	<property name="dist" location="${DEST}/${JDK_VERSION}" />
 	<property name="src" location="." />
 
 	<target name="init">
-		<mkdir dir="${dist}"/>
+		<mkdir dir="${DEST}"/>
 	</target>
 
 	<target name="clean_image" depends="init" description="clean example test docker image if there is one">
@@ -22,7 +22,7 @@
 
 	<target name="build_image" depends="clean_image" description="build example test docker image">
 		<exec executable="docker"  failonerror="true">
-			<arg line="build -t adoptopenjdk-example-test -f dockerfile/Dockerfile --pull . --build-arg SDK=${JVM_VERSION}" />
+			<arg line="build -t adoptopenjdk-example-test -f dockerfile/Dockerfile --pull . --build-arg SDK=${JVM_VERSION} --build-arg IMAGE_VERSION=${dockerImageTag}"/>
 		</exec>
 	</target>
 

--- a/thirdparty_containers/functional-test/build.xml
+++ b/thirdparty_containers/functional-test/build.xml
@@ -4,6 +4,7 @@
 	<description>
 		Build functional-test Docker image
 	</description>
+	<import file="${TEST_ROOT}/thirdparty_containers/build.xml"/>
 
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/thirdparty_containers/functional-test" />
@@ -21,7 +22,7 @@
 
 	<target name="build_image" depends="clean_image" description="build functional test docker image">
 		<exec executable="docker"  failonerror="true">
-			<arg line="build -t adoptopenjdk-functional-test -f dockerfile/Dockerfile --pull . --build-arg SDK=${JVM_VERSION}" />
+			<arg line="build -t adoptopenjdk-functional-test -f dockerfile/Dockerfile --pull . --build-arg SDK=${JVM_VERSION} --build-arg IMAGE_VERSION=${dockerImageTag}"/>
 		</exec>
 	</target>
 

--- a/thirdparty_containers/jenkins/build.xml
+++ b/thirdparty_containers/jenkins/build.xml
@@ -4,6 +4,7 @@
 	<description>
 		Build Jenkins test Docker image
 	</description>
+	<import file="${TEST_ROOT}/thirdparty_containers/build.xml"/>
 
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/thirdparty_containers/jenkins-test" />
@@ -18,10 +19,9 @@
 			<arg line="rmi -f adoptopenjdk-jenkins-test" />
 		</exec>
 	</target>
-
 	<target name="build_image" depends="clean_image" description="build jenkins test docker image">
 		<exec executable="docker"  failonerror="true">
-			<arg line="build -t adoptopenjdk-jenkins-test -f dockerfile/Dockerfile --pull . --build-arg SDK=${JVM_VERSION}" />
+			<arg line="build -t adoptopenjdk-jenkins-test -f dockerfile/Dockerfile --pull . --build-arg SDK=${JVM_VERSION} --build-arg IMAGE_VERSION=${dockerImageTag}"/>
 		</exec>
 	</target>
 

--- a/thirdparty_containers/kafka/build.xml
+++ b/thirdparty_containers/kafka/build.xml
@@ -4,6 +4,7 @@
 	<description>
 		Build kafka-test Docker image
 	</description>
+	<import file="${TEST_ROOT}/thirdparty_containers/build.xml"/>
 
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/thirdparty_containers/kafka-test" />
@@ -21,7 +22,7 @@
 
 	<target name="build_image" depends="clean_image" description="build kafka test docker image">
 		<exec executable="docker"  failonerror="true">
-			<arg line="build -t adoptopenjdk-kafka-test -f dockerfile/Dockerfile --pull . --build-arg SDK=${JVM_VERSION}" />
+			<arg line="build -t adoptopenjdk-kafka-test -f dockerfile/Dockerfile --pull . --build-arg SDK=${JVM_VERSION} --build-arg IMAGE_VERSION=${dockerImageTag}"/>
 		</exec>
 	</target>
 

--- a/thirdparty_containers/lucene-solr/build.xml
+++ b/thirdparty_containers/lucene-solr/build.xml
@@ -4,6 +4,7 @@
 	<description>
 		Build lucene-solr-test Docker image
 	</description>
+	<import file="${TEST_ROOT}/thirdparty_containers/build.xml"/>
 
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/thirdparty_containers/lucene-solr-test" />
@@ -32,7 +33,7 @@
 			</else>
 		</if>
 		<exec executable="docker"  failonerror="true">
-			<arg line="build -t adoptopenjdk-lucene-solr-test -f dockerfile/Dockerfile --pull . --build-arg SDK=${JVM_VERSION} --build-arg LUCENE_SOLR_TAG=${LUCENE_SOLR_TAG}"/>
+			<arg line="build -t adoptopenjdk-lucene-solr-test -f dockerfile/Dockerfile --pull . --build-arg SDK=${JVM_VERSION} --build-arg LUCENE_SOLR_TAG=${LUCENE_SOLR_TAG} --build-arg IMAGE_VERSION=${dockerImageTag}"/>
 		</exec>
 	</target>
 

--- a/thirdparty_containers/openliberty-mp-tck/build.xml
+++ b/thirdparty_containers/openliberty-mp-tck/build.xml
@@ -4,6 +4,7 @@
 	<description>
 		Build openliberty-mp-tck Docker image
 	</description>
+	<import file="${TEST_ROOT}/thirdparty_containers/build.xml"/>
 
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/thirdparty_containers/openliberty-mp-tck" />
@@ -21,7 +22,7 @@
 
 	<target name="build_image" depends="clean_image" description="build openliberty-mp-tck tck docker image">
 		<exec executable="docker"  failonerror="true">
-			<arg line="build -t adoptopenjdk-openliberty-mp-tck -f dockerfile/Dockerfile --pull . --build-arg SDK=${JVM_VERSION}" />
+			<arg line="build -t adoptopenjdk-openliberty-mp-tck -f dockerfile/Dockerfile --pull . --build-arg SDK=${JVM_VERSION} --build-arg IMAGE_VERSION=${dockerImageTag}"/>
 		</exec>
 	</target>
 

--- a/thirdparty_containers/payara-mp-tck/build.xml
+++ b/thirdparty_containers/payara-mp-tck/build.xml
@@ -4,6 +4,7 @@
 	<description>
 		Build payara-mp-tck Docker image
 	</description>
+	<import file="${TEST_ROOT}/thirdparty_containers/build.xml"/>
 
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/thirdparty_containers/payara-mp-tck" />
@@ -21,7 +22,7 @@
 
 	<target name="build_image" depends="clean_image" description="build payara-mp-tck tck docker image">
 		<exec executable="docker"  failonerror="true">
-			<arg line="build -t adoptopenjdk-payara-mp-tck -f dockerfile/Dockerfile --pull . --build-arg SDK=${JVM_VERSION}" />
+			<arg line="build -t adoptopenjdk-payara-mp-tck -f dockerfile/Dockerfile --pull . --build-arg SDK=${JVM_VERSION} --build-arg IMAGE_VERSION=${dockerImageTag}"/>
 		</exec>
 	</target>
 

--- a/thirdparty_containers/scala/build.xml
+++ b/thirdparty_containers/scala/build.xml
@@ -4,14 +4,14 @@
 	<description>
 		Build Scala test Docker image
 	</description>
+	<import file="${TEST_ROOT}/thirdparty_containers/build.xml"/>
 
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/thirdparty_containers/scala-test" />
-	<property name="dist" location="${DEST}/${JDK_VERSION}" />
 	<property name="src" location="." />
 
 	<target name="init">
-		<mkdir dir="${dist}"/>
+		<mkdir dir="${DEST}"/>
 	</target>
 
 	<target name="clean_image" depends="init" description="clean scala test docker image if there is one">
@@ -22,7 +22,7 @@
 
 	<target name="build_image" depends="clean_image" description="build scala test docker image">
 		<exec executable="docker"  failonerror="true">
-			<arg line="build -t adoptopenjdk-scala-test -f dockerfile/Dockerfile --pull . --build-arg SDK=${JVM_VERSION}" />
+			<arg line="build -t adoptopenjdk-scala-test -f dockerfile/Dockerfile --pull . --build-arg SDK=${JVM_VERSION} --build-arg IMAGE_VERSION=${dockerImageTag}"/>
 		</exec>
 	</target>
 

--- a/thirdparty_containers/system-test/build.xml
+++ b/thirdparty_containers/system-test/build.xml
@@ -4,6 +4,7 @@
 	<description>
 		Build system-test Docker image
 	</description>
+	<import file="${TEST_ROOT}/thirdparty_containers/build.xml"/>
 
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/thirdparty_containers/system-test" />
@@ -21,7 +22,7 @@
 
 	<target name="build_image" depends="clean_image" description="build system test docker image">
 		<exec executable="docker"  failonerror="true">
-			<arg line="build -t adoptopenjdk-system-test -f dockerfile/Dockerfile --pull . --build-arg SDK=${JVM_VERSION}" />
+			<arg line="build -t adoptopenjdk-system-test -f dockerfile/Dockerfile --pull . --build-arg SDK=${JVM_VERSION} --build-arg IMAGE_VERSION=${dockerImageTag}"/>
 		</exec>
 	</target>
 

--- a/thirdparty_containers/thorntail-mp-tck/build.xml
+++ b/thirdparty_containers/thorntail-mp-tck/build.xml
@@ -4,6 +4,7 @@
 	<description>
 		Build thorntail-mp-tck Docker image
 	</description>
+	<import file="${TEST_ROOT}/thirdparty_containers/build.xml"/>
 
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/thirdparty_containers/thorntail-mp-tck" />
@@ -21,7 +22,7 @@
 
 	<target name="build_image" depends="clean_image" description="build thorntail-mp-tck tck docker image">
 		<exec executable="docker"  failonerror="true">
-			<arg line="build -t adoptopenjdk-thorntail-mp-tck -f dockerfile/Dockerfile --pull . --build-arg SDK=${JVM_VERSION}" />
+			<arg line="build -t adoptopenjdk-thorntail-mp-tck -f dockerfile/Dockerfile --pull . --build-arg SDK=${JVM_VERSION} --build-arg IMAGE_VERSION=${dockerImageTag}"/>
 		</exec>
 	</target>
 

--- a/thirdparty_containers/tomcat/build.xml
+++ b/thirdparty_containers/tomcat/build.xml
@@ -4,6 +4,7 @@
 	<description>
 		Build tomcat-test Docker image
 	</description>
+	<import file="${TEST_ROOT}/thirdparty_containers/build.xml"/>
 
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/thirdparty_containers/tomcat-test" />
@@ -21,7 +22,7 @@
 
 	<target name="build_image" depends="clean_image" description="build tomcat test docker image">
 		<exec executable="docker"  failonerror="true">
-			<arg line="build -t adoptopenjdk-tomcat-test -f dockerfile/Dockerfile --pull . --build-arg SDK=${JVM_VERSION}" />
+			<arg line="build -t adoptopenjdk-tomcat-test -f dockerfile/Dockerfile --pull . --build-arg SDK=${JVM_VERSION} --build-arg IMAGE_VERSION=${dockerImageTag}"/>
 		</exec>
 	</target>
 

--- a/thirdparty_containers/tomee/build.xml
+++ b/thirdparty_containers/tomee/build.xml
@@ -4,6 +4,7 @@
 	<description>
 		Build Tomee test Docker image
 	</description>
+	<import file="${TEST_ROOT}/thirdparty_containers/build.xml"/>
 
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/thirdparty_containers/tomee-test" />
@@ -21,7 +22,7 @@
 
 	<target name="build_image" depends="clean_image" description="build TomEE test docker image">
 		<exec executable="docker"  failonerror="true">
-			<arg line="build -t adoptopenjdk-tomee-test -f dockerfile/Dockerfile --pull . --build-arg SDK=${JVM_VERSION}" />
+			<arg line="build -t adoptopenjdk-tomee-test -f dockerfile/Dockerfile --pull . --build-arg SDK=${JVM_VERSION} --build-arg IMAGE_VERSION=${dockerImageTag}"/>
 		</exec>
 	</target>
 

--- a/thirdparty_containers/wildfly/build.xml
+++ b/thirdparty_containers/wildfly/build.xml
@@ -4,6 +4,7 @@
 	<description>
 		Build wildfly-test Docker image
 	</description>
+	<import file="${TEST_ROOT}/thirdparty_containers/build.xml"/>
 
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/thirdparty_containers/wildfly-test" />
@@ -21,7 +22,7 @@
 
 	<target name="build_image" depends="clean_image" description="build wildfly test docker image">
 		<exec executable="docker"  failonerror="true">
-			<arg line="build -t adoptopenjdk-wildfly-test -f dockerfile/Dockerfile --pull . --build-arg SDK=${JVM_VERSION}" />
+			<arg line="build -t adoptopenjdk-wildfly-test -f dockerfile/Dockerfile --pull . --build-arg SDK=${JVM_VERSION} --build-arg IMAGE_VERSION=${dockerImageTag}"/>
 		</exec>
 	</target>
 

--- a/thirdparty_containers/wycheproof/build.xml
+++ b/thirdparty_containers/wycheproof/build.xml
@@ -4,6 +4,7 @@
 	<description>
 		Build wycheproof Docker image
 	</description>
+	<import file="${TEST_ROOT}/thirdparty_containers/build.xml"/>
 
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/thirdparty_containers/wycheproof" />
@@ -21,7 +22,7 @@
 
 	<target name="build_image" depends="clean_image" description="build wycheproof tck docker image">
 		<exec executable="docker"  failonerror="true">
-			<arg line="build -t adoptopenjdk-wycheproof -f dockerfile/Dockerfile --pull . --build-arg SDK=${JVM_VERSION}" />
+			<arg line="build -t adoptopenjdk-wycheproof -f dockerfile/Dockerfile --pull . --build-arg SDK=${JVM_VERSION} --build-arg IMAGE_VERSION=${dockerImageTag}"/>
 		</exec>
 	</target>
 


### PR DESCRIPTION
1. Set Docker base image tag in parent build.xml
2. Import parent build.xml. Otherwise when setting BUILD_LIST to
specific subproject, targets in parent build.xml do not run actually.

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>