### PR TITLE
check git repo sha

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ systemtest_prereqs/*
 openjdk/*.gz
 .DS_Store
 
+/.classpath
+/.project

--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -395,6 +395,8 @@ def post(output_name) {
 			step([$class: "TapPublisher", testResults: "**/*.tap", outputTapToConsole: false, failIfNoResults: failIfNoResultsValue])
 
 			junit allowEmptyResults: true, keepLongStdio: true, testResults: '**/work/**/*.jtr.xml, **/junitreports/**/*.xml, **/external_test_reports/**/*.xml'
+			archiveSHAFile()
+
 			if (currentBuild.result == 'UNSTABLE' || params.ARCHIVE_TEST_RESULTS) {
 				def test_output_tar_name = "${output_name}_test_output${suffix}"
 				sh "${tar_cmd} ${test_output_tar_name} ${pax_opt} ./openjdk-tests/TestConfig/test_output_*"
@@ -403,7 +405,8 @@ def post(output_name) {
 					echo "ARTIFACTORY_SERVER is not set. Saving artifacts on jenkins."
 					archiveArtifacts artifacts: test_output_tar_name, fingerprint: true, allowEmptyArchive: true
 				} else {
-					uploadToArtifactory()
+					def pattern = "${env.WORKSPACE}/*_test_output.*"
+					uploadToArtifactory(pattern)
 				}
 			}
 			//for performance test, archive regardless the build result
@@ -414,7 +417,8 @@ def post(output_name) {
 					echo "ARTIFACTORY_SERVER is not set. Saving artifacts on jenkins."
 					archiveArtifacts artifacts: benchmark_output_tar_name, fingerprint: true, allowEmptyArchive: true
 				} else {
-					uploadToArtifactory()
+					def pattern = "${env.WORKSPACE}/*_test_output.*"
+					uploadToArtifactory(pattern)
 				}
 			}
 		}
@@ -490,7 +494,18 @@ def getJenkinsDomain() {
 	return domainName
 }
 
-def uploadToArtifactory() {
+def archiveSHAFile() {
+	def shaFile = "openjdk-tests/TestConfig/SHA.txt";
+	if (!params.ARTIFACTORY_SERVER) {
+		echo "ARTIFACTORY_SERVER is not set. Saving SHA file on jenkins."
+		archiveArtifacts artifacts: shaFile, fingerprint: true, allowEmptyArchive: true
+	} else {
+		def pattern = "${env.WORKSPACE}/${shaFile}"
+		uploadToArtifactory(pattern)
+	}
+}
+
+def uploadToArtifactory(pattern) {
 	if (params.ARTIFACTORY_SERVER) {
 		def server = Artifactory.server params.ARTIFACTORY_SERVER
 		def artifactoryRepo = params.ARTIFACTORY_REPO ? params.ARTIFACTORY_REPO : "sys-rt-generic-local"
@@ -500,7 +515,7 @@ def uploadToArtifactory() {
 		def uploadSpec = """{
 			"files":[
 					{
-						"pattern": "${env.WORKSPACE}/*_test_output.*",
+						"pattern": "${pattern}",
 						"target": "${artifactoryUploadDir}"
 					}
 				]

--- a/get.sh
+++ b/get.sh
@@ -277,6 +277,9 @@ getTestKitGenAndFunctionalTestMaterial()
     else
 	    mv openj9/test/functional functional
     fi
+	echo "call checkTestRepoSHAs" 
+	checkTestRepoSHAs
+
 	rm -rf openj9
 
 	if [ "$VENDOR_REPOS" != "" ]; then
@@ -354,6 +357,21 @@ else
 	echo "Cannot find java executable in TEST_JDK_HOME: ${TEST_JDK_HOME}!"
 	exit 1
 fi
+}
+
+checkTestRepoSHAs()
+{
+output_file="$TESTDIR/TestConfig/SHA.txt"
+if [ -e ${output_file} ]; then
+	echo "rm $output_file"
+	rm ${output_file}
+fi
+
+echo "$TESTDIR/TestConfig/scripts/getSHA.sh --repo_dir $TESTDIR --output_file $output_file"
+$TESTDIR/TestConfig/scripts/getSHA.sh --repo_dir $TESTDIR --output_file $output_file
+
+echo "$TESTDIR/TestConfig/scripts/getSHA.sh --repo_dir $TESTDIR/openj9 --output_file $output_file"
+$TESTDIR/TestConfig/scripts/getSHA.sh --repo_dir $TESTDIR/openj9 --output_file $output_file
 }
 
 parseCommandLineArgs "$@"

--- a/openjdk/build.xml
+++ b/openjdk/build.xml
@@ -75,11 +75,14 @@
 				<property name="regressionRepo" value="https://github.com/AdoptOpenJDK/${openjdkGit}.git" />
 			</else>
 		</if>
+
 		<echo message="git clone --depth 1 -q ${gitReleaseTag} ${regressionRepo}" />
 		<exec executable="git" failonerror="false">
 			<arg line="clone --depth 1 -q ${gitReleaseTag} ${regressionRepo}" />
 		</exec>
 		<move file="${jdkName}" tofile="openjdk-jdk"/>
+
+		<checkGitRepoSha repoDir="openjdk-jdk" />
 	</target>
 	
 	<target name="openjdk-jdk.check">

--- a/systemtest/common.xml
+++ b/systemtest/common.xml
@@ -59,12 +59,6 @@
 			<arg value="${stf_branch}"/>
 			<arg value="${stf_repo}"/>
 		</exec>
-		<echo message="SHA of the checked out STF materials:"/>
-		<exec executable="git" failonerror="false">
-			<arg value="ls-remote" />
-			<arg value="${stf_repo}"/>
-			<arg value="${stf_branch}"/>
-		</exec>
 		<if>
 			<isset property="isZOS" />
 			<then>
@@ -86,6 +80,7 @@
 				</exec>
 			</then>
 		</if>
+		<checkGitRepoSha repoDir="${SYSTEMTEST_ROOT}/stf" />
 	</target>
 
 	<target name="clone_systemtest">
@@ -98,12 +93,6 @@
 			<arg value="-b"/>
 			<arg value="${openjdk_systemtest_branch}"/>
 			<arg value="${openjdk_systemtest_repo}"/>
-		</exec>
-		<echo message="SHA of the checked out openjdk-systemtest materials:"/>
-		<exec executable="git" failonerror="false">
-			<arg value="ls-remote" />
-			<arg value="${openjdk_systemtest_repo}"/>
-			<arg value="${openjdk_systemtest_branch}"/>
 		</exec>
 		<if>
 			<isset property="isZOS" />
@@ -126,6 +115,7 @@
 				</exec>
 			</then>
 		</if>
+		<checkGitRepoSha repoDir="${SYSTEMTEST_ROOT}/openjdk-systemtest" />
 	</target>
 	
 	<target name="clone_openj9-systemtest">
@@ -137,12 +127,6 @@
 			<arg value="-b"/>
 			<arg value="${openj9_systemtest_branch}"/>
 			<arg value="${openj9_systemtest_repo}"/>
-		</exec>
-		<echo message="SHA of the checked out openj9-systemtest materials:"/>
-		<exec executable="git" failonerror="false">
-			<arg value="ls-remote" />
-			<arg value="${openj9_systemtest_repo}"/>
-			<arg value="${openjdk_systemtest_branch}"/>
 		</exec>
 		<if>
 			<isset property="isZOS" />
@@ -165,6 +149,7 @@
 				</exec>
 			</then>
 		</if>
+		<checkGitRepoSha repoDir="${SYSTEMTEST_ROOT}/openj9-systemtest" />
 	</target>
 
 	<target name="check_systemtest" depends="common_init">


### PR DESCRIPTION
- archive SHA file regardless of build result
- call ant macrodef checkGitRepoSha when git clone a repo
- remove `git ls-remote` as it is no longer needed

Issue: #1169 #1218

Signed-off-by: lanxia <lan_xia@ca.ibm.com>