### PR TITLE
Adding functionality to run SyntheticGCWorkload as a javaagent

### DIFF
--- a/functional/SyntheticGCWorkload/build.xml
+++ b/functional/SyntheticGCWorkload/build.xml
@@ -52,6 +52,9 @@
 		<jar jarfile="${DEST}/SyntheticGCWorkload.jar" filesonly="true">
 			<fileset dir="${build}" />
 			<fileset dir="${src}/../" includes="*.properties,*.xml" />
+			<manifest>
+				<attribute name="Premain-Class" value="net.adoptopenjdk.casa.agent.Agent"/>
+			</manifest>
 		</jar>
 		<copy todir="${DEST}">
 			<fileset dir="${src}/../" includes="*.xml" />

--- a/functional/SyntheticGCWorkload/src/net/adoptopenjdk/casa/agent/Agent.java
+++ b/functional/SyntheticGCWorkload/src/net/adoptopenjdk/casa/agent/Agent.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+package net.adoptopenjdk.casa.agent;
+
+import java.lang.instrument.Instrumentation;
+
+/**
+ * The class that is launched when the Synthetic GC workload is run as a java
+ * agent
+ */
+public class Agent {
+
+    final private static String CACHING = "-c";
+    final private static String SESSIONS = "-s";
+
+    public static void premain(String args, Instrumentation inst) {
+
+        String[] argsArr = null;
+        if (args != null) {
+            argsArr = args.split(" ");
+        } else {
+            // throw exception saying we need params
+            throw new IllegalArgumentException(
+                    "Must provide arguments. Use -c to launch caching workload, or -s to launch sessions workload");
+        }
+
+        if (argsArr[0].equals(SESSIONS)) {
+            // launch sessions workload
+            String[] sessionsArgs = new String[argsArr.length - 1];
+            // remove the -s flag, pass everything else to premain runner
+            System.arraycopy(argsArr, 1, sessionsArgs, 0, sessionsArgs.length);
+
+            net.adoptopenjdk.casa.workload_sessions.Main.premainRunner(sessionsArgs);
+
+        } else if (argsArr[0].equals(CACHING)) {
+            // launch caching workload
+            String[] cachingArgs = new String[argsArr.length - 1];
+            // remove the -c flag, pass everything else to runner
+            System.arraycopy(argsArr, 1, cachingArgs, 0, cachingArgs.length);
+            try {
+                net.adoptopenjdk.casa.workload_caching.Main.premainRunner(cachingArgs);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+
+        } else {
+            throw new IllegalArgumentException(
+                    "Invalid first argument --- First argument must be '-c' (caching workload) or '-s' (sessions workload)");
+        }
+
+    }
+}

--- a/functional/SyntheticGCWorkload/src/net/adoptopenjdk/casa/workload_caching/Main.java
+++ b/functional/SyntheticGCWorkload/src/net/adoptopenjdk/casa/workload_caching/Main.java
@@ -151,6 +151,26 @@ public class Main
 		 */
 		Event.SUCCESS.issue(); 
 	}
+
+	/**
+	 * Function is called from the agent. Simply starts the main method in a new thread
+	 */
+	public static void premainRunner(final String [] args) throws InterruptedException {
+
+		Thread main = new Thread(new Runnable() {
+
+			@Override
+			public void run() {
+				try {
+					main(args);
+				} catch (InterruptedException e) {
+					e.printStackTrace();
+				}
+			}
+		});
+
+		main.start();
+	}
 	
 	/**
 	 * Allows the progress bar to be printed again. 

--- a/functional/SyntheticGCWorkload/src/net/adoptopenjdk/casa/workload_sessions/Main.java
+++ b/functional/SyntheticGCWorkload/src/net/adoptopenjdk/casa/workload_sessions/Main.java
@@ -134,6 +134,22 @@ public class Main
 		// Attempt to exit on successfully 
 		Event.SUCCESS.issue();		
 	}
+
+	/**
+	 * Used when run as agent. Simply runs the main method in a new thread
+	 */
+	public static void premainRunner(final String [] args) {
+		
+		Thread main = new Thread(new Runnable(){
+		
+			@Override
+			public void run() {
+				main(args);
+			}
+		});
+
+		main.start();		
+    }
 	
 	/**
 	 * Gets the workloads object. 


### PR DESCRIPTION
- Added class `Agent.java` which will start the appropriate main method in a new thread, and pass control to the other application so both applications run together in same jvm.
- modified build.xml to recognize `Agent.java` as the entry point for javaagent
- example usage for sessions workload (-s) `$ java -Xbootclasspath/a:. -javaagent:SyntheticGCWorkload.jar="-s <config file> [options]" -jar <app.jar> [app options]`

Signed-off-by: Cedric Hansen <cedric.hansen@ibm.com>