### PR TITLE
Add JVM options -Xss2M -Xmso1M for AIX platform

### DIFF
--- a/jck/runtime.lang/playlist.xml
+++ b/jck/runtime.lang/playlist.xml
@@ -58,7 +58,7 @@
 		</subsets>
 	</test>
 	<test>
-		<testCaseName>jck-runtime-lang-CLSS</testCaseName>
+		<testCaseName>jck-runtime-lang-CLSS-NON-AIX</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -70,6 +70,7 @@
 	-results-root=$(REPORTDIR)  \
 	-test=Jck -test-args=$(Q)tests=lang/CLSS,jckRoot=$(JCK_ROOT),jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
 	$(TEST_STATUS)</command>
+		<platformRequirements>^os.aix</platformRequirements>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -77,7 +78,31 @@
 			<group>jck</group>
 		</groups>
 		<subsets>
-			<subset>10+</subset>
+			<subset>11+</subset>
+		</subsets>
+	</test>
+	<test>
+		<testCaseName>jck-runtime-lang-CLSS-AIX</testCaseName>
+		<variations>
+			<variation>-Xss2M -Xmso1M</variation>
+		</variations>
+		<command>export JAVA_HOME=$(TEST_JDK_HOME)$(D)  $(AND_IF_SUCCESS) \
+	perl $(TEST_RESROOT)$(D)..$(D)..$(D)system$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
+	-test-root=$(Q)$(TEST_RESROOT)$(D)..$(D)..$(D)system$(D)stf;$(TEST_RESROOT)$(D)..$(D)..$(D)system$(D)openjdk-systemtest$(Q) \
+	-systemtest-prereqs=$(Q)$(JCK_ROOT)$(Q)  \
+	-java-args-setup=$(Q)$(JVM_OPTIONS)$(Q) \
+	-results-root=$(REPORTDIR)  \
+	-test=Jck -test-args=$(Q)tests=lang/CLSS,jckRoot=$(JCK_ROOT),jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
+	$(TEST_STATUS)</command>
+		<platformRequirements>os.aix</platformRequirements>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>jck</group>
+		</groups>
+		<subsets>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	<test>


### PR DESCRIPTION
**Add JVM options -Xss2M -Xmso1M for AIX platform**

These two options `-Xss2M -Xmso1M` are required by `lang/CLSS/clss015/clss01507m1/clss01507m1_rt.html` at `AIX` platform, otherwise a hang might occur.

Reviewer: @ShelleyLambert 
FYI: @llxia @DanHeidinga @pshipton 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>