### PR TITLE
Add Dacapo benchmarks

### DIFF
--- a/perf/dacapo/build.xml
+++ b/perf/dacapo/build.xml
@@ -34,9 +34,9 @@
 	</target>
 
 	<target name="getEvaluationDacapoSuite" depends="init">
-		<echo message="wget -q https://sourceforge.net/projects/dacapobench/files/evaluation/" />
+		<echo message="wget -q https://sourceforge.net/projects/dacapobench/files/evaluation/dacapo-evaluation-git%2B8b7a2dc.jar/download" />
 			<exec executable="wget" failonerror="true">
-				<arg line="-q -O dacapoEval.jar https://sourceforge.net/projects/dacapobench/files/evaluation/" />
+				<arg line="-q -O dacapoEval11.jar https://sourceforge.net/projects/dacapobench/files/evaluation/dacapo-evaluation-git%2B8b7a2dc.jar/download" />
 			</exec>
 	</target>
 

--- a/perf/dacapo/build.xml
+++ b/perf/dacapo/build.xml
@@ -33,14 +33,7 @@
 			</exec>
 	</target>
 
-	<target name="getEvaluationDacapoSuite" depends="init">
-		<echo message="wget -q https://sourceforge.net/projects/dacapobench/files/evaluation/dacapo-evaluation-git%2B8b7a2dc.jar/download" />
-			<exec executable="wget" failonerror="true">
-				<arg line="-q -O dacapoEval11.jar https://sourceforge.net/projects/dacapobench/files/evaluation/dacapo-evaluation-git%2B8b7a2dc.jar/download" />
-			</exec>
-	</target>
-
-	<target name="dist" depends="getDacapoSuite,getEvaluationDacapoSuite" description="generate the distribution">
+	<target name="dist" depends="getDacapoSuite" description="generate the distribution">
 		<copy todir="${DEST}">
 			<fileset dir="${src}"/>
 		</copy>

--- a/perf/dacapo/build.xml
+++ b/perf/dacapo/build.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+
+<!--
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+-->
+
+<project name="Dacapo suite" default="build" basedir=".">
+	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+	<description>Dacapo suite</description>
+
+	<!-- set global properties for this build -->
+	<property name="DEST" value="${BUILD_ROOT}/perf/dacapo" />
+	<property name="src" location="." />
+	
+	<target name="init">
+		<mkdir dir="${DEST}" />
+	</target>
+
+	<target name="getDacapoSuite" depends="init">
+		<echo message="wget -q https://sourceforge.net/projects/dacapobench/files/latest/download" />
+			<exec executable="wget" failonerror="true">
+				<arg line="-q -O dacapo.jar https://sourceforge.net/projects/dacapobench/files/latest/download" />
+			</exec>
+	</target>
+
+	<target name="getEvaluationDacapoSuite" depends="init">
+		<echo message="wget -q https://sourceforge.net/projects/dacapobench/files/evaluation/" />
+			<exec executable="wget" failonerror="true">
+				<arg line="-q -O dacapoEval.jar https://sourceforge.net/projects/dacapobench/files/evaluation/" />
+			</exec>
+	</target>
+
+	<target name="dist" depends="getDacapoSuite,getEvaluationDacapoSuite" description="generate the distribution">
+		<copy todir="${DEST}">
+			<fileset dir="${src}"/>
+		</copy>
+	</target>
+
+	<target name="build">
+		<antcall target="dist" inheritall="true" />
+	</target>
+</project>

--- a/perf/dacapo/playlist.xml
+++ b/perf/dacapo/playlist.xml
@@ -150,17 +150,4 @@
 			<group>perf</group>
 		</groups>
 	</test>
-	<test>
-		<testCaseName>dacapo-cassandra-eval</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)dacapoEval11.jar$(Q) cassandra; \
-		$(TEST_STATUS)</command>
-		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
-		<levels>
-			<level>special</level>
-		</levels>
-		<groups>
-			<group>perf</group>
-		</groups>
-	</test>
-
 </playlist>

--- a/perf/dacapo/playlist.xml
+++ b/perf/dacapo/playlist.xml
@@ -19,6 +19,9 @@
 		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) eclipse; \
 		$(TEST_STATUS)</command>
 		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
+		<subsets>
+			<subset>8</subset>
+		</subsets>
 		<levels>
 			<level>sanity</level>
 		</levels>

--- a/perf/dacapo/playlist.xml
+++ b/perf/dacapo/playlist.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+-->
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="../../TestConfig/playlist.xsd">
+	<test>
+		<testCaseName>dacapo-tomcat</testCaseName>
+		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) tomcat; \
+		$(TEST_STATUS)</command>
+		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>perf</group>
+		</groups>
+	</test>
+	<test>
+		<testCaseName>dacapo-eclipse</testCaseName>
+		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) eclipse; \
+		$(TEST_STATUS)</command>
+		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>perf</group>
+		</groups>
+	</test>
+</playlist>

--- a/perf/dacapo/playlist.xml
+++ b/perf/dacapo/playlist.xml
@@ -15,8 +15,20 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:noNamespaceSchemaLocation="../../TestConfig/playlist.xsd">
 	<test>
-		<testCaseName>dacapo-tomcat</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) tomcat; \
+		<testCaseName>dacapo-eclipse</testCaseName>
+		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) eclipse; \
+		$(TEST_STATUS)</command>
+		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>perf</group>
+		</groups>
+	</test>
+	<test>
+		<testCaseName>dacapo-avrora</testCaseName>
+		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) avrora; \
 		$(TEST_STATUS)</command>
 		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
 		<levels>
@@ -27,12 +39,121 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>dacapo-eclipse</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) eclipse; \
+		<testCaseName>dacapo-batik</testCaseName>
+		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) batik; \
+		$(TEST_STATUS)</command>
+		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>perf</group>
+		</groups>
+	</test>
+	<test>
+		<testCaseName>dacapo-fop</testCaseName>
+		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) fop; \
+		$(TEST_STATUS)</command>
+		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>perf</group>
+		</groups>
+	</test>
+	<test>
+		<testCaseName>dacapo-h2</testCaseName>
+		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) h2; \
+		$(TEST_STATUS)</command>
+		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>perf</group>
+		</groups>
+	</test> 
+	<test>
+		<testCaseName>dacapo-jython</testCaseName>
+		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) jython; \
+		$(TEST_STATUS)</command>
+		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>perf</group>
+		</groups>
+	</test>
+		<test>
+		<testCaseName>dacapo-luindex</testCaseName>
+		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) luindex; \
+		$(TEST_STATUS)</command>
+		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>perf</group>
+		</groups>
+	</test>
+	<test>
+		<testCaseName>dacapo-lusearch-fix</testCaseName>
+		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) lusearch-fix; \
 		$(TEST_STATUS)</command>
 		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
 		<levels>
 			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>perf</group>
+		</groups>
+	</test>
+	<test>
+		<testCaseName>dacapo-pmd</testCaseName>
+		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) pmd; \
+		$(TEST_STATUS)</command>
+		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>perf</group>
+		</groups>
+	</test>
+	<test>
+		<testCaseName>dacapo-sunflow</testCaseName>
+		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) sunflow; \
+		$(TEST_STATUS)</command>
+		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>perf</group>
+		</groups>
+	</test>
+	<test>
+		<testCaseName>dacapo-tomcat</testCaseName>
+		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) tomcat; \
+		$(TEST_STATUS)</command>
+		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>perf</group>
+		</groups>
+		<disabled>https://bugs.openjdk.java.net/browse/JDK-8155588</disabled>
+	</test>
+	<test>
+		<testCaseName>dacapo-xalan</testCaseName>
+		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) xalan; \
+		$(TEST_STATUS)</command>
+		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
+		<levels>
+			<level>extended</level>
 		</levels>
 		<groups>
 			<group>perf</group>

--- a/perf/dacapo/playlist.xml
+++ b/perf/dacapo/playlist.xml
@@ -59,7 +59,7 @@
 		$(TEST_STATUS)</command>
 		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
 		<levels>
-			<level>extended</level>
+			<level>sanity</level>
 		</levels>
 		<groups>
 			<group>perf</group>
@@ -150,4 +150,17 @@
 			<group>perf</group>
 		</groups>
 	</test>
+	<test>
+		<testCaseName>dacapo-cassandra-eval</testCaseName>
+		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)dacapoEval.jar$(Q) cassandra; \
+		$(TEST_STATUS)</command>
+		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
+		<levels>
+			<level>special</level>
+		</levels>
+		<groups>
+			<group>perf</group>
+		</groups>
+	</test>
+
 </playlist>

--- a/perf/dacapo/playlist.xml
+++ b/perf/dacapo/playlist.xml
@@ -39,18 +39,6 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>dacapo-batik</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) batik; \
-		$(TEST_STATUS)</command>
-		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
-		<levels>
-			<level>extended</level>
-		</levels>
-		<groups>
-			<group>perf</group>
-		</groups>
-	</test>
-	<test>
 		<testCaseName>dacapo-fop</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) fop; \
 		$(TEST_STATUS)</command>

--- a/perf/dacapo/playlist.xml
+++ b/perf/dacapo/playlist.xml
@@ -152,7 +152,7 @@
 	</test>
 	<test>
 		<testCaseName>dacapo-cassandra-eval</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)dacapoEval.jar$(Q) cassandra; \
+		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)dacapoEval11.jar$(Q) cassandra; \
 		$(TEST_STATUS)</command>
 		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
 		<levels>


### PR DESCRIPTION
Include a set (appropriate for OpenJDK binaries) from the most recent list available from: https://github.com/dacapobench/dacapobench/blob/master/benchmarks/RELEASE_NOTES.txt

Fixes #1189 
