### PR TITLE
Enable jck-runtime-api-signaturetest and jck-runtime-api-javax_naming-spi on AIX

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -352,6 +352,11 @@ def runTest( ) {
 							echo "env.DISPLAY is ${env.DISPLAY}"
 							makeTest("${RUNTEST_CMD}")
 						}
+					} else if (env.SPEC.startsWith('aix')) {
+						sh "nohup /usr/bin/X11/X -force -vfb -x abx -x dbe -x GLX :0 &"
+						env.DISPLAY = ":0"
+						echo "env.DISPLAY is ${env.DISPLAY}"
+						makeTest("${RUNTEST_CMD}")
 					} else {
 						makeTest("${RUNTEST_CMD}")
 					}

--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -229,8 +229,7 @@
 	-test=Jck -test-args=$(Q)tests=api/signaturetest,jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
 	$(TEST_STATUS)</command>
 		<!-- Disabled on osx due to runtimes/infrastructure/issues/1111 -->
-		<!-- Disabled on aix due to runtimes/infrastructure/issues/2022 -->
-		<platformRequirements>^os.osx,^os.aix</platformRequirements>
+		<platformRequirements>^os.osx</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -368,8 +367,7 @@
 	-test=Jck -test-args=$(Q)tests=api/javax_naming/spi,jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
 	$(TEST_STATUS)</command>
 		<!-- Disabled on osx due to runtimes/infrastructure/issues/1111 -->
-		<!-- Disabled on aix due to runtimes/infrastructure/issues/2022 -->
-		<platformRequirements>^os.osx,^os.aix</platformRequirements>
+		<platformRequirements>^os.osx</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>


### PR DESCRIPTION
- Add cmd to associate XVFB with one display on aix for jck test only
- Enable jck-runtime-api-signaturetest and jck-runtime-api-javax_naming-spi on AIX

Signed-off-by: lanxia <lan_xia@ca.ibm.com>