### PR TITLE
Enabled CS tests on Power

### DIFF
--- a/system/daaLoadTest/playlist.xml
+++ b/system/daaLoadTest/playlist.xml
@@ -211,7 +211,7 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
-		<platformRequirements>bits.64,^arch.ppc,^arch.arm,^os.osx</platformRequirements>
+		<platformRequirements>bits.64,^arch.arm,^os.osx</platformRequirements>
 	</test>
 	
 	<test>

--- a/system/lambdaLoadTest/playlist.xml
+++ b/system/lambdaLoadTest/playlist.xml
@@ -133,7 +133,7 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
-		<platformRequirements>bits.64,^arch.ppc,^arch.arm,^os.osx</platformRequirements>
+		<platformRequirements>bits.64,^arch.arm,^os.osx</platformRequirements>
 	</test>
 	
 	<test>

--- a/system/mauveLoadTest/playlist.xml
+++ b/system/mauveLoadTest/playlist.xml
@@ -181,7 +181,7 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
-		<platformRequirements>bits.64,^arch.ppc,^arch.arm,^os.osx</platformRequirements>
+		<platformRequirements>bits.64,^arch.arm,^os.osx</platformRequirements>
 		<disabled>AdoptOpenJDK/openjdk-systemtest/issues/75</disabled>
 	</test>
 	

--- a/system/otherLoadTest/playlist.xml
+++ b/system/otherLoadTest/playlist.xml
@@ -340,6 +340,6 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
-		<platformRequirements>bits.64,^arch.ppc,^arch.arm,^os.osx</platformRequirements>
+		<platformRequirements>bits.64,^arch.arm,^os.osx</platformRequirements>
 	</test>
 </playlist>


### PR DESCRIPTION
Certain tests had ^arch.ppc for concurrent scavenge. This commit
removes the specificed ^arch.ppc so Power has the same coverage
for testing concurrent scavenge on Power as x86 and Z.

Signed-off-by: Andrew Gao <Andrew.Gao@ibm.com>