### PR TITLE
Add jenkins test pipeline for OpenJDK Project Builds

### DIFF
--- a/buildenv/jenkins/upstream_openjdk_tests
+++ b/buildenv/jenkins/upstream_openjdk_tests
@@ -248,18 +248,19 @@ node("ci.role.test") {
                         stage("prepare $r.OS-$r.ARCH") {
                             def jdk_url = r.JDK_URL
                             def source_url = r.SOURCE_URL
+                            def jenkins_file = r.getJenkinsFile()
                             def jdk_jre_url = "$r.JDK_URL $r.JRE_URL"
-                            parallelJobs["openjdk$version-$r.OS-$r.ARCH sanity.openjdk"] = {
+                            parallelJobs["Test_openjdk${version}_hs_sanity.openjdk_${r.ARCH}_${r.OS}"] = {
                                 // Run a _sanity.openjdk test job with appropriate parameters
                                 build job: TEST_JOB_NAME, parameters: [
                                     string(name: 'ADOPTOPENJDK_REPO', value: params.ADOPTOPENJDK_REPO ? params.ADOPTOPENJDK_REPO : "https://github.com/AdoptOpenJDK/openjdk-tests.git"),
                                     string(name: 'ADOPTOPENJDK_BRANCH', value: params.ADOPTOPENJDK_BRANCH ? params.ADOPTOPENJDK_BRANCH : "master"),
                                     string(name: 'OPENJ9_REPO', value: params.OPENJ9_REPO ? params.OPENJ9_REPO : ""),
                                     string(name: 'OPENJ9_BRANCH', value: params.OPENJ9_BRANCH ? params.OPENJ9_BRANCH : ""),
-                                    string(name: 'JenkinsFile', value: r.getJenkinsFile()),
+                                    string(name: 'JenkinsFile', value: jenkins_file),
                                     string(name: 'JDK_IMPL', value: "hotspot"),
                                     string(name: 'BUILD_LIST', value: "openjdk"),
-                                    string(name: 'TARGET', value: "sanity"),
+                                    string(name: 'TARGET', value: "sanity.openjdk"),
                                     string(name: 'SDK_RESOURCE', value: "customized"),
                                     string(name: 'CUSTOMIZED_SDK_URL', value: jdk_jre_url),
                                     string(name: 'CUSTOMIZED_SDK_SOURCE_URL', value: source_url),
@@ -267,17 +268,17 @@ node("ci.role.test") {
                                     booleanParam(name: 'AUTO_DETECT', value: true),
                                 ], propagate: true
                             }
-                            parallelJobs["openjdk$version-$r.OS-$r.ARCH sanity.system"] = {
+                            parallelJobs["Test_openjdk${version}_hs_sanity.system_${r.ARCH}_${r.OS}"] = {
                                 // Run a systemtest test job with appropriate parameters
                                 build job: TEST_JOB_NAME, parameters: [
                                     string(name: 'ADOPTOPENJDK_REPO', value: params.ADOPTOPENJDK_REPO ? params.ADOPTOPENJDK_REPO : "https://github.com/AdoptOpenJDK/openjdk-tests.git"),
                                     string(name: 'ADOPTOPENJDK_BRANCH', value: params.ADOPTOPENJDK_BRANCH ? params.ADOPTOPENJDK_BRANCH : "master"),
                                     string(name: 'OPENJ9_REPO', value: params.OPENJ9_REPO ? params.OPENJ9_REPO : ""),
                                     string(name: 'OPENJ9_BRANCH', value: params.OPENJ9_BRANCH ? params.OPENJ9_BRANCH : ""),
-                                    string(name: 'JenkinsFile', value: r.getJenkinsFile()),
+                                    string(name: 'JenkinsFile', value: jenkins_file),
                                     string(name: 'JDK_IMPL', value: "hotspot"),
                                     string(name: 'BUILD_LIST', value: "systemtest"),
-                                    string(name: 'TARGET', value: "sanity"),
+                                    string(name: 'TARGET', value: "sanity.system"),
                                     string(name: 'SDK_RESOURCE', value: "customized"),
                                     string(name: 'CUSTOMIZED_SDK_URL', value: jdk_url),
                                     booleanParam(name: 'IS_PARALLEL', value: false),

--- a/buildenv/jenkins/upstream_openjdk_tests
+++ b/buildenv/jenkins/upstream_openjdk_tests
@@ -62,7 +62,8 @@ class LatestReleaseInfo implements Serializable {
 
     public boolean isRetestNeeded() {
         ZonedDateTime previous = getLatestFromWorspace()
-        return previous == null || (previous != null && latestCurrent.compareTo(previous) > 0)
+        ZonedDateTime current = ZonedDateTime.parse(latestCurrent, DateTimeFormatter.ISO_DATE_TIME);
+        return previous == null || (previous != null && current.compareTo(previous) > 0)
     }
 
     public void writeLatestToWorkspace() {

--- a/buildenv/jenkins/upstream_openjdk_tests
+++ b/buildenv/jenkins/upstream_openjdk_tests
@@ -196,7 +196,9 @@ class ReleaseMetadata {
     }
 }
 
-node("ci.role.test") {
+Map parallelJobs = [:]
+//node("ci.role.test") {
+node() {
     parameters {
         string(name:'VERSIONS', defaultValue: '8 11', description: "Space separated list of versions to check")
         booleanParam(name:'INCLUDE_EA', defaultValue: true, description: "Whether or not to include EA builds")
@@ -209,76 +211,73 @@ node("ci.role.test") {
     boolean forceRetest = params.FORCE_RETEST ? params.FORCE_RETEST : false
     Map releaseCtxts = [:]
     Map latestRelInfos = [:]
-    Map parallelJobs = [:]
 
     TEST_JOB_NAME = "${env.JOB_NAME}"
     File workspace = new File("${env.WORKSPACE}")
     workspace.mkdirs()
-    versions.each { version -> 
+    versions.each { version ->
         ReleaseRetriever retriever = new ReleaseRetriever(version, includeEA)
         List ctxts = retriever.getReleaseContexts()
         latestRelInfos.put(version, new LatestReleaseInfo(version, retriever.getLatestReleaseDate()))
         releaseCtxts.put(version, ctxts)
     }
     dir("$env.WORKSPACE") { // use workspace relative directory
-    versions.each { version -> 
-        stage("prepare OpenJDK Version: $version") {
-            LatestReleaseInfo relInfo = latestRelInfos.get(version)
-            List ctxts = releaseCtxts.get(version)
-            ctxts.each { println it.toString() }
-            if (forceRetest || relInfo.isRetestNeeded()) {
-                // trigger tests for each context
-                ctxts.each{ r -> 
-                    stage("prepare $r.OS-$r.ARCH") {
-                        def jdk_url = r.JDK_URL
-                        def source_url = r.SOURCE_URL
-                        def jdk_jre_url = "$r.JDK_URL $r.JRE_URL"
-                        parallelJobs["openjdk$version-$r.OS-$r.ARCH sanity.openjdk"] = {
-                            // Run a _sanity.openjdk test job with appropriate parameters
-                            build job: TEST_JOB_NAME, parameters: [
-                                string(name: 'ADOPTOPENJDK_REPO', value: params.ADOPTOPENJDK_REPO ? params.ADOPTOPENJDK_REPO : "https://github.com/AdoptOpenJDK/openjdk-tests.git"),
-                                string(name: 'ADOPTOPENJDK_BRANCH', value: params.ADOPTOPENJDK_BRANCH ? params.ADOPTOPENJDK_BRANCH : "master"),
-                                string(name: 'OPENJ9_REPO', value: params.OPENJ9_REPO ? params.OPENJ9_REPO : ""),
-                                string(name: 'OPENJ9_BRANCH', value: params.OPENJ9_BRANCH ? params.OPENJ9_BRANCH : ""),
-                                string(name: 'JenkinsFile', value: r.getJenkinsFile()),
-                                string(name: 'JDK_IMPL', value: "hotspot"),
-                                string(name: 'BUILD_LIST', value: "openjdk"),
-                                string(name: 'TARGET', value: "sanity"),
-                                string(name: 'SDK_RESOURCE', value: "customized"),
-                                string(name: 'CUSTOMIZED_SDK_URL', value: jdk_jre_url),
-                                string(name: 'CUSTOMIZED_SDK_SOURCE_URL', value: source_url),
-                                booleanParam(name: 'IS_PARALLEL', value: false),
-                                booleanParam(name: 'AUTO_DETECT', value: true),
-                            ], propagate: true
-                        }
-                        parallelJobs["openjdk$version-$r.OS-$r.ARCH sanity.system"] = {
-                            // Run a systemtest test job with appropriate parameters
-                            build job: TEST_JOB_NAME, parameters: [
-                                string(name: 'ADOPTOPENJDK_REPO', value: params.ADOPTOPENJDK_REPO ? params.ADOPTOPENJDK_REPO : "https://github.com/AdoptOpenJDK/openjdk-tests.git"),
-                                string(name: 'ADOPTOPENJDK_BRANCH', value: params.ADOPTOPENJDK_BRANCH ? params.ADOPTOPENJDK_BRANCH : "master"),
-                                string(name: 'OPENJ9_REPO', value: params.OPENJ9_REPO ? params.OPENJ9_REPO : ""),
-                                string(name: 'OPENJ9_BRANCH', value: params.OPENJ9_BRANCH ? params.OPENJ9_BRANCH : ""),
-                                string(name: 'JenkinsFile', value: r.getJenkinsFile()),
-                                string(name: 'JDK_IMPL', value: "hotspot"),
-                                string(name: 'BUILD_LIST', value: "systemtest"),
-                                string(name: 'TARGET', value: "sanity"),
-                                string(name: 'SDK_RESOURCE', value: "customized"),
-                                string(name: 'CUSTOMIZED_SDK_URL', value: jdk_url),
-                                booleanParam(name: 'IS_PARALLEL', value: false),
-                                booleanParam(name: 'AUTO_DETECT', value: true),
-                            ], propagate: true
+        versions.each { version ->
+            stage("prepare OpenJDK Version: $version") {
+                LatestReleaseInfo relInfo = latestRelInfos.get(version)
+                List ctxts = releaseCtxts.get(version)
+                ctxts.each { println it.toString() }
+                if (forceRetest || relInfo.isRetestNeeded()) {
+                    // trigger tests for each context
+                    ctxts.each{ r -> 
+                        stage("prepare $r.OS-$r.ARCH") {
+                            def jdk_url = r.JDK_URL
+                            def source_url = r.SOURCE_URL
+                            def jdk_jre_url = "$r.JDK_URL $r.JRE_URL"
+                            parallelJobs["openjdk$version-$r.OS-$r.ARCH sanity.openjdk"] = {
+                                // Run a _sanity.openjdk test job with appropriate parameters
+                                build job: TEST_JOB_NAME, parameters: [
+                                    string(name: 'ADOPTOPENJDK_REPO', value: params.ADOPTOPENJDK_REPO ? params.ADOPTOPENJDK_REPO : "https://github.com/AdoptOpenJDK/openjdk-tests.git"),
+                                    string(name: 'ADOPTOPENJDK_BRANCH', value: params.ADOPTOPENJDK_BRANCH ? params.ADOPTOPENJDK_BRANCH : "master"),
+                                    string(name: 'OPENJ9_REPO', value: params.OPENJ9_REPO ? params.OPENJ9_REPO : ""),
+                                    string(name: 'OPENJ9_BRANCH', value: params.OPENJ9_BRANCH ? params.OPENJ9_BRANCH : ""),
+                                    string(name: 'JenkinsFile', value: r.getJenkinsFile()),
+                                    string(name: 'JDK_IMPL', value: "hotspot"),
+                                    string(name: 'BUILD_LIST', value: "openjdk"),
+                                    string(name: 'TARGET', value: "sanity"),
+                                    string(name: 'SDK_RESOURCE', value: "customized"),
+                                    string(name: 'CUSTOMIZED_SDK_URL', value: jdk_jre_url),
+                                    string(name: 'CUSTOMIZED_SDK_SOURCE_URL', value: source_url),
+                                    booleanParam(name: 'IS_PARALLEL', value: false),
+                                    booleanParam(name: 'AUTO_DETECT', value: true),
+                                ], propagate: true
+                            }
+                            parallelJobs["openjdk$version-$r.OS-$r.ARCH sanity.system"] = {
+                                // Run a systemtest test job with appropriate parameters
+                                build job: TEST_JOB_NAME, parameters: [
+                                    string(name: 'ADOPTOPENJDK_REPO', value: params.ADOPTOPENJDK_REPO ? params.ADOPTOPENJDK_REPO : "https://github.com/AdoptOpenJDK/openjdk-tests.git"),
+                                    string(name: 'ADOPTOPENJDK_BRANCH', value: params.ADOPTOPENJDK_BRANCH ? params.ADOPTOPENJDK_BRANCH : "master"),
+                                    string(name: 'OPENJ9_REPO', value: params.OPENJ9_REPO ? params.OPENJ9_REPO : ""),
+                                    string(name: 'OPENJ9_BRANCH', value: params.OPENJ9_BRANCH ? params.OPENJ9_BRANCH : ""),
+                                    string(name: 'JenkinsFile', value: r.getJenkinsFile()),
+                                    string(name: 'JDK_IMPL', value: "hotspot"),
+                                    string(name: 'BUILD_LIST', value: "systemtest"),
+                                    string(name: 'TARGET', value: "sanity"),
+                                    string(name: 'SDK_RESOURCE', value: "customized"),
+                                    string(name: 'CUSTOMIZED_SDK_URL', value: jdk_url),
+                                    booleanParam(name: 'IS_PARALLEL', value: false),
+                                    booleanParam(name: 'AUTO_DETECT', value: true),
+                                ], propagate: true
+                            }
                         }
                     }
+                } else {
+                    println "No new releases detected for Upstream OpenJDK ${version}"
                 }
-            } else {
-                println "No new releases detected for Upstream OpenJDK ${version}"
+                relInfo.writeLatestToWorkspace()
             }
-            relInfo.writeLatestToWorkspace()
         }
     }
-    }
-    stage("run tests parallel") {
-        parallel(parallelJobs)
-    }
 }
+parallel(parallelJobs)
 

--- a/buildenv/jenkins/upstream_openjdk_tests
+++ b/buildenv/jenkins/upstream_openjdk_tests
@@ -3,6 +3,7 @@
 import groovy.json.JsonSlurper;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Base64;
 
 // Data structure with info for triggering the test builds
 class ReleaseContext implements Serializable {
@@ -83,9 +84,9 @@ class ReleaseRetriever implements Serializable {
     final String VERSION
     final ReleaseMetadata metadata
 
-    ReleaseRetriever(String version, boolean includeEA) {
+    ReleaseRetriever(String version, boolean includeEA, String base64Token) {
         this.VERSION = version
-        this.metadata = getMetadata(version, includeEA)
+        this.metadata = getMetadata(version, includeEA, base64Token)
     }
 
     public List getReleaseContexts() {
@@ -132,12 +133,13 @@ class ReleaseRetriever implements Serializable {
     }
 
     @NonCPS
-    public static ReleaseMetadata getMetadataEA(String version) {
+    public static ReleaseMetadata getMetadataEA(String version, String base64Token) {
         String baseURL = VERSION_TO_URL.get(version)
         def http = new URL("${baseURL}/releases").openConnection() as HttpURLConnection
         http.setRequestMethod('GET')
         http.setRequestProperty("Accept", 'application/json')
         http.setRequestProperty("Content-Type", 'application/json')
+        http.setRequestProperty("Authorization", "Basic " + base64Token)
         http.connect()
         def response = [:]
         boolean error = false
@@ -162,13 +164,14 @@ class ReleaseRetriever implements Serializable {
     }
 
     @NonCPS
-    public static ReleaseMetadata getMetadataGA(String version) {
+    public static ReleaseMetadata getMetadataGA(String version, String base64Token) {
         String baseURL = VERSION_TO_URL.get(version)
         // latest release API URL only includes GA releases
         def http = new URL("${baseURL}/releases/latest").openConnection() as HttpURLConnection
         http.setRequestMethod('GET')
         http.setRequestProperty("Accept", 'application/json')
         http.setRequestProperty("Content-Type", 'application/json')
+        http.setRequestProperty("Authorization", "Basic " + base64Token)
         http.connect()
         def response = [:]
         if (http.responseCode == 200) {
@@ -183,11 +186,11 @@ class ReleaseRetriever implements Serializable {
     }
 
     @NonCPS
-    public static ReleaseMetadata getMetadata(String version, boolean includeEA) {
+    public static ReleaseMetadata getMetadata(String version, boolean includeEA, String base64Token) {
         if (includeEA) {
-            return getMetadataEA(version)
+            return getMetadataEA(version, base64Token)
         } else {
-            return getMetadataGA(version)
+            return getMetadataGA(version, base64Token)
         }
     }
 }
@@ -208,6 +211,8 @@ Map parallelJobs = [:]
 node("ci.role.test") {
     parameters {
         string(name:'VERSIONS', defaultValue: '8 11', description: "Space separated list of versions to check")
+        string(name:'GH_USERNAME', description: "Github API username to authenticate as")
+        string(name:'GH_TOKEN', description: "Github API OAuth personalized access token to be used for authentication")
         booleanParam(name:'INCLUDE_EA', defaultValue: true, description: "Whether or not to include EA builds")
         booleanParam(name:'FORCE_RETEST', defaultValue: false, description: "Whether or not to force a re-test irrespective previous runs")
     }
@@ -216,6 +221,9 @@ node("ci.role.test") {
     List versions = params.VERSIONS ? params.VERSIONS.split(" ") : "8 11".split(" ")
     boolean includeEA = params.INCLUDE_EA ? params.INCLUDE_EA : true
     boolean forceRetest = params.FORCE_RETEST ? params.FORCE_RETEST : false
+    String user = params.GH_USERNAME ? params.GH_USERNAME : "gh-user-not-set"
+    String token = params.GH_TOKEN ? params.GH_TOKEN : "gh-token-not-set"
+    String userTokenBase64 = Base64.getEncoder().encodeToString((user + ":" + token).getBytes())
     Map releaseCtxts = [:]
     Map latestRelInfos = [:]
 
@@ -223,7 +231,7 @@ node("ci.role.test") {
     File workspace = new File("${env.WORKSPACE}")
     workspace.mkdirs()
     versions.each { version ->
-        ReleaseRetriever retriever = new ReleaseRetriever(version, includeEA)
+        ReleaseRetriever retriever = new ReleaseRetriever(version, includeEA, userTokenBase64)
         List ctxts = retriever.getReleaseContexts()
         latestRelInfos.put(version, new LatestReleaseInfo(version, retriever.getLatestReleaseDate()))
         releaseCtxts.put(version, ctxts)

--- a/buildenv/jenkins/upstream_openjdk_tests
+++ b/buildenv/jenkins/upstream_openjdk_tests
@@ -27,7 +27,7 @@ class ReleaseContext implements Serializable {
         return "openjdk_" + getMappedArch() + "_" + OS;
     }
 
-    private String getMappedArch() {
+    public String getMappedArch() {
         switch(ARCH) {
             case "x64":
                 return "x86-64"
@@ -229,7 +229,6 @@ node("ci.role.test&&hw.arch.x86&&sw.os.linux") {
     Map releaseCtxts = [:]
     Map latestRelInfos = [:]
 
-    TEST_JOB_NAME = "${env.JOB_NAME}"
     File workspace = new File("${env.WORKSPACE}")
     workspace.mkdirs()
     versions.each { version ->
@@ -253,7 +252,8 @@ node("ci.role.test&&hw.arch.x86&&sw.os.linux") {
                             def jdk_version = version
                             def jenkins_file = r.getJenkinsFile()
                             def jdk_jre_url = "$r.JDK_URL $r.JRE_URL"
-                            def job_branch_name = "Test_upstream_openjdk${version}_hs_sanity.openjdk_${r.ARCH}_${r.OS}"
+                            def mapped_arch = r.getMappedArch()
+                            def job_branch_name = "Test_upstream_openjdk${version}_hs_sanity.openjdk_${mapped_arch}_${r.OS}"
                             parallelJobs[job_branch_name] = {
                                 // Run a _sanity.openjdk test job with appropriate parameters
                                 build job: job_branch_name, parameters: [
@@ -270,7 +270,7 @@ node("ci.role.test&&hw.arch.x86&&sw.os.linux") {
                             }
                             parallelJobs["Test_openjdk${version}_hs_sanity.system_${r.ARCH}_${r.OS}"] = {
                                 // Run a systemtest test job with appropriate parameters
-                                build job: TEST_JOB_NAME, parameters: [
+                                build job: job_branch_name, parameters: [
                                     string(name: 'JenkinsFile', value: jenkins_file),
                                     string(name: 'JDK_IMPL', value: "hotspot"),
                                     // needs to be passed for 11 as default is 8, causing conflicts with AUTO_DETECT

--- a/buildenv/jenkins/upstream_openjdk_tests
+++ b/buildenv/jenkins/upstream_openjdk_tests
@@ -1,0 +1,284 @@
+#!groovy
+
+import groovy.json.JsonSlurper;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+// Data structure with info for triggering the test builds
+class ReleaseContext implements Serializable {
+
+    final String ARCH
+    final String OS
+    String JDK_URL
+    String JRE_URL
+    String SOURCE_URL
+
+    ReleaseContext(String arch, String os) {
+        this.ARCH = arch
+        this.OS = os
+    }
+
+    public String toString() {
+        return "$ARCH-$OS: $JDK_URL $JRE_URL $SOURCE_URL ${getJenkinsFile()}";
+    }
+
+    public String getJenkinsFile() {
+        return "openjdk_" + getMappedArch() + "_" + OS;
+    }
+
+    private String getMappedArch() {
+        switch(ARCH) {
+            case "x64":
+                return "x86-64"
+            default:
+                return ARCH
+        }
+        throw new InternalError() // must not happen
+    }
+}
+
+class LatestReleaseInfo implements Serializable {
+
+    final File TIMESTAMP_FILE
+    final String latestCurrent
+
+    LatestReleaseInfo(String version, String latestCurrent) {
+        this.TIMESTAMP_FILE = new File("latest_timestamp_${version}")
+        this.latestCurrent = latestCurrent
+    }
+
+    public ZonedDateTime getLatestFromWorspace() {
+       try {
+           String latest_timestamp = TIMESTAMP_FILE.text
+           ZonedDateTime previous = null
+           if (latest_timestamp != null) {
+               previous = ZonedDateTime.parse(latest_timestamp, DateTimeFormatter.ISO_DATE_TIME);
+           }
+           return previous // potentially null
+       } catch (IOException e) {
+           return null
+       }
+    }
+
+    public boolean isRetestNeeded() {
+        ZonedDateTime previous = getLatestFromWorspace()
+        return previous == null || (previous != null && latestCurrent.compareTo(previous) > 0)
+    }
+
+    public void writeLatestToWorkspace() {
+        TIMESTAMP_FILE.write latestCurrent
+    }
+
+}
+
+// Retrieve latest release information from Github API. The result is being used
+// for triggering relevant test jobs
+class ReleaseRetriever implements Serializable {
+
+    static final Map VERSION_TO_URL = [
+        "8": "https://api.github.com/repos/AdoptOpenJDK/openjdk8-upstream-binaries",
+        "11": "https://api.github.com/repos/AdoptOpenJDK/openjdk11-upstream-binaries"
+    ]
+    final String VERSION
+    final ReleaseMetadata metadata
+
+    ReleaseRetriever(String version, boolean includeEA) {
+        this.VERSION = version
+        this.metadata = getMetadata(version, includeEA)
+    }
+
+    public List getReleaseContexts() {
+        List rels = []
+        Map items = metadata.items
+        ZonedDateTime newest = metadata.newest
+        def val = items.get(newest)
+        rels.add(new ReleaseContext("x64", "linux"))
+        if (VERSION.equals("11")) {
+            rels.add(new ReleaseContext("aarch64", "linux"))
+        }
+        rels.add(new ReleaseContext("x64", "windows"))
+        val.assets.each{ a -> 
+            if (!a.name.endsWith(".sign")) {
+                rels.each{ r ->
+                   if (a.name.contains(r.OS) && a.name.contains(r.ARCH)) {
+                       if (!a.name.contains("debuginfo")) {
+                           if (a.name.contains("-jdk")) {
+                               r.JDK_URL = a.browser_download_url
+                           }
+                           if (a.name.contains("-jre")) {
+                               r.JRE_URL = a.browser_download_url
+                           }
+                           // if the name neither contains -jre nor -jdk assume
+                           // JDK (which was prior jre/jdk separation)
+                           if (!a.name.contains("-jre") && !a.name.contains("-jdk")) {
+                               r.JDK_URL = a.browser_download_url
+                           }
+                       }
+                   }
+                   if (a.name.contains("-sources_")) {
+                       r.SOURCE_URL = a.browser_download_url
+                   }
+                }
+            }
+        }
+        return rels;
+    }
+
+
+    public String getLatestReleaseDate() {
+        ZonedDateTime latest = metadata.newest
+        return DateTimeFormatter.ISO_INSTANT.format(latest)
+    }
+
+    @NonCPS
+    public static ReleaseMetadata getMetadataEA(String version) {
+        String baseURL = VERSION_TO_URL.get(version)
+        def http = new URL("${baseURL}/releases").openConnection() as HttpURLConnection
+        http.setRequestMethod('GET')
+        http.setRequestProperty("Accept", 'application/json')
+        http.setRequestProperty("Content-Type", 'application/json')
+        http.connect()
+        def response = [:]
+        if (http.responseCode == 200) {
+            response = new JsonSlurper().parseText(http.inputStream.getText('UTF-8'))
+        } else {
+            response = new JsonSlurper().parseText(http.errorStream.getText('UTF-8'))
+        }
+        List publishDates = []
+        Map items = [:]
+        response.each { item ->
+            ZonedDateTime parsedDate = ZonedDateTime.parse(item.published_at, DateTimeFormatter.ISO_DATE_TIME);
+            items.put(parsedDate, item)
+            publishDates.add(parsedDate)
+        }
+        ZonedDateTime newest = publishDates.sort().last()
+        return new ReleaseMetadata(newest, items)
+    }
+
+    @NonCPS
+    public static ReleaseMetadata getMetadataGA(String version) {
+        String baseURL = VERSION_TO_URL.get(version)
+        // latest release API URL only includes GA releases
+        def http = new URL("${baseURL}/releases/latest").openConnection() as HttpURLConnection
+        http.setRequestMethod('GET')
+        http.setRequestProperty("Accept", 'application/json')
+        http.setRequestProperty("Content-Type", 'application/json')
+        http.connect()
+        def response = [:]
+        if (http.responseCode == 200) {
+            response = new JsonSlurper().parseText(http.inputStream.getText('UTF-8'))
+        } else {
+            response = new JsonSlurper().parseText(http.errorStream.getText('UTF-8'))
+        }
+        ZonedDateTime newest = ZonedDateTime.parse(response.published_at, DateTimeFormatter.ISO_DATE_TIME);
+        Map items = [:]
+        items.put(newest, response)
+        return new ReleaseMetadata(newest, items)
+    }
+
+    @NonCPS
+    public static ReleaseMetadata getMetadata(String version, boolean includeEA) {
+        if (includeEA) {
+            return getMetadataEA(version)
+        } else {
+            return getMetadataGA(version)
+        }
+    }
+}
+
+class ReleaseMetadata {
+    final ZonedDateTime newest
+    final Map items
+    
+    ReleaseMetadata(ZonedDateTime newest, Map items) {
+        this.newest = newest
+        this.items = items
+    }
+}
+
+node("ci.role.test") {
+    parameters {
+        string(name:'VERSIONS', defaultValue: '8 11', description: "Space separated list of versions to check")
+        booleanParam(name:'INCLUDE_EA', defaultValue: true, description: "Whether or not to include EA builds")
+        booleanParam(name:'FORCE_RETEST', defaultValue: false, description: "Whether or not to force a re-test irrespective previous runs")
+    }
+
+    // All params have sensible defaults
+    List versions = params.VERSIONS ? params.VERSIONS.split(" ") : "8 11".split(" ")
+    boolean includeEA = params.INCLUDE_EA ? params.INCLUDE_EA : true
+    boolean forceRetest = params.FORCE_RETEST ? params.FORCE_RETEST : false
+    Map releaseCtxts = [:]
+    Map latestRelInfos = [:]
+    Map parallelJobs = [:]
+
+    TEST_JOB_NAME = "${env.JOB_NAME}"
+    File workspace = new File("${env.WORKSPACE}")
+    workspace.mkdirs()
+    versions.each { version -> 
+        ReleaseRetriever retriever = new ReleaseRetriever(version, includeEA)
+        List ctxts = retriever.getReleaseContexts()
+        latestRelInfos.put(version, new LatestReleaseInfo(version, retriever.getLatestReleaseDate()))
+        releaseCtxts.put(version, ctxts)
+    }
+    dir("$env.WORKSPACE") { // use workspace relative directory
+    versions.each { version -> 
+        stage("prepare OpenJDK Version: $version") {
+            LatestReleaseInfo relInfo = latestRelInfos.get(version)
+            List ctxts = releaseCtxts.get(version)
+            ctxts.each { println it.toString() }
+            if (forceRetest || relInfo.isRetestNeeded()) {
+                // trigger tests for each context
+                ctxts.each{ r -> 
+                    stage("prepare $r.OS-$r.ARCH") {
+                        def jdk_url = r.JDK_URL
+                        def source_url = r.SOURCE_URL
+                        def jdk_jre_url = "$r.JDK_URL $r.JRE_URL"
+                        parallelJobs["openjdk$version-$r.OS-$r.ARCH sanity.openjdk"] = {
+                            // Run a _sanity.openjdk test job with appropriate parameters
+                            build job: TEST_JOB_NAME, parameters: [
+                                string(name: 'ADOPTOPENJDK_REPO', value: params.ADOPTOPENJDK_REPO ? params.ADOPTOPENJDK_REPO : "https://github.com/AdoptOpenJDK/openjdk-tests.git"),
+                                string(name: 'ADOPTOPENJDK_BRANCH', value: params.ADOPTOPENJDK_BRANCH ? params.ADOPTOPENJDK_BRANCH : "master"),
+                                string(name: 'OPENJ9_REPO', value: params.OPENJ9_REPO ? params.OPENJ9_REPO : ""),
+                                string(name: 'OPENJ9_BRANCH', value: params.OPENJ9_BRANCH ? params.OPENJ9_BRANCH : ""),
+                                string(name: 'JenkinsFile', value: r.getJenkinsFile()),
+                                string(name: 'JDK_IMPL', value: "hotspot"),
+                                string(name: 'BUILD_LIST', value: "openjdk"),
+                                string(name: 'TARGET', value: "sanity"),
+                                string(name: 'SDK_RESOURCE', value: "customized"),
+                                string(name: 'CUSTOMIZED_SDK_URL', value: jdk_jre_url),
+                                string(name: 'CUSTOMIZED_SDK_SOURCE_URL', value: source_url),
+                                booleanParam(name: 'IS_PARALLEL', value: false),
+                                booleanParam(name: 'AUTO_DETECT', value: true),
+                            ], propagate: true
+                        }
+                        parallelJobs["openjdk$version-$r.OS-$r.ARCH sanity.system"] = {
+                            // Run a systemtest test job with appropriate parameters
+                            build job: TEST_JOB_NAME, parameters: [
+                                string(name: 'ADOPTOPENJDK_REPO', value: params.ADOPTOPENJDK_REPO ? params.ADOPTOPENJDK_REPO : "https://github.com/AdoptOpenJDK/openjdk-tests.git"),
+                                string(name: 'ADOPTOPENJDK_BRANCH', value: params.ADOPTOPENJDK_BRANCH ? params.ADOPTOPENJDK_BRANCH : "master"),
+                                string(name: 'OPENJ9_REPO', value: params.OPENJ9_REPO ? params.OPENJ9_REPO : ""),
+                                string(name: 'OPENJ9_BRANCH', value: params.OPENJ9_BRANCH ? params.OPENJ9_BRANCH : ""),
+                                string(name: 'JenkinsFile', value: r.getJenkinsFile()),
+                                string(name: 'JDK_IMPL', value: "hotspot"),
+                                string(name: 'BUILD_LIST', value: "systemtest"),
+                                string(name: 'TARGET', value: "sanity"),
+                                string(name: 'SDK_RESOURCE', value: "customized"),
+                                string(name: 'CUSTOMIZED_SDK_URL', value: jdk_url),
+                                booleanParam(name: 'IS_PARALLEL', value: false),
+                                booleanParam(name: 'AUTO_DETECT', value: true),
+                            ], propagate: true
+                        }
+                    }
+                }
+            } else {
+                println "No new releases detected for Upstream OpenJDK ${version}"
+            }
+            relInfo.writeLatestToWorkspace()
+        }
+    }
+    }
+    stage("run tests parallel") {
+        parallel(parallelJobs)
+    }
+}
+

--- a/buildenv/jenkins/upstream_openjdk_tests
+++ b/buildenv/jenkins/upstream_openjdk_tests
@@ -43,8 +43,8 @@ class LatestReleaseInfo implements Serializable {
     final File TIMESTAMP_FILE
     final String latestCurrent
 
-    LatestReleaseInfo(String version, String latestCurrent) {
-        this.TIMESTAMP_FILE = new File("latest_timestamp_${version}")
+    LatestReleaseInfo(File workspace, String version, String latestCurrent) {
+        this.TIMESTAMP_FILE = new File(workspace, "latest_timestamp_${version}")
         this.latestCurrent = latestCurrent
     }
 
@@ -233,7 +233,7 @@ node("ci.role.test") {
     versions.each { version ->
         ReleaseRetriever retriever = new ReleaseRetriever(version, includeEA, userTokenBase64)
         List ctxts = retriever.getReleaseContexts()
-        latestRelInfos.put(version, new LatestReleaseInfo(version, retriever.getLatestReleaseDate()))
+        latestRelInfos.put(version, new LatestReleaseInfo(workspace, version, retriever.getLatestReleaseDate()))
         releaseCtxts.put(version, ctxts)
     }
     dir("$env.WORKSPACE") { // use workspace relative directory

--- a/buildenv/jenkins/upstream_openjdk_tests
+++ b/buildenv/jenkins/upstream_openjdk_tests
@@ -208,7 +208,9 @@ class ReleaseMetadata {
 // parallel build job configs
 Map parallelJobs = [:]
 
-node("ci.role.test") {
+// Only schedule GH API work on x86 linux nodes as there
+// are plenty available.
+node("ci.role.test&&hw.arch.x86&&sw.os.linux") {
     parameters {
         string(name:'VERSIONS', defaultValue: '8 11', description: "Space separated list of versions to check")
         string(name:'GH_USERNAME', description: "Github API username to authenticate as")
@@ -248,6 +250,7 @@ node("ci.role.test") {
                         stage("prepare $r.OS-$r.ARCH") {
                             def jdk_url = r.JDK_URL
                             def source_url = r.SOURCE_URL
+                            def jdk_version = version
                             def jenkins_file = r.getJenkinsFile()
                             def jdk_jre_url = "$r.JDK_URL $r.JRE_URL"
                             parallelJobs["Test_openjdk${version}_hs_sanity.openjdk_${r.ARCH}_${r.OS}"] = {
@@ -259,6 +262,8 @@ node("ci.role.test") {
                                     string(name: 'OPENJ9_BRANCH', value: params.OPENJ9_BRANCH ? params.OPENJ9_BRANCH : ""),
                                     string(name: 'JenkinsFile', value: jenkins_file),
                                     string(name: 'JDK_IMPL', value: "hotspot"),
+                                    // needs to be passed for 11 as default is 8, causing conflicts with AUTO_DETECT
+                                    string(name: 'JDK_VERSION', value: jdk_version),
                                     string(name: 'BUILD_LIST', value: "openjdk"),
                                     string(name: 'TARGET', value: "sanity.openjdk"),
                                     string(name: 'SDK_RESOURCE', value: "customized"),
@@ -277,6 +282,8 @@ node("ci.role.test") {
                                     string(name: 'OPENJ9_BRANCH', value: params.OPENJ9_BRANCH ? params.OPENJ9_BRANCH : ""),
                                     string(name: 'JenkinsFile', value: jenkins_file),
                                     string(name: 'JDK_IMPL', value: "hotspot"),
+                                    // needs to be passed for 11 as default is 8, causing conflicts with AUTO_DETECT
+                                    string(name: 'JDK_VERSION', value: jdk_version),
                                     string(name: 'BUILD_LIST', value: "systemtest"),
                                     string(name: 'TARGET', value: "sanity.system"),
                                     string(name: 'SDK_RESOURCE', value: "customized"),

--- a/buildenv/jenkins/upstream_openjdk_tests
+++ b/buildenv/jenkins/upstream_openjdk_tests
@@ -205,8 +205,7 @@ class ReleaseMetadata {
 // parallel build job configs
 Map parallelJobs = [:]
 
-//node("ci.role.test") {
-node() {
+node("ci.role.test") {
     parameters {
         string(name:'VERSIONS', defaultValue: '8 11', description: "Space separated list of versions to check")
         booleanParam(name:'INCLUDE_EA', defaultValue: true, description: "Whether or not to include EA builds")

--- a/buildenv/jenkins/upstream_openjdk_tests
+++ b/buildenv/jenkins/upstream_openjdk_tests
@@ -197,7 +197,9 @@ class ReleaseMetadata {
     }
 }
 
+// parallel build job configs
 Map parallelJobs = [:]
+
 //node("ci.role.test") {
 node() {
     parameters {
@@ -273,7 +275,7 @@ node() {
                         }
                     }
                 } else {
-                    println "No new releases detected for Upstream OpenJDK ${version}"
+                    println "No new releases detected for Upstream OpenJDK ${version}. Latest release published on: $relInfo.latestCurrent"
                 }
                 relInfo.writeLatestToWorkspace()
             }

--- a/buildenv/jenkins/upstream_openjdk_tests
+++ b/buildenv/jenkins/upstream_openjdk_tests
@@ -140,10 +140,15 @@ class ReleaseRetriever implements Serializable {
         http.setRequestProperty("Content-Type", 'application/json')
         http.connect()
         def response = [:]
+        boolean error = false
         if (http.responseCode == 200) {
             response = new JsonSlurper().parseText(http.inputStream.getText('UTF-8'))
         } else {
             response = new JsonSlurper().parseText(http.errorStream.getText('UTF-8'))
+            error = true
+        }
+        if (error) {
+            throw new InternalError("HTTP error: " + response.message)
         }
         List publishDates = []
         Map items = [:]

--- a/buildenv/jenkins/upstream_openjdk_tests
+++ b/buildenv/jenkins/upstream_openjdk_tests
@@ -228,6 +228,11 @@ node("ci.role.test&&hw.arch.x86&&sw.os.linux") {
     String userTokenBase64 = Base64.getEncoder().encodeToString((user + ":" + token).getBytes())
     Map releaseCtxts = [:]
     Map latestRelInfos = [:]
+    List testList = [ "openjdk", "system" ]
+    Map testsTargetBuildList = [
+                                 "openjdk": [ "target": "sanity.openjdk", "buildlist": "openjdk" ],
+                                 "system":  [ "target": "sanity.system", "buildlist": "systemtest" ]
+                               ]
 
     File workspace = new File("${env.WORKSPACE}")
     workspace.mkdirs()
@@ -246,40 +251,31 @@ node("ci.role.test&&hw.arch.x86&&sw.os.linux") {
                 if (forceRetest || relInfo.isRetestNeeded()) {
                     // trigger tests for each context
                     ctxts.each{ r -> 
-                        stage("prepare $r.OS-$r.ARCH") {
-                            def jdk_url = r.JDK_URL
-                            def source_url = r.SOURCE_URL
-                            def jdk_version = version
-                            def jenkins_file = r.getJenkinsFile()
-                            def jdk_jre_url = "$r.JDK_URL $r.JRE_URL"
-                            def mapped_arch = r.getMappedArch()
-                            def job_branch_name = "Test_upstream_openjdk${version}_hs_sanity.openjdk_${mapped_arch}_${r.OS}"
-                            parallelJobs[job_branch_name] = {
-                                // Run a _sanity.openjdk test job with appropriate parameters
-                                build job: job_branch_name, parameters: [
-                                    string(name: 'JenkinsFile', value: jenkins_file),
-                                    string(name: 'JDK_IMPL', value: "hotspot"),
-                                    // needs to be passed for 11 as default is 8, causing conflicts with AUTO_DETECT
-                                    string(name: 'JDK_VERSION', value: jdk_version),
-                                    string(name: 'BUILD_LIST', value: "openjdk"),
-                                    string(name: 'TARGET', value: "sanity.openjdk"),
-                                    string(name: 'SDK_RESOURCE', value: "customized"),
-                                    string(name: 'CUSTOMIZED_SDK_URL', value: jdk_jre_url),
-                                    string(name: 'CUSTOMIZED_SDK_SOURCE_URL', value: source_url),
-                                ], propagate: true
-                            }
-                            parallelJobs["Test_openjdk${version}_hs_sanity.system_${r.ARCH}_${r.OS}"] = {
-                                // Run a systemtest test job with appropriate parameters
-                                build job: job_branch_name, parameters: [
-                                    string(name: 'JenkinsFile', value: jenkins_file),
-                                    string(name: 'JDK_IMPL', value: "hotspot"),
-                                    // needs to be passed for 11 as default is 8, causing conflicts with AUTO_DETECT
-                                    string(name: 'JDK_VERSION', value: jdk_version),
-                                    string(name: 'BUILD_LIST', value: "systemtest"),
-                                    string(name: 'TARGET', value: "sanity.system"),
-                                    string(name: 'SDK_RESOURCE', value: "customized"),
-                                    string(name: 'CUSTOMIZED_SDK_URL', value: jdk_url),
-                                ], propagate: true
+                        testList.each { testname -> // currently "openjdk" and "system" tests
+                            stage("prepare $r.OS-$r.ARCH") {
+                                def jdk_url = r.JDK_URL
+                                def source_url = r.SOURCE_URL
+                                def jdk_version = version
+                                def jenkins_file = r.getJenkinsFile()
+                                def jdk_jre_url = "$r.JDK_URL $r.JRE_URL"
+                                def mapped_arch = r.getMappedArch()
+                                def target = testsTargetBuildList.get(testname).get("target")
+                                def buildList = testsTargetBuildList.get(testname).get("buildlist")
+                                def job_branch_name = "Test_upstream_openjdk${version}_hs_${target}_${mapped_arch}_${r.OS}"
+                                parallelJobs[job_branch_name] = {
+                                    // Run a _sanity.openjdk test job with appropriate parameters
+                                    build job: job_branch_name, parameters: [
+                                        string(name: 'JenkinsFile', value: jenkins_file),
+                                        string(name: 'JDK_IMPL', value: "hotspot"),
+                                        // needs to be passed for 11 as default is 8, causing conflicts with AUTO_DETECT
+                                        string(name: 'JDK_VERSION', value: jdk_version),
+                                        string(name: 'BUILD_LIST', value: buildList),
+                                        string(name: 'TARGET', value: target),
+                                        string(name: 'SDK_RESOURCE', value: "customized"),
+                                        string(name: 'CUSTOMIZED_SDK_URL', value: jdk_jre_url),
+                                        string(name: 'CUSTOMIZED_SDK_SOURCE_URL', value: source_url),
+                                    ], propagate: true
+                                }
                             }
                         }
                     }

--- a/buildenv/jenkins/upstream_openjdk_tests
+++ b/buildenv/jenkins/upstream_openjdk_tests
@@ -253,13 +253,10 @@ node("ci.role.test&&hw.arch.x86&&sw.os.linux") {
                             def jdk_version = version
                             def jenkins_file = r.getJenkinsFile()
                             def jdk_jre_url = "$r.JDK_URL $r.JRE_URL"
-                            parallelJobs["Test_openjdk${version}_hs_sanity.openjdk_${r.ARCH}_${r.OS}"] = {
+                            def job_branch_name = "Test_upstream_openjdk${version}_hs_sanity.openjdk_${r.ARCH}_${r.OS}"
+                            parallelJobs[job_branch_name] = {
                                 // Run a _sanity.openjdk test job with appropriate parameters
-                                build job: TEST_JOB_NAME, parameters: [
-                                    string(name: 'ADOPTOPENJDK_REPO', value: params.ADOPTOPENJDK_REPO ? params.ADOPTOPENJDK_REPO : "https://github.com/AdoptOpenJDK/openjdk-tests.git"),
-                                    string(name: 'ADOPTOPENJDK_BRANCH', value: params.ADOPTOPENJDK_BRANCH ? params.ADOPTOPENJDK_BRANCH : "master"),
-                                    string(name: 'OPENJ9_REPO', value: params.OPENJ9_REPO ? params.OPENJ9_REPO : ""),
-                                    string(name: 'OPENJ9_BRANCH', value: params.OPENJ9_BRANCH ? params.OPENJ9_BRANCH : ""),
+                                build job: job_branch_name, parameters: [
                                     string(name: 'JenkinsFile', value: jenkins_file),
                                     string(name: 'JDK_IMPL', value: "hotspot"),
                                     // needs to be passed for 11 as default is 8, causing conflicts with AUTO_DETECT
@@ -269,17 +266,11 @@ node("ci.role.test&&hw.arch.x86&&sw.os.linux") {
                                     string(name: 'SDK_RESOURCE', value: "customized"),
                                     string(name: 'CUSTOMIZED_SDK_URL', value: jdk_jre_url),
                                     string(name: 'CUSTOMIZED_SDK_SOURCE_URL', value: source_url),
-                                    booleanParam(name: 'IS_PARALLEL', value: false),
-                                    booleanParam(name: 'AUTO_DETECT', value: true),
                                 ], propagate: true
                             }
                             parallelJobs["Test_openjdk${version}_hs_sanity.system_${r.ARCH}_${r.OS}"] = {
                                 // Run a systemtest test job with appropriate parameters
                                 build job: TEST_JOB_NAME, parameters: [
-                                    string(name: 'ADOPTOPENJDK_REPO', value: params.ADOPTOPENJDK_REPO ? params.ADOPTOPENJDK_REPO : "https://github.com/AdoptOpenJDK/openjdk-tests.git"),
-                                    string(name: 'ADOPTOPENJDK_BRANCH', value: params.ADOPTOPENJDK_BRANCH ? params.ADOPTOPENJDK_BRANCH : "master"),
-                                    string(name: 'OPENJ9_REPO', value: params.OPENJ9_REPO ? params.OPENJ9_REPO : ""),
-                                    string(name: 'OPENJ9_BRANCH', value: params.OPENJ9_BRANCH ? params.OPENJ9_BRANCH : ""),
                                     string(name: 'JenkinsFile', value: jenkins_file),
                                     string(name: 'JDK_IMPL', value: "hotspot"),
                                     // needs to be passed for 11 as default is 8, causing conflicts with AUTO_DETECT
@@ -288,8 +279,6 @@ node("ci.role.test&&hw.arch.x86&&sw.os.linux") {
                                     string(name: 'TARGET', value: "sanity.system"),
                                     string(name: 'SDK_RESOURCE', value: "customized"),
                                     string(name: 'CUSTOMIZED_SDK_URL', value: jdk_url),
-                                    booleanParam(name: 'IS_PARALLEL', value: false),
-                                    booleanParam(name: 'AUTO_DETECT', value: true),
                                 ], propagate: true
                             }
                         }


### PR DESCRIPTION
This pipeline performs Github API calls so as to determine whether or not new releases are available for OpenJDK Project Builds released at:

JDK 11: https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/
JDK 8:   https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries

If there are new releases, `sanity.openjdk` and `sanity.system` test jobs are being scheduled for each {version, architecture, platform} triplet.

Example run on Grinder_Sandbox (blue ocean view):
https://ci.adoptopenjdk.net/blue/organizations/jenkins/Grinder_Sandbox/detail/Grinder_Sandbox/495/pipeline

The idea would be to clone `Grinder_Sandbox` or `Grinder` Jenkins job configs and set up a separate job which runs daily or some such. The pipeline has functionality built in so as to not trigger new test jobs when the `published_at` date of the releases hasn't changed. Example for this scenario:

https://ci.adoptopenjdk.net/job/Grinder_Sandbox/494/console

Thoughts?

Closes #1183