### PR TITLE
Exclude java_lang_invoke_MethodHandlesProxiesTest for openjdk8-openj9

### DIFF
--- a/openjdk/ProblemList_openjdk8-openj9.txt
+++ b/openjdk/ProblemList_openjdk8-openj9.txt
@@ -46,6 +46,7 @@ java/lang/invoke/LFCaching/LFMultiThreadCachingTest.java		https://github.com/ecl
 java/lang/invoke/LFCaching/LFSingleThreadCachingTest.java		https://github.com/eclipse/openj9/issues/1128	generic-all
 java/lang/invoke/LambdaFormTest.java		https://github.com/eclipse/openj9/issues/1128	generic-all
 java/lang/invoke/MethodHandles/TestCatchException.java		https://github.com/eclipse/openj9/issues/1128	generic-all
+java_lang_invoke_MethodHandlesProxiesTest   https://github.com/eclipse/openj9/issues/5950   generic-all
 java/lang/invoke/MethodHandlesTest.java		https://github.com/eclipse/openj9/issues/1128	generic-all
 java/lang/invoke/PrivateInvokeTest.java		https://github.com/eclipse/openj9/issues/1128	generic-all
 java/lang/invoke/ProtectedMemberDifferentPackage/Test.java		https://github.com/eclipse/openj9/issues/1128	generic-all

--- a/openjdk/ProblemList_openjdk8-openj9.txt
+++ b/openjdk/ProblemList_openjdk8-openj9.txt
@@ -46,7 +46,7 @@ java/lang/invoke/LFCaching/LFMultiThreadCachingTest.java		https://github.com/ecl
 java/lang/invoke/LFCaching/LFSingleThreadCachingTest.java		https://github.com/eclipse/openj9/issues/1128	generic-all
 java/lang/invoke/LambdaFormTest.java		https://github.com/eclipse/openj9/issues/1128	generic-all
 java/lang/invoke/MethodHandles/TestCatchException.java		https://github.com/eclipse/openj9/issues/1128	generic-all
-java_lang_invoke_MethodHandlesProxiesTest.java 	https://github.com/eclipse/openj9/issues/5950   generic-all
+java/lang/invoke/MethodHandlesProxiesTest.java 	https://github.com/eclipse/openj9/issues/5950   generic-all
 java/lang/invoke/MethodHandlesTest.java		https://github.com/eclipse/openj9/issues/1128	generic-all
 java/lang/invoke/PrivateInvokeTest.java		https://github.com/eclipse/openj9/issues/1128	generic-all
 java/lang/invoke/ProtectedMemberDifferentPackage/Test.java		https://github.com/eclipse/openj9/issues/1128	generic-all

--- a/openjdk/ProblemList_openjdk8-openj9.txt
+++ b/openjdk/ProblemList_openjdk8-openj9.txt
@@ -46,7 +46,7 @@ java/lang/invoke/LFCaching/LFMultiThreadCachingTest.java		https://github.com/ecl
 java/lang/invoke/LFCaching/LFSingleThreadCachingTest.java		https://github.com/eclipse/openj9/issues/1128	generic-all
 java/lang/invoke/LambdaFormTest.java		https://github.com/eclipse/openj9/issues/1128	generic-all
 java/lang/invoke/MethodHandles/TestCatchException.java		https://github.com/eclipse/openj9/issues/1128	generic-all
-java_lang_invoke_MethodHandlesProxiesTest   https://github.com/eclipse/openj9/issues/5950   generic-all
+java_lang_invoke_MethodHandlesProxiesTest.java 	https://github.com/eclipse/openj9/issues/5950   generic-all
 java/lang/invoke/MethodHandlesTest.java		https://github.com/eclipse/openj9/issues/1128	generic-all
 java/lang/invoke/PrivateInvokeTest.java		https://github.com/eclipse/openj9/issues/1128	generic-all
 java/lang/invoke/ProtectedMemberDifferentPackage/Test.java		https://github.com/eclipse/openj9/issues/1128	generic-all


### PR DESCRIPTION
Excluding pending fix for https://github.com/eclipse/openj9/issues/5950