### PR TITLE
replaced/removed JAVA_BIN in JCK and OpenJDK folders of openjdk-tests

### DIFF
--- a/jck/build.xml
+++ b/jck/build.xml
@@ -195,18 +195,12 @@
 	</target>
 
 	<target name="configure_stf" depends="check_systemtest">
-		<ant antfile="${SYSTEMTEST_ROOT}/stf/stf.build/build.xml" dir="${SYSTEMTEST_ROOT}/stf/stf.build/" target="configure" inheritAll="false">
-			<property name="java.home" value="${JAVA_BIN}/.." />
-		</ant>
-		<ant antfile="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build/build.xml" dir="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build/" target="configure" inheritAll="false">
-			<property name="java.home" value="${JAVA_BIN}/.." />
-		</ant>
+		<ant antfile="${SYSTEMTEST_ROOT}/stf/stf.build/build.xml" dir="${SYSTEMTEST_ROOT}/stf/stf.build/" target="configure" inheritAll="false"></ant>
+		<ant antfile="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build/build.xml" dir="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build/" target="configure" inheritAll="false"></ant>
 	</target>
 
 	<target name="compile_stf" depends="configure_stf">
-		<ant antfile="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build/build.xml" dir="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build" inheritAll="false">
-			<property name="java.home" value="${JAVA_BIN}/.." />
-		</ant>
+		<ant antfile="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build/build.xml" dir="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build" inheritAll="false"></ant>
 	</target>
 
 	<target name="dist" depends="compile_stf" description="generate the distribution">
@@ -274,11 +268,7 @@
 	</target>
 
 	<target name="clean">
-		<ant antfile="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build/build.xml" dir="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build" inheritAll="false" target="clean">
-			<property name="java.home" value="${JAVA_BIN}/.." />
-		</ant>
-		<ant antfile="${SYSTEMTEST_ROOT}/stf/stf.build/build.xml" dir="${SYSTEMTEST_ROOT}/stf/stf.build" inheritAll="false" target="clean">
-			<property name="java.home" value="${JAVA_BIN}/.." />
-		</ant>
+		<ant antfile="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build/build.xml" dir="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build" inheritAll="false" target="clean"></ant>
+		<ant antfile="${SYSTEMTEST_ROOT}/stf/stf.build/build.xml" dir="${SYSTEMTEST_ROOT}/stf/stf.build" inheritAll="false" target="clean"></ant>
 	</target>
 </project>

--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -48,11 +48,7 @@ JTREG_BASIC_OPTIONS += $(JTREG_XML_OPTION)
 JTREG_BASIC_OPTIONS += $(EXTRA_JTREG_OPTIONS)
 
 ifndef JRE_IMAGE
-	ifeq ($(JDK_VERSION),8)
-		JRE_ROOT := $(JAVA_BIN)$(D)..$(D)..
-	else
-		JRE_ROOT := $(JAVA_BIN)$(D)..
-	endif
+	JRE_ROOT := $(TEST_JDK_HOME)
 	JRE_IMAGE := $(JRE_ROOT)$(D)..$(D)j2re-image
 endif
 


### PR DESCRIPTION
- Replaced/removed JAVA_BIN in JCK and OpenJDK folders to avoid ambiguity in openjdk-test
[ci skip]

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>