### PR TITLE
Exclude failure test on windows with jdk11,13 hs|openj9

### DIFF
--- a/openjdk/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/ProblemList_openjdk11-openj9.txt
@@ -201,7 +201,7 @@ java/net/Inet6Address/B6206527.java	https://github.com/AdoptOpenJDK/openjdk-test
 java/net/ipv6tests/B6521014.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/602	linux-all
 java/net/httpclient/UnknownBodyLengthTest.java	https://bugs.openjdk.java.net/browse/JDK-8210130	windows-all
 sun/net/www/protocol/http/RedirectOnPost.java	https://github.com/eclipse/openj9/issues/5140	windows-all
-
+com/sun/net/httpserver/bugs/B6361557.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1272	windows-all
 ############################################################################
 
 # jdk_io

--- a/openjdk/ProblemList_openjdk11.txt
+++ b/openjdk/ProblemList_openjdk11.txt
@@ -81,6 +81,7 @@ java/net/MulticastSocket/Test.java                             https://github.co
 java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267 macosx-all,linux-s390x
 #java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue	https://github.com/AdoptOpenJDK/openjdk-tests/issues/602
 java/nio/channels/DatagramChannel/Promiscuous.java              https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699    linux-s390x,macosx-all
+com/sun/net/httpserver/bugs/B6361557.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1272	windows-all
 ############################################################################
 
 # jdk_io
@@ -141,9 +142,10 @@ java/rmi/module/ModuleTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/is
 ############################################################################
 
 # jdk_util
+
 java/util/concurrent/locks/Lock/TimedAcquireLeak.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
 java/util/logging/TestLoggerWeakRefLeak.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
-
+java/util/concurrent/tck/JSR166TestCase.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1272 windows-all
 ############################################################################
 
 # svc_tools

--- a/openjdk/ProblemList_openjdk13-openj9.txt
+++ b/openjdk/ProblemList_openjdk13-openj9.txt
@@ -218,7 +218,7 @@ java/net/Inet6Address/B6206527.java	https://github.com/AdoptOpenJDK/openjdk-test
 java/net/ipv6tests/B6521014.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/602	linux-all
 java/net/httpclient/UnknownBodyLengthTest.java	https://bugs.openjdk.java.net/browse/JDK-8210130	windows-all
 sun/net/www/protocol/http/RedirectOnPost.java	https://github.com/eclipse/openj9/issues/5140	windows-all
-
+com/sun/net/httpserver/bugs/B6361557.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1272	windows-all
 ############################################################################
 
 # jdk_io

--- a/openjdk/ProblemList_openjdk13.txt
+++ b/openjdk/ProblemList_openjdk13.txt
@@ -82,6 +82,7 @@ java/net/MulticastSocket/Test.java                             https://github.co
 java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267 macosx-all,linux-s390x
 #java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue	https://github.com/AdoptOpenJDK/openjdk-tests/issues/602
 java/nio/channels/DatagramChannel/Promiscuous.java              https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699    linux-s390x,macosx-all
+com/sun/net/httpserver/bugs/B6361557.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1272	windows-all
 ############################################################################
 
 # jdk_io
@@ -144,7 +145,7 @@ java/rmi/module/ModuleTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/is
 # jdk_util
 java/util/concurrent/locks/Lock/TimedAcquireLeak.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
 java/util/logging/TestLoggerWeakRefLeak.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
-
+java/util/concurrent/tck/JSR166TestCase.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1272 windows-all
 ############################################################################
 
 # svc_tools


### PR DESCRIPTION
These tests have related JBS issues.

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>