### PR TITLE
Exclude tests failures for jdk13 openj9

### DIFF
--- a/openjdk/ProblemList_openjdk13-openj9.txt
+++ b/openjdk/ProblemList_openjdk13-openj9.txt
@@ -259,6 +259,7 @@ jdk/nio/zipfs/ZipFSTester.java https://github.com/eclipse/openj9/issues/4679 lin
 # jdk_rmi
 
 java/rmi/activation/Activatable/checkActivateRef/CheckActivateRef.java https://github.com/eclipse/openj9/issues/4126 windows-all
+java/rmi/activation/Activatable/checkAnnotations/CheckAnnotations https://github.com/eclipse/openj9/issues/6749 windows-all
 java/rmi/activation/Activatable/checkRegisterInLog/CheckRegisterInLog.java https://github.com/eclipse/openj9/issues/4772 windows-all
 java/rmi/activation/Activatable/inactiveGroup/InactiveGroup.java	https://github.com/eclipse/openj9/issues/5140	windows-all
 java/rmi/activation/CommandEnvironment/SetChildEnv.java https://github.com/eclipse/openj9/issues/4778 windows-all

--- a/openjdk/ProblemList_openjdk13-openj9.txt
+++ b/openjdk/ProblemList_openjdk13-openj9.txt
@@ -186,7 +186,7 @@ java/net/Inet6Address/B6206527.java https://github.com/AdoptOpenJDK/openjdk-infr
 java/net/MulticastSocket/Promiscuous.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699 linux-s390x
 java/net/MulticastSocket/SetLoopbackMode.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699 linux-s390x
 java/net/MulticastSocket/Test.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699 linux-s390x
-java/net/Socket/asyncClose/AsyncClose.java https://github.com/eclipse/openj9/issues/4560 linux-all,windows-all
+java/net/Socket/asyncClose/AsyncClose.java https://github.com/eclipse/openj9/issues/4560 linux-all,windows-all,macosx-all
 java/net/SocketImpl/BadUsages.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/897 linux-all
 java/net/SocketOption/OptionsTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 java/net/SocketOption/UnsupportedOptionsTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all

--- a/openjdk/ProblemList_openjdk13-openj9.txt
+++ b/openjdk/ProblemList_openjdk13-openj9.txt
@@ -187,6 +187,7 @@ java/net/MulticastSocket/Promiscuous.java https://github.com/AdoptOpenJDK/openjd
 java/net/MulticastSocket/SetLoopbackMode.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699 linux-s390x
 java/net/MulticastSocket/Test.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699 linux-s390x
 java/net/Socket/asyncClose/AsyncClose.java https://github.com/eclipse/openj9/issues/4560 linux-all,windows-all
+java/net/SocketImpl/BadUsages.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/897 linux-all
 java/net/SocketOption/OptionsTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 java/net/SocketOption/UnsupportedOptionsTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 java/net/SocketPermission/SocketPermissionCollection.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
@@ -314,6 +315,7 @@ java/util/concurrent/tck/JSR166TestCase.java	https://github.com/eclipse/openj9/i
 java/util/logging/TestLoggerWeakRefLeak.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 java/util/logging/LogManager/TestLoggerNames.java https://github.com/eclipse/openj9/issues/4561 generic-all
 java/util/stream/boottest/java.base/java/util/stream/NodeTest.java https://github.com/eclipse/openj9/issues/4129 macosx-all
+java/util/stream/test/org/openjdk/tests/java/util/SplittableRandomTest.java https://github.com/eclipse/openj9/issues/6735 linux-x86,windows-x86
 java/util/stream/test/org/openjdk/tests/java/util/stream/ToArrayOpTest.java	https://github.com/eclipse/openj9/issues/3447	generic-all
 
 ############################################################################


### PR DESCRIPTION
Excluding BadUsages.java, SplittableRandomTest.java, CheckAnnotations.java and AsyncClose.java

Signed-of-by: Adam Thorpe <adam.thorpe@ibm.com>