### PR TITLE
Fixed openjdk download when jdk_version is next

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -41,6 +41,7 @@ def setupEnv() {
 	}
 
 	if ( params.JDK_VERSION ) {
+		env.ORIGIN_JDK_VERSION = params.JDK_VERSION
 		env.JDK_VERSION = params.JDK_VERSION.equalsIgnoreCase("next") ? "" : params.JDK_VERSION
 	} else if ( params.JAVA_VERSION ) { // temporarily support JAVA_VERSION
 		env.JDK_VERSION = (params.JAVA_VERSION.trim())[2..-2];

--- a/openjdk/build.xml
+++ b/openjdk/build.xml
@@ -23,7 +23,6 @@
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/openjdk" />
 	<property name="src" location="." />
-	<property name="openjdkGit" value="openjdk-jdk${JDK_VERSION}u" />
 	<property environment="env" />
 	<if>
 		<isset property="env.RELEASE_TAG"/>
@@ -67,12 +66,28 @@
 		<if>
 			<contains string="${JVM_VERSION}" substring="openj9"/>
 			<then>
-				<property name="jdkName" value="openj9-openjdk-jdk${JDK_VERSION}" />
-				<property name="regressionRepo" value="https://github.com/ibmruntimes/openj9-openjdk-jdk${JDK_VERSION}.git" />
+				<if>
+					<equals arg1="${env.ORIGIN_JDK_VERSION}" arg2="next" />
+					<then>
+						<property name="jdkName" value="openj9-openjdk-jdk" />
+					</then>					
+					<else>
+						<property name="jdkName" value="openj9-openjdk-jdk${JDK_VERSION}" />
+					</else>
+				</if>
+				<property name="regressionRepo" value="https://github.com/ibmruntimes/${jdkName}.git" />
 			</then>
 			<else>
-				<property name="jdkName" value="${openjdkGit}" />
-				<property name="regressionRepo" value="https://github.com/AdoptOpenJDK/${openjdkGit}.git" />
+				<if>
+					<equals arg1="${env.ORIGIN_JDK_VERSION}" arg2="next" />
+					<then>
+						<property name="jdkName" value="openjdk-jdk" />
+					</then>					
+					<else>
+						<property name="jdkName" value="openjdk-jdk${JDK_VERSION}u" />
+					</else>
+				</if>
+				<property name="regressionRepo" value="https://github.com/AdoptOpenJDK/${jdkName}.git" />
 			</else>
 		</if>
 


### PR DESCRIPTION
- When jdk_version is next, download repo will be openjdk-jdk or openj9-openjdk-jdk.
[ci skip]
Issue: #1176

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>