### PR TITLE
Enhancement when customize target is empty

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -324,7 +324,7 @@ def runTest( ) {
 			}
 			def CUSTOM_OPTION = ''
 			TARGET = "${params.TARGET}";
-			if (TARGET.contains('custom')) {
+			if (TARGET.contains('custom') && CUSTOM_TARGET!='') {
 				CUSTOM_OPTION = "${TARGET.toUpperCase()}_TARGET='${CUSTOM_TARGET}'"
 			}
 			RUNTEST_CMD = "./openjdk-tests _${params.TARGET} ${CUSTOM_OPTION}"


### PR DESCRIPTION
Make sure if customized target is empty only default customized target will run in jenkins job. Otherwise it will run the whole test set.

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>