### PR TITLE
Checkout repo on z/OS via sh and git

### DIFF
--- a/buildenv/jenkins/openjdk_s390x_zos
+++ b/buildenv/jenkins/openjdk_s390x_zos
@@ -10,7 +10,11 @@ stage('Queue') {
         PLATFORM = 's390x_zos'
         SDK_RESOURCE = 'upstream'
         SPEC='zos_390-64_cmprssptrs'
-        checkout scm
+
+        def gitConfig = scm.getUserRemoteConfigs()[0]
+        def SCM_GIT_REPO = gitConfig.getUrl()
+        def SCM_GIT_BRANCH = scm.branches[0].name
+        sh "git clone -b ${SCM_GIT_BRANCH} ${SCM_GIT_REPO} openjdk-tests"
         jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
         jenkinsfile.testBuild()
     }


### PR DESCRIPTION
- z/OS commands need to run through sh in order to
  setup the env. The 'scm checkout' runs the git
  command through a different mechanism so the env was
  not getting setup correctly and we were getting
  "git not found" errors.
- Note: The three new commands require script approval
  in order to execute

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>