### PR TITLE
Set umask 0002 on macos for shared classes caches to work

### DIFF
--- a/systemtest/sharedClasses/playlist.xml
+++ b/systemtest/sharedClasses/playlist.xml
@@ -24,12 +24,14 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>perl $(SYSTEMTEST_RESROOT)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl \
+		<command>if [[ $(PLATFORM) =~ $(Q)osx$(Q) ]] ; then export original_umask_val=`umask` $(AND_IF_SUCCESS) umask 0002 $(AND_IF_SUCCESS) umask -p; fi; \
+	perl $(SYSTEMTEST_RESROOT)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl \
 	-test-root=$(Q)$(SYSTEMTEST_RESROOT)$(D)stf;$(SYSTEMTEST_RESROOT)$(D)openjdk-systemtest;$(SYSTEMTEST_RESROOT)$(D)openj9-systemtest$(Q) \
 	-systemtest-prereqs=$(Q)$(SYSTEMTEST_RESROOT)$(D)systemtest_prereqs$(Q) \
 	-java-args=$(Q)$(JVM_OPTIONS)$(Q) \
 	-results-root=$(REPORTDIR) \
 	-test=SharedClassesAPI; \
+	if [[ $(PLATFORM) =~ $(Q)osx$(Q) ]] ; then umask $$original_umask_val $(AND_IF_SUCCESS) umask -p; fi; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>


### PR DESCRIPTION
Resolves https://github.com/AdoptOpenJDK/openjdk-tests/issues/1262
Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>