### PR TITLE
Shallow clone OpenJ9

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -245,13 +245,14 @@ getTestKitGenAndFunctionalTestMaterial()
 		OPENJ9_BRANCH="-b $OPENJ9_BRANCH"
 	fi
 
-	echo "git clone $OPENJ9_BRANCH $OPENJ9_REPO"
-	git clone -q $OPENJ9_BRANCH $OPENJ9_REPO
+	echo "git clone --depth 1 $OPENJ9_BRANCH $OPENJ9_REPO"
+	git clone --depth 1 -q $OPENJ9_BRANCH $OPENJ9_REPO
 
 	if [ "$OPENJ9_SHA" != "" ]
 	then
 		echo "update to openj9 sha: $OPENJ9_SHA"
 		cd openj9
+		git fetch --unshallow
 		git fetch -q --tags $OPENJ9_REPO +refs/pull/*:refs/remotes/origin/pr/*
 		git checkout -q $OPENJ9_SHA
 		cd $TESTDIR


### PR DESCRIPTION
This change effectively reverts 285d19b9 to do a shallow clone of
OpenJ9. If a specific SHA is specified we will fetch all the SHAs
by a call to `git fetch --unshallow` which is put the repository in
a state identical to one that did not do a shallow clone.

This change is the best of both worlds as now for clones which do
not care about a particular SHA no longer incur the cost of cloning
the full repository history and clones which need a specific SHA
should always work.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>