### PR TITLE
Un-exclude java/lang/Class/forName/arrayClass/ExceedMaxDim.java and java/lang/String/UnicodeCasingTest.java

### DIFF
--- a/external/payara-mp-tck/playlist.xml
+++ b/external/payara-mp-tck/playlist.xml
@@ -31,5 +31,6 @@
 		<groups>
 			<group>external</group>
 		</groups>
+		<disabled>https://github.com/AdoptOpenJDK/openjdk-tests/issues/1160</disabled>
 	</test>
 </playlist>

--- a/openjdk/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/ProblemList_openjdk11-openj9.txt
@@ -30,7 +30,6 @@ java/lang/String/UnicodeCasingTest.java https://github.com/eclipse/openj9/issues
 java/lang/Class/GetModuleTest.java	https://github.com/eclipse/openj9/issues/3040	generic-all
 java/lang/Class/GetPackageBootLoaderChildLayer.java	https://github.com/eclipse/openj9/issues/5274	generic-all
 java/lang/Class/forName/NonJavaNames.sh	https://github.com/eclipse/openj9/issues/5225	generic-all
-java/lang/Class/forName/arrayClass/ExceedMaxDim.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 java/lang/Class/forName/modules/TestDriver.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 java/lang/ClassLoader/EndorsedDirs.java	https://github.com/eclipse/openj9/issues/3055	generic-all
 java/lang/ClassLoader/ExtDirs.java	https://github.com/eclipse/openj9/issues/3055	generic-all


### PR DESCRIPTION
Tests pass on osx, linux & windows