### PR TITLE
Clean up the workspace and prune obsolete local branches

### DIFF
--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -164,6 +164,8 @@ ARCH_OS_LIST.each { ARCH_OS ->
 									branch('master')
 									extensions {
 										relativeTargetDirectory('openjdk-tests')
+										cleanBeforeCheckout()
+										pruneStaleBranch()
 									}
 								}
 								scriptPath("buildenv/jenkins/openjdk_${ARCH_OS}")


### PR DESCRIPTION
Clean up the workspace before every checkout to ensure build is not
affected by the files generated by the previous build

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>