### PR TITLE
Exit immediately with a non-zero status if build or tests fail

### DIFF
--- a/external/tomee/dockerfile/tomee-test.sh
+++ b/external/tomee/dockerfile/tomee-test.sh
@@ -37,7 +37,7 @@ java -version
 
 cd /tomee
 
-#set -e
+set -e
 echo "Build TomEE without running test"
 mvn --batch-mode -Pquick -Dsurefire.useFile=false -DdisableXmlReport=true -DuniqueVersion=false -ff -Dassemble -DskipTests -DfailIfNoTests=false clean install
 echo "Build TomEE completed"


### PR DESCRIPTION
It helps to make docker run get correct status and hence testkitgen get
correct information

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>