### PR TITLE
sanity.external: Payara-mp-tck exclude

### DIFF
--- a/external/payara-mp-tck/playlist.xml
+++ b/external/payara-mp-tck/playlist.xml
@@ -31,5 +31,6 @@
 		<groups>
 			<group>external</group>
 		</groups>
+		<disabled>https://github.com/AdoptOpenJDK/openjdk-tests/issues/1160</disabled>
 	</test>
 </playlist>

--- a/external/scala/dockerfile/scala-test.sh
+++ b/external/scala/dockerfile/scala-test.sh
@@ -42,9 +42,9 @@ pwd
 set -e
 
 echo "Try to echo Scala version by using sbt \"scala -version\"" && \
-sbt "scala -version"
+sbt -Dsbt.log.noformat=true "scala -version"
 
 echo "Begin to execute Scala test with cmd: sbt \"partest $TEST_SUITE\"" && \
-sbt "partest --terse $TEST_SUITE"
+sbt -Dsbt.log.noformat=true "partest --terse $TEST_SUITE"
 
 set +e


### PR DESCRIPTION
These tests are failing for both implementations, and an issue has been reported upstream (see #1160).  Until we hear back we will exclude.