### PR TITLE
Enable CS test cases on Power

### DIFF
--- a/system/daaLoadTest/playlist.xml
+++ b/system/daaLoadTest/playlist.xml
@@ -137,7 +137,7 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
-		<platformRequirements>bits.64,^arch.ppc,^arch.arm,^os.osx</platformRequirements>
+		<platformRequirements>bits.64,^arch.arm,^os.osx</platformRequirements>
 	</test>
 	
 	<test>
@@ -162,7 +162,7 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
-		<platformRequirements>bits.64,^arch.ppc,^arch.arm,^os.osx</platformRequirements>
+		<platformRequirements>bits.64,^arch.arm,^os.osx</platformRequirements>
 	</test>
 	
 	<test>
@@ -187,7 +187,7 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
-		<platformRequirements>bits.64,^arch.ppc,^arch.arm,^os.osx</platformRequirements>
+		<platformRequirements>bits.64,^arch.arm,^os.osx</platformRequirements>
 	</test>
 	
 	<test>

--- a/system/mathLoadTest/playlist.xml
+++ b/system/mathLoadTest/playlist.xml
@@ -102,7 +102,7 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
-		<platformRequirements>bits.64,^arch.ppc,^arch.arm,^os.osx</platformRequirements>
+		<platformRequirements>bits.64,^arch.arm,^os.osx</platformRequirements>
 	</test>
 	
 	<test>
@@ -127,7 +127,7 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
-		<platformRequirements>bits.64,^arch.ppc,^arch.arm,^os.osx</platformRequirements>
+		<platformRequirements>bits.64,^arch.arm,^os.osx</platformRequirements>
 	</test>
 	
 	<test>
@@ -152,7 +152,7 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
-		<platformRequirements>bits.64,^arch.ppc,^arch.arm,^os.osx</platformRequirements>
+		<platformRequirements>bits.64,^arch.arm,^os.osx</platformRequirements>
 	</test>
 	
 	<test>

--- a/system/mauveLoadTest/playlist.xml
+++ b/system/mauveLoadTest/playlist.xml
@@ -206,7 +206,7 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
-		<platformRequirements>bits.64,^arch.ppc,^arch.arm,^os.osx</platformRequirements>
+		<platformRequirements>bits.64,^arch.arm,^os.osx</platformRequirements>
 		<disabled>AdoptOpenJDK/openjdk-systemtest/issues/78</disabled>
 	</test>
 	
@@ -231,7 +231,7 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
-		<platformRequirements>bits.64,^arch.ppc,^arch.arm,^os.osx</platformRequirements>
+		<platformRequirements>bits.64,^arch.arm,^os.osx</platformRequirements>
 		<disabled>AdoptOpenJDK/openjdk-systemtest/issues/64</disabled>
 	</test>
 	<!-- The above tests are to be run using concurrentScavenge on z/OS, z/Linux, x/Linux and x/Windows using 64-bit OpenJ9 SDK -->


### PR DESCRIPTION
There are some CS test cases that were not enabled on Power.
This commit enables all CS testing on the Power platform.

Signed-off-by: Andrew Gao <andrewgao98@gmail.com>