### PR TITLE
Removed quiet option from git fetch

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -265,8 +265,8 @@ getTestKitGenAndFunctionalTestMaterial()
 		echo "update to openj9 sha: $OPENJ9_SHA"
 		cd openj9
 		git fetch --unshallow
-		git fetch -q --tags $OPENJ9_REPO +refs/pull/*:refs/remotes/origin/pr/*
-		git checkout -q $OPENJ9_SHA
+		git fetch --tags $OPENJ9_REPO +refs/pull/*:refs/remotes/origin/pr/*
+		git checkout $OPENJ9_SHA
 		cd $TESTDIR
 	fi
 


### PR DESCRIPTION
A command is failing during tests, as seen in #1224. Removed quiet option
(-q) from 2 commands to allow more output and hopefully determine what
causes the error.

Signed-off-by: Colton Mills <millscolt3@gmail.com>