### PR TITLE
Reinclude TestDriver test case

### DIFF
--- a/openjdk/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/ProblemList_openjdk11-openj9.txt
@@ -31,7 +31,6 @@ java/lang/Class/GetModuleTest.java	https://github.com/eclipse/openj9/issues/3040
 java/lang/Class/GetPackageBootLoaderChildLayer.java	https://github.com/eclipse/openj9/issues/5274	generic-all
 java/lang/Class/forName/NonJavaNames.sh	https://github.com/eclipse/openj9/issues/5225	generic-all
 java/lang/Class/forName/arrayClass/ExceedMaxDim.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
-java/lang/Class/forName/modules/TestDriver.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 java/lang/ClassLoader/EndorsedDirs.java	https://github.com/eclipse/openj9/issues/3055	generic-all
 java/lang/ClassLoader/ExtDirs.java	https://github.com/eclipse/openj9/issues/3055	generic-all
 java/lang/ClassLoader/LibraryPathProperty.java	https://github.ibm.com/runtimes/openjdk-contribution/issues/606	generic-all

--- a/openjdk/ProblemList_openjdk12-openj9.txt
+++ b/openjdk/ProblemList_openjdk12-openj9.txt
@@ -30,7 +30,6 @@ java/lang/Class/GenericStringTest.java https://github.com/eclipse/openj9/issues/
 java/lang/Class/GetModuleTest.java	https://github.com/eclipse/openj9/issues/3040	generic-all
 java/lang/Class/GetPackageBootLoaderChildLayer.java	https://github.com/eclipse/openj9/issues/5274	generic-all
 java/lang/Class/forName/NonJavaNames.sh	https://github.com/eclipse/openj9/issues/5225	generic-all
-java/lang/Class/forName/modules/TestDriver.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 java/lang/ClassLoader/EndorsedDirs.java	https://github.com/eclipse/openj9/issues/3055	generic-all
 java/lang/ClassLoader/ExtDirs.java	https://github.com/eclipse/openj9/issues/3055	generic-all
 java/lang/ClassLoader/LibraryPathProperty.java	https://github.ibm.com/runtimes/openjdk-contribution/issues/606	generic-all


### PR DESCRIPTION
Removed TestDriver.java from adoptjdk11openj9 and adoptjdk12openj9 Problem Lists