### PR TITLE
Turn off detailed error message for all level of external tests

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -90,7 +90,7 @@ def setupEnv() {
 		}
 	}
 
-	if (env.BUILD_LIST == 'openjdk' ||  env.BUILD_LIST == 'external') {
+	if (env.BUILD_LIST == 'openjdk' ||  env.BUILD_LIST.contains('external')) {
 		env.DIAGNOSTICLEVEL ='noDetails'
 	}
 


### PR DESCRIPTION
External tests output is huge with all kinds of characters, which increase the occurrence of TAP parsing issue. 

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>