### PR TITLE
Add support for auto generate jck builds

### DIFF
--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -24,6 +24,10 @@ if (!binding.hasVariable('ARTIFACTORY_REPO')) ARTIFACTORY_REPO = ""
 if (!binding.hasVariable('ARTIFACTORY_ROOT_DIR')) ARTIFACTORY_ROOT_DIR = ""
 if (!binding.hasVariable('TIME_LIMIT')) TIME_LIMIT = "10"
 if (!binding.hasVariable('SUFFIX')) SUFFIX = ""
+if (!binding.hasVariable('JCK_GIT_REPO')) JCK_GIT_REPO = ""
+if (!binding.hasVariable('JCK_GIT_REPO_PREFIX')) JCK_GIT_REPO_PREFIX = ""
+if (!binding.hasVariable('SSH_AGENT_CREDENTIAL')) SSH_AGENT_CREDENTIAL = ""
+
 if (!binding.hasVariable('BUILDS_TO_KEEP')) {
 	BUILDS_TO_KEEP = 10
 } else {
@@ -108,6 +112,10 @@ ARCH_OS_LIST.each { ARCH_OS ->
 					BUILD_LIST = GROUP_BUILD_LIST_MAP[GROUP]
 				}
 
+				// for jck builds, if JCK_GIT_REPO_PREFIX is set, set JCK_GIT_REPO if it is not set
+				if (GROUP == "jck" && JCK_GIT_REPO_PREFIX && !JCK_GIT_REPO) {
+					JCK_GIT_REPO = "${JCK_GIT_REPO_PREFIX}/JCK${JDK_VERSION}-unzipped.git"
+				}
 				pipelineJob("$TEST_JOB_NAME") {
  					description('<h1>THIS IS AN AUTOMATICALLY GENERATED JOB. PLEASE DO NOT MODIFY, IT WILL BE OVERWRITTEN.</h1><p>This job is defined in testJobTemplate in the https://github.com/AdoptOpenJDK/openjdk-tests repo. If you wish to change the job, please modify testJobTemplate script.</p>')
 					definition {
@@ -132,8 +140,8 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							stringParam('JVM_OPTIONS', "", "Use this to replace the test original command line options")
 							stringParam('ITERATIONS',"1", "Number of times to repeat execution of test target")
 							stringParam('LABEL', "", "Jenkins node label to run on, leave this blank to get sent to any machine matching the platform, set to node name for runs a particular machine")
-							stringParam('JCK_GIT_REPO', "", "For JCK test only")
-							stringParam('SSH_AGENT_CREDENTIAL', "", "Optional. Only use when ssh credentials are needed")
+							stringParam('JCK_GIT_REPO', JCK_GIT_REPO, "For JCK test only")
+							stringParam('SSH_AGENT_CREDENTIAL', SSH_AGENT_CREDENTIAL, "Optional. Only use when ssh credentials are needed")
 							booleanParam('KEEP_WORKSPACE', false, "Keep workspace on the machine")
 							stringParam('ARTIFACTORY_SERVER', ARTIFACTORY_SERVER, "Optional. Default is to upload test output (failed build) onto artifactory only. By unset this value, test output will be archived to Jenkins")
 							stringParam('ARTIFACTORY_REPO', ARTIFACTORY_REPO, "Optional. It should be used with ARTIFACTORY_SERVER")


### PR DESCRIPTION
- for jck build, if JCK_GIT_REPO_PREFIX is set, set JCK_GIT_REPO if it
is not set
- JCK_GIT_REPO_PREFIX will be ignored by non-jck builds

Signed-off-by: lanxia <lan_xia@ca.ibm.com>