### PR TITLE
Disable jck-runtime-api-javax_naming-spi on osx and aix

### DIFF
--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -367,6 +367,9 @@
 	-results-root=$(REPORTDIR)  \
 	-test=Jck -test-args=$(Q)tests=api/javax_naming/spi,jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
 	$(TEST_STATUS)</command>
+		<!-- Disabled on osx due to runtimes/infrastructure/issues/1111 -->
+		<!-- Disabled on aix due to runtimes/infrastructure/issues/2022 -->
+		<platformRequirements>^os.osx,^os.aix</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>


### PR DESCRIPTION
Signed-off-by: lanxia <lan_xia@ca.ibm.com>