### PR TITLE
Remove duplicated test JDKInternalAPIsTest

### DIFF
--- a/system/modularity/playlist.xml
+++ b/system/modularity/playlist.xml
@@ -340,28 +340,6 @@
 		<disabled>https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/200</disabled>
 	</test>
 	<test>
-		<testCaseName>JDKInternalAPIsTest</testCaseName>
-		<variations>
-			<variation>NoOptions</variation>
-		</variations>
-		<command>perl $(SYSTEMTEST_RESROOT)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
-	-test-root=$(Q)$(SYSTEMTEST_RESROOT)$(D)stf;$(SYSTEMTEST_RESROOT)$(D)openjdk-systemtest$(Q) \
-	-systemtest-prereqs=$(Q)$(SYSTEMTEST_RESROOT)$(D)systemtest_prereqs$(Q)  \
-	-java-args=$(Q)$(JVM_OPTIONS)$(Q) \
-	-results-root=$(REPORTDIR) \
-	-test=JDKInternalAPIsTest; \
-	$(TEST_STATUS)</command> 
-		<subsets>
-			<subset>9+</subset>
-		</subsets>
-		<levels>
-			<level>sanity</level>
-		</levels>
-		<groups>
-			<group>system</group>
-		</groups>
-	</test>
-	<test>
 		<testCaseName>ServiceLoadersTest</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>


### PR DESCRIPTION
The test JDKInternalAPIsTest was defined twice in the
system/modularity/playlist.xml file as defined in #923.

Fixes: #923
Signed-off-by: Andre Ha <Andre.Ha@ibm.com>