### PR TITLE
Remove -p option from umask as it doesn't work on AIX

### DIFF
--- a/system/sharedClasses/playlist.xml
+++ b/system/sharedClasses/playlist.xml
@@ -24,14 +24,14 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>if [[ ! $(Q)$(PLATFORM)$(Q) == *$(Q)win$(Q)* ]] ; then export original_umask_val=`umask` $(AND_IF_SUCCESS) umask 0002 $(AND_IF_SUCCESS) umask -p; fi; \
+		<command>if [[ ! $(Q)$(PLATFORM)$(Q) == *$(Q)win$(Q)* ]] ; then export original_umask_val=`umask` $(AND_IF_SUCCESS) umask 0002 $(AND_IF_SUCCESS) echo umask set to `umask`; fi; \
 	perl $(SYSTEMTEST_RESROOT)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl \
 	-test-root=$(Q)$(SYSTEMTEST_RESROOT)$(D)stf;$(SYSTEMTEST_RESROOT)$(D)openjdk-systemtest;$(SYSTEMTEST_RESROOT)$(D)openj9-systemtest$(Q) \
 	-systemtest-prereqs=$(Q)$(SYSTEMTEST_RESROOT)$(D)systemtest_prereqs$(Q) \
 	-java-args=$(Q)$(JVM_OPTIONS)$(Q) \
 	-results-root=$(REPORTDIR) \
 	-test=SharedClassesAPI; \
-	if [[ ! $(Q)$(PLATFORM)$(Q) == *$(Q)win$(Q)* ]] ; then umask $$original_umask_val $(AND_IF_SUCCESS) umask -p; fi; \
+	if [[ ! $(Q)$(PLATFORM)$(Q) == *$(Q)win$(Q)* ]] ; then umask $$original_umask_val $(AND_IF_SUCCESS)  echo umask set to `umask`; fi; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>


### PR DESCRIPTION
Related to https://github.com/eclipse/openj9/issues/6840

Background: 

On AIX 7.1
```
umask -p
umask: Improper mask.
```

We should remove `-p` option as it doesn't work with all AIX versions, and simply use umask to output the updated umask value (for debug/logging purposes). 

FYI @hangshao0 

Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>