### PR TITLE
Only track release if publish_date != null

### DIFF
--- a/buildenv/jenkins/upstream_openjdk_tests
+++ b/buildenv/jenkins/upstream_openjdk_tests
@@ -155,9 +155,15 @@ class ReleaseRetriever implements Serializable {
         List publishDates = []
         Map items = [:]
         response.each { item ->
-            ZonedDateTime parsedDate = ZonedDateTime.parse(item.published_at, DateTimeFormatter.ISO_DATE_TIME);
-            items.put(parsedDate, item)
-            publishDates.add(parsedDate)
+            // At certain points in time there may be a release upcoming, which hasn't
+            // been published yet. For example, uploaded, but not saved/published. This
+            // may be visible to some users. If it's not published, we consider it
+            // not available.
+            if (item.published_at != null) {
+                ZonedDateTime parsedDate = ZonedDateTime.parse(item.published_at, DateTimeFormatter.ISO_DATE_TIME);
+                items.put(parsedDate, item)
+                publishDates.add(parsedDate)
+            }
         }
         ZonedDateTime newest = publishDates.sort().last()
         return new ReleaseMetadata(newest, items)


### PR DESCRIPTION
Apparently, at certain points in time a Github API call may
return in-flux releases for certain users. In that case we
might get an item a published_at date of 'null'. Disregard
such in-flux releases as they haven't been published.

Signed-off-by: Severin Gehwolf <sgehwolf@redhat.com>