### PR TITLE
Set auto map between JDK_VERSION and jdk source repo

### DIFF
--- a/openjdk/build.xml
+++ b/openjdk/build.xml
@@ -23,22 +23,7 @@
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/openjdk" />
 	<property name="src" location="." />
-	<condition property="openjdkGit" value="openjdk-jdk8u">
-		<equals arg1="${JDK_VERSION}" arg2="8"/>
-	</condition>
-	<condition property="openjdkGit" value="openjdk-jdk9">
-		<equals arg1="${JDK_VERSION}" arg2="9"/>
-	</condition>
-	<condition property="openjdkGit" value="openjdk-jdk10u">
-		<equals arg1="${JDK_VERSION}" arg2="10"/>
-	</condition>
-	<condition property="openjdkGit" value="openjdk-jdk11u">
-        <equals arg1="${JDK_VERSION}" arg2="11"/>
-    </condition>
-	<condition property="openjdkGit" value="openjdk-jdk12u">
-        <equals arg1="${JDK_VERSION}" arg2="12"/>
-    </condition>
-
+	<property name="openjdkGit" value="openjdk-jdk${JDK_VERSION}u" />
 	<property environment="env" />
 	<if>
 		<isset property="env.RELEASE_TAG"/>


### PR DESCRIPTION
As naming convention is stable we can set up this auto map instead of
adding a new condition property whenever a new JDK_VERSION is available.

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>