### PR TITLE
Passing JenkinsFile parameter to children

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -46,6 +46,7 @@ def setupEnv() {
 		env.JDK_VERSION = (params.JAVA_VERSION.trim())[2..-2];
 	}
 
+	JENKINS_FILE = params.JenkinsFile ? params.JenkinsFile : ""			
 	env.TEST_JDK_HOME = "$WORKSPACE/openjdkbinary/j2sdk-image"
 	env.JRE_IMAGE = params.JRE_IMAGE ? "${WORKSPACE}/${params.JRE_IMAGE}" : "$WORKSPACE/openjdkbinary/j2re-image"
 	env.JVM_VERSION = params.JVM_VERSION ? params.JVM_VERSION : ""
@@ -146,6 +147,7 @@ def setupParallelEnv() {
 						string(name: 'KEEP_REPORTDIR', value: KEEP_REPORTDIR),
 						string(name: 'EXTRA_OPTIONS', value: EXTRA_OPTIONS),
 						string(name: 'JVM_OPTIONS', value: JVM_OPTIONS),
+						string(name: 'JenkinsFile', value: JENKINS_FILE),
 						string(name: 'ITERATIONS', value: ITERATIONS),
 						string(name: 'LABEL', value: LABEL),
 						string(name: 'JCK_GIT_REPO', value: JCK_GIT_REPO),


### PR DESCRIPTION
Previously, the JenkinsFile parameter
would not be passed onto children builds,
which would cause an issue if the user
wanted a JenkinsFile architecture that was
not the default. The children would spawn
with the default architecture
(openjdk_x86-64_linux), and as a result,
it would fail. This change passes the
parent's architecture to the children so
that the bug would be fixed.

Signed-off-by: Michael Wang <Ziqing.Wang@ibm.com>