### PR TITLE
WIP: Add jck label

### DIFF
--- a/buildenv/jenkins/openjdk_x86-64_linux
+++ b/buildenv/jenkins/openjdk_x86-64_linux
@@ -6,8 +6,16 @@ if (params.DOCKER_REQUIRED) {
     LABEL='ci.role.test&&hw.arch.x86&&sw.os.linux'
 }
 
+if (params.LABEL) {
+	if (params.LABEL.startsWith('&&')) {
+		LABEL += params.LABEL
+	} else {
+		LABEL = params.LABEL
+	}
+} 
+
 stage('Queue') {
-    node((params.LABEL) ? params.LABEL : LABEL) {
+    node(LABEL) {
         PLATFORM = 'x64_linux'
         SDK_RESOURCE = 'upstream'
         SPEC='linux_x86-64_cmprssptrs'

--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -105,8 +105,10 @@ ARCH_OS_LIST.each { ARCH_OS ->
 
 				// for all jck builds, we need -Xfuture option passed in
 				def EXTRA_OPTIONS = "";
+				def LABEL = "";
 				if (GROUP == "jck" && JDK_IMPL == "openj9") {
 					EXTRA_OPTIONS = "-Xfuture"
+					LABEL = "&& !ci.role.test.no_jck"
 				}
 				
 				// for jck builds, if JCK_GIT_REPO_PREFIX is set, set JCK_GIT_REPO if it is not set
@@ -136,7 +138,7 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							stringParam('EXTRA_OPTIONS', EXTRA_OPTIONS, "Use this to append options to the test command")
 							stringParam('JVM_OPTIONS', "", "Use this to replace the test original command line options")
 							stringParam('ITERATIONS',"1", "Number of times to repeat execution of test target")
-							stringParam('LABEL', "", "Jenkins node label to run on, leave this blank to get sent to any machine matching the platform, set to node name for runs a particular machine")
+							stringParam('LABEL', LABEL, "Jenkins node label to run on, leave this blank to get sent to any machine matching the platform, set to node name for runs a particular machine")
 							stringParam('JCK_GIT_REPO', JCK_GIT_REPO, "For JCK test only")
 							stringParam('SSH_AGENT_CREDENTIAL', SSH_AGENT_CREDENTIAL, "Optional. Only use when ssh credentials are needed")
 							booleanParam('KEEP_WORKSPACE', false, "Keep workspace on the machine")


### PR DESCRIPTION
- Define LABEL as a parameter in testJobTemplate, with default value empty
- When group is JCK, set it to "&& !ci.role.test.no_jck"
- In the Jenkins template files for each platform, add logic append value found in LABEL, if it starts with "&&". This takes care of 3 scenarios - (a) when LABEL is empty (default) (b) When a custom value is provided for LABEL (e.g. node name given in grinders by users) (c) JCK builds where we'd have the JCK label supplied via generated jobs. 

FYI @AdamBrousseau @llxia @sophia-guo 
Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>