### PR TITLE
Portable interpreter invocation

### DIFF
--- a/functional/SyntheticGCWorkload/concurrent_slack_sweep.sh
+++ b/functional/SyntheticGCWorkload/concurrent_slack_sweep.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/functional/SyntheticGCWorkload/run_abort_test.sh
+++ b/functional/SyntheticGCWorkload/run_abort_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/functional/SyntheticGCWorkload/run_test.sh
+++ b/functional/SyntheticGCWorkload/run_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/functional/SyntheticGCWorkload/run_tests.sh
+++ b/functional/SyntheticGCWorkload/run_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/get.sh
+++ b/get.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/maketest.sh
+++ b/maketest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/perf/idle_micro/log_parse.sh
+++ b/perf/idle_micro/log_parse.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/perf/idle_micro/runIdleTest.sh
+++ b/perf/idle_micro/runIdleTest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/perf/liberty/configs/benchmark.sh
+++ b/perf/liberty/configs/benchmark.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -69,4 +69,4 @@ export WLP_SKIP_MAXPERMSIZE="1"
 #TODO: Need to soft-code these configs. Need to add various affinity tools in the perf pre-reqs ()
 export AFFINITY="numactl --physcpubind=0-3 --membind=0"
 
-bash ${1}/scripts/bin/sufp_benchmark.sh 
+bash ${1}/scripts/bin/sufp_benchmark.sh

--- a/perf/liberty/scripts/bin/common_utils.sh
+++ b/perf/liberty/scripts/bin/common_utils.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ################################################################################
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/perf/liberty/scripts/bin/database_utils.sh
+++ b/perf/liberty/scripts/bin/database_utils.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ################################################################################
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/perf/liberty/scripts/bin/sufp_benchmark.sh
+++ b/perf/liberty/scripts/bin/sufp_benchmark.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ################################################################################
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
* *BSD does not have /bin/bash.  Use /usr/bin/env bash for portability.