### PR TITLE
remove name('AdoptOpenJDK') in testJobTemplate

### DIFF
--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -166,7 +166,6 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							scm {
 								git {
 									remote {
-										name('AdoptOpenJDK')
 										url(ADOPTOPENJDK_REPO)
 									}
 									branch('master')


### PR DESCRIPTION
By setting this value, the Jenkins job creates `remote.AdoptOpenJDK.url`
instead of `remote.origin.url`. This causes an issue later when we are
trying to display the git url. Hence, remove the name.

Fixes: #1238

Signed-off-by: lanxia <lan_xia@ca.ibm.com>