### PR TITLE
set USER_CREDENTIALS_ID in parallel build

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -45,7 +45,8 @@ def setupEnv() {
 		env.JDK_VERSION = params.JDK_VERSION.equalsIgnoreCase("next") ? "" : params.JDK_VERSION
 	}
 
-	JENKINS_FILE = params.JenkinsFile ? params.JenkinsFile : ""			
+	JENKINS_FILE = params.JenkinsFile ? params.JenkinsFile : ""
+	env.USER_CREDENTIALS_ID = params.USER_CREDENTIALS_ID ? params.USER_CREDENTIALS_ID : ""
 	env.TEST_JDK_HOME = "$WORKSPACE/openjdkbinary/j2sdk-image"
 	env.JRE_IMAGE = params.JRE_IMAGE ? "${WORKSPACE}/${params.JRE_IMAGE}" : "$WORKSPACE/openjdkbinary/j2re-image"
 	env.JVM_VERSION = params.JVM_VERSION ? params.JVM_VERSION : ""
@@ -160,6 +161,7 @@ def setupParallelEnv() {
 						string(name: 'LABEL', value: LABEL),
 						string(name: 'JCK_GIT_REPO', value: JCK_GIT_REPO),
 						string(name: 'SSH_AGENT_CREDENTIAL', value: SSH_AGENT_CREDENTIAL),
+						string(name: 'USER_CREDENTIALS_ID', value: env.USER_CREDENTIALS_ID),
 						booleanParam(name: 'KEEP_WORKSPACE', value: KEEP_WORKSPACE),
 						string(name: 'ARTIFACTORY_SERVER', value: ARTIFACTORY_SERVER),
 						booleanParam(name: 'PERSONAL_BUILD', value: PERSONAL_BUILD),


### PR DESCRIPTION
USER_CREDENTIALS_ID value is needed for git clone internal repo and it
is needed to be set in parallel build

Signed-off-by: lanxia <lan_xia@ca.ibm.com>