### PR TITLE
Disable -Xint modes from system test

### DIFF
--- a/system/daaLoadTest/playlist.xml
+++ b/system/daaLoadTest/playlist.xml
@@ -221,22 +221,16 @@
 			<variation>Mode103</variation>
 			<variation>Mode104</variation>
 			<variation>Mode107</variation>
-			<variation>Mode108</variation>
-			<variation>Mode109</variation>
-			<variation>Mode109-CS</variation>
 			<variation>Mode110</variation>
 			<variation>Mode112</variation>
 			<variation>Mode113</variation>
 			<variation>Mode121</variation>
 			<variation>Mode122</variation>
 			<variation>Mode140</variation>
-			<variation>Mode159</variation>
-			<variation>Mode159-CS</variation>
 			<variation>Mode187</variation>
 			<variation>Mode301</variation>
 			<variation>Mode351</variation>
 			<variation>Mode501</variation>
-			<variation>Mode550</variation>
 			<variation>Mode551</variation>
 			<variation>Mode553</variation>
 			<variation>Mode554</variation>
@@ -253,6 +247,7 @@
 			<variation>Mode110-OSRG</variation>
 			<variation>Mode610-OSRG</variation>
 			<variation>Mode612-OSRG</variation>
+			<!--Note: -Xint modes Mode108, Mode109, Mode109-CS, Mode159, Mode159-CS, Mode550 should be run manually -->
 		</variations>
 		<command>perl $(SYSTEMTEST_RESROOT)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl \
 	-test-root=$(Q)$(SYSTEMTEST_RESROOT)$(D)stf;$(SYSTEMTEST_RESROOT)$(D)openjdk-systemtest;$(SYSTEMTEST_RESROOT)$(D)openj9-systemtest$(Q) \
@@ -280,22 +275,16 @@
 			<variation>Mode103</variation>
 			<variation>Mode104</variation>
 			<variation>Mode107</variation>
-			<variation>Mode108</variation>
-			<variation>Mode109</variation>
-			<variation>Mode109-CS</variation>
 			<variation>Mode110</variation>
 			<variation>Mode112</variation>
 			<variation>Mode113</variation>
 			<variation>Mode121</variation>
 			<variation>Mode122</variation>
 			<variation>Mode140</variation>
-			<variation>Mode159</variation>
-			<variation>Mode159-CS</variation>
 			<variation>Mode187</variation>
 			<variation>Mode301</variation>
 			<variation>Mode351</variation>
 			<variation>Mode501</variation>
-			<variation>Mode550</variation>
 			<variation>Mode551</variation>
 			<variation>Mode553</variation>
 			<variation>Mode554</variation>
@@ -312,6 +301,7 @@
 			<variation>Mode110-OSRG</variation>
 			<variation>Mode610-OSRG</variation>
 			<variation>Mode612-OSRG</variation>
+			<!--Note: -Xint modes Mode108, Mode109, Mode109-CS, Mode159, Mode159-CS, Mode550 should be run manually -->
 		</variations>
 		<command>perl $(SYSTEMTEST_RESROOT)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl \
 	-test-root=$(Q)$(SYSTEMTEST_RESROOT)$(D)stf;$(SYSTEMTEST_RESROOT)$(D)openjdk-systemtest;$(SYSTEMTEST_RESROOT)$(D)openj9-systemtest$(Q) \
@@ -339,22 +329,16 @@
 			<variation>Mode103</variation>
 			<variation>Mode104</variation>
 			<variation>Mode107</variation>
-			<variation>Mode108</variation>
-			<variation>Mode109</variation>
-			<variation>Mode109-CS</variation>
 			<variation>Mode110</variation>
 			<variation>Mode112</variation>
 			<variation>Mode113</variation>
 			<variation>Mode121</variation>
 			<variation>Mode122</variation>
 			<variation>Mode140</variation>
-			<variation>Mode159</variation>
-			<variation>Mode159-CS</variation>
 			<variation>Mode187</variation>
 			<variation>Mode301</variation>
 			<variation>Mode351</variation>
 			<variation>Mode501</variation>
-			<variation>Mode550</variation>
 			<variation>Mode551</variation>
 			<variation>Mode553</variation>
 			<variation>Mode554</variation>
@@ -371,6 +355,7 @@
 			<variation>Mode110-OSRG</variation>
 			<variation>Mode610-OSRG</variation>
 			<variation>Mode612-OSRG</variation>
+			<!--Note: -Xint modes Mode108, Mode109, Mode109-CS, Mode159, Mode159-CS, Mode550 should be run manually -->
 		</variations>
 		<command>perl $(SYSTEMTEST_RESROOT)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl \
 	-test-root=$(Q)$(SYSTEMTEST_RESROOT)$(D)stf;$(SYSTEMTEST_RESROOT)$(D)openjdk-systemtest;$(SYSTEMTEST_RESROOT)$(D)openj9-systemtest$(Q) \
@@ -398,22 +383,16 @@
 			<variation>Mode103</variation>
 			<variation>Mode104</variation>
 			<variation>Mode107</variation>
-			<variation>Mode108</variation>
-			<variation>Mode109</variation>
-			<variation>Mode109-CS</variation>
 			<variation>Mode110</variation>
 			<variation>Mode112</variation>
 			<variation>Mode113</variation>
 			<variation>Mode121</variation>
 			<variation>Mode122</variation>
 			<variation>Mode140</variation>
-			<variation>Mode159</variation>
-			<variation>Mode159-CS</variation>
 			<variation>Mode187</variation>
 			<variation>Mode301</variation>
 			<variation>Mode351</variation>
 			<variation>Mode501</variation>
-			<variation>Mode550</variation>
 			<variation>Mode551</variation>
 			<variation>Mode553</variation>
 			<variation>Mode554</variation>
@@ -430,6 +409,7 @@
 			<variation>Mode110-OSRG</variation>
 			<variation>Mode610-OSRG</variation>
 			<variation>Mode612-OSRG</variation>
+			<!--Note: -Xint modes Mode108, Mode109, Mode109-CS, Mode159, Mode159-CS, Mode550 should be run manually -->
 		</variations>
 		<command>perl $(SYSTEMTEST_RESROOT)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl \
 	-test-root=$(Q)$(SYSTEMTEST_RESROOT)$(D)stf;$(SYSTEMTEST_RESROOT)$(D)openjdk-systemtest;$(SYSTEMTEST_RESROOT)$(D)openj9-systemtest$(Q) \

--- a/system/lambdaLoadTest/playlist.xml
+++ b/system/lambdaLoadTest/playlist.xml
@@ -143,22 +143,16 @@
 			<variation>Mode103</variation>
 			<variation>Mode104</variation>
 			<variation>Mode107</variation>
-			<variation>Mode108</variation>
-			<variation>Mode109</variation>
-			<variation>Mode109-CS</variation>
 			<variation>Mode110</variation>
 			<variation>Mode112</variation>
 			<variation>Mode113</variation>
 			<variation>Mode121</variation>
 			<variation>Mode122</variation>
 			<variation>Mode140</variation>
-			<variation>Mode159</variation>
-			<variation>Mode159-CS</variation>
 			<variation>Mode187</variation>
 			<variation>Mode301</variation>
 			<variation>Mode351</variation>
 			<variation>Mode501</variation>
-			<variation>Mode550</variation>
 			<variation>Mode551</variation>
 			<variation>Mode553</variation>
 			<variation>Mode554</variation>
@@ -175,6 +169,7 @@
 			<variation>Mode110-OSRG</variation>
 			<variation>Mode610-OSRG</variation>
 			<variation>Mode612-OSRG</variation>
+			<!--Note: -Xint modes Mode108, Mode109, Mode109-CS, Mode159, Mode159-CS, Mode550 should be run manually -->
 		</variations>
 		<command>perl $(SYSTEMTEST_RESROOT)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
 	-test-root=$(Q)$(SYSTEMTEST_RESROOT)$(D)stf;$(SYSTEMTEST_RESROOT)$(D)openjdk-systemtest$(Q) \
@@ -202,22 +197,16 @@
 			<variation>Mode103</variation>
 			<variation>Mode104</variation>
 			<variation>Mode107</variation>
-			<variation>Mode108</variation>
-			<variation>Mode109</variation>
-			<variation>Mode109-CS</variation>
 			<variation>Mode110</variation>
 			<variation>Mode112</variation>
 			<variation>Mode113</variation>
 			<variation>Mode121</variation>
 			<variation>Mode122</variation>
 			<variation>Mode140</variation>
-			<variation>Mode159</variation>
-			<variation>Mode159-CS</variation>
 			<variation>Mode187</variation>
 			<variation>Mode301</variation>
 			<variation>Mode351</variation>
 			<variation>Mode501</variation>
-			<variation>Mode550</variation>
 			<variation>Mode551</variation>
 			<variation>Mode553</variation>
 			<variation>Mode554</variation>
@@ -234,6 +223,7 @@
 			<variation>Mode110-OSRG</variation>
 			<variation>Mode610-OSRG</variation>
 			<variation>Mode612-OSRG</variation>
+			<!--Note: -Xint modes Mode108, Mode109, Mode109-CS, Mode159, Mode159-CS, Mode550 should be run manually -->
 		</variations>
 		<command>perl $(SYSTEMTEST_RESROOT)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
 	-test-root=$(Q)$(SYSTEMTEST_RESROOT)$(D)stf;$(SYSTEMTEST_RESROOT)$(D)openjdk-systemtest$(Q) \

--- a/system/mathLoadTest/playlist.xml
+++ b/system/mathLoadTest/playlist.xml
@@ -162,22 +162,16 @@
 			<variation>Mode103</variation>
 			<variation>Mode104</variation>
 			<variation>Mode107</variation>
-			<variation>Mode108</variation>
-			<variation>Mode109</variation>
-			<variation>Mode109-CS</variation>
 			<variation>Mode110</variation>
 			<variation>Mode112</variation>
 			<variation>Mode113</variation>
 			<variation>Mode121</variation>
 			<variation>Mode122</variation>
 			<variation>Mode140</variation>
-			<variation>Mode159</variation>
-			<variation>Mode159-CS</variation>
 			<variation>Mode187</variation>
 			<variation>Mode301</variation>
 			<variation>Mode351</variation>
 			<variation>Mode501</variation>
-			<variation>Mode550</variation>
 			<variation>Mode551</variation>
 			<variation>Mode553</variation>
 			<!-- disable Mode554 until the issue is fixed rtc 139897-->
@@ -194,6 +188,7 @@
 			<variation>Mode110-OSRG</variation>
 			<variation>Mode610-OSRG</variation>
 			<variation>Mode612-OSRG</variation>
+			<!--Note: -Xint modes Mode108, Mode109, Mode109-CS, Mode159, Mode159-CS, Mode550 should be run manually -->
 		</variations>
 		<command>perl $(SYSTEMTEST_RESROOT)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl \
 	-test-root=$(Q)$(SYSTEMTEST_RESROOT)$(D)stf;$(SYSTEMTEST_RESROOT)$(D)openjdk-systemtest$(Q) \
@@ -220,22 +215,16 @@
 			<variation>Mode103</variation>
 			<variation>Mode104</variation>
 			<variation>Mode107</variation>
-			<variation>Mode108</variation>
-			<variation>Mode109</variation>
-			<variation>Mode109-CS</variation>
 			<variation>Mode110</variation>
 			<variation>Mode112</variation>
 			<variation>Mode113</variation>
 			<variation>Mode121</variation>
 			<variation>Mode122</variation>
 			<variation>Mode140</variation>
-			<variation>Mode159</variation>
-			<variation>Mode159-CS</variation>
 			<variation>Mode187</variation>
 			<variation>Mode301</variation>
 			<variation>Mode351</variation>
 			<variation>Mode501</variation>
-			<variation>Mode550</variation>
 			<variation>Mode551</variation>
 			<variation>Mode553</variation>
 			<variation>Mode554</variation>
@@ -252,6 +241,7 @@
 			<variation>Mode110-OSRG</variation>
 			<variation>Mode610-OSRG</variation>
 			<variation>Mode612-OSRG</variation>
+			<!--Note: -Xint modes Mode108, Mode109, Mode109-CS, Mode159, Mode159-CS, Mode550 should be run manually -->
 		</variations>
 		<command>perl $(SYSTEMTEST_RESROOT)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl \
 	-test-root=$(Q)$(SYSTEMTEST_RESROOT)$(D)stf;$(SYSTEMTEST_RESROOT)$(D)openjdk-systemtest$(Q) \
@@ -279,22 +269,16 @@
 			<variation>Mode103</variation>
 			<variation>Mode104</variation>
 			<variation>Mode107</variation>
-			<variation>Mode108</variation>
-			<variation>Mode109</variation>
-			<variation>Mode109-CS</variation>
 			<variation>Mode110</variation>
 			<variation>Mode112</variation>
 			<variation>Mode113</variation>
 			<variation>Mode121</variation>
 			<variation>Mode122</variation>
 			<variation>Mode140</variation>
-			<variation>Mode159</variation>
-			<variation>Mode159-CS</variation>
 			<variation>Mode187</variation>
 			<variation>Mode301</variation>
 			<variation>Mode351</variation>
 			<variation>Mode501</variation>
-			<variation>Mode550</variation>
 			<variation>Mode551</variation>
 			<variation>Mode553</variation>
 			<variation>Mode554</variation>
@@ -311,6 +295,7 @@
 			<variation>Mode110-OSRG</variation>
 			<variation>Mode610-OSRG</variation>
 			<variation>Mode612-OSRG</variation>
+			<!--Note: -Xint modes Mode108, Mode109, Mode109-CS, Mode159, Mode159-CS, Mode550 should be run manually -->
 		</variations>
 		<command>perl $(SYSTEMTEST_RESROOT)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl \
 	-test-root=$(Q)$(SYSTEMTEST_RESROOT)$(D)stf;$(SYSTEMTEST_RESROOT)$(D)openjdk-systemtest$(Q) \

--- a/system/mauveLoadTest/playlist.xml
+++ b/system/mauveLoadTest/playlist.xml
@@ -243,8 +243,6 @@
 			<variation>Mode103</variation>
 			<variation>Mode104</variation>
 			<variation>Mode107</variation>
-			<variation>Mode108</variation>
-			<variation>Mode109</variation>
 			<variation>Mode110</variation>
 			<variation>Mode112</variation>
 			<variation>Mode113</variation>
@@ -254,7 +252,6 @@
 			<variation>Mode301</variation>
 			<variation>Mode351</variation>
 			<variation>Mode501</variation>
-			<variation>Mode550</variation>
 			<variation>Mode551</variation>
 			<variation>Mode553</variation>
 			<variation>Mode554</variation>
@@ -271,6 +268,7 @@
 			<variation>Mode110-OSRG</variation>
 			<variation>Mode610-OSRG</variation>
 			<variation>Mode612-OSRG</variation>
+			<!--Note: -Xint modes Mode108, Mode109, Mode550 should be run manually -->
 		</variations>
 		<command>perl $(SYSTEMTEST_RESROOT)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
 	-test-root=$(Q)$(SYSTEMTEST_RESROOT)$(D)stf;$(SYSTEMTEST_RESROOT)$(D)openjdk-systemtest$(Q) \
@@ -300,8 +298,6 @@
 			<variation>Mode103</variation>
 			<variation>Mode104</variation>
 			<variation>Mode107</variation>
-			<variation>Mode108</variation>
-			<variation>Mode109</variation>
 			<variation>Mode110</variation>
 			<variation>Mode112</variation>
 			<variation>Mode113</variation>
@@ -311,7 +307,6 @@
 			<variation>Mode301</variation>
 			<variation>Mode351</variation>
 			<variation>Mode501</variation>
-			<variation>Mode550</variation>
 			<variation>Mode551</variation>
 			<variation>Mode553</variation>
 			<variation>Mode554</variation>
@@ -328,6 +323,7 @@
 			<variation>Mode110-OSRG</variation>
 			<variation>Mode610-OSRG</variation>
 			<variation>Mode612-OSRG</variation>
+			<!--Note: -Xint modes Mode108, Mode109, Mode550 should be run manually -->
 		</variations>
 		<command>perl $(SYSTEMTEST_RESROOT)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
 	-test-root=$(Q)$(SYSTEMTEST_RESROOT)$(D)stf;$(SYSTEMTEST_RESROOT)$(D)openjdk-systemtest$(Q) \
@@ -358,8 +354,6 @@
 			<variation>Mode103</variation>
 			<variation>Mode104</variation>
 			<variation>Mode107</variation>
-			<variation>Mode108</variation>
-			<variation>Mode109</variation>
 			<variation>Mode110</variation>
 			<variation>Mode112</variation>
 			<variation>Mode113</variation>
@@ -369,7 +363,6 @@
 			<variation>Mode301</variation>
 			<variation>Mode351</variation>
 			<variation>Mode501</variation>
-			<variation>Mode550</variation>
 			<variation>Mode551</variation>
 			<variation>Mode553</variation>
 			<variation>Mode554</variation>
@@ -386,6 +379,7 @@
 			<variation>Mode110-OSRG</variation>
 			<variation>Mode610-OSRG</variation>
 			<variation>Mode612-OSRG</variation>
+			<!--Note: -Xint modes Mode108, Mode109, Mode550 should be run manually -->
 		</variations>
 		<command>perl $(SYSTEMTEST_RESROOT)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
 	-test-root=$(Q)$(SYSTEMTEST_RESROOT)$(D)stf;$(SYSTEMTEST_RESROOT)$(D)openjdk-systemtest$(Q) \

--- a/system/otherLoadTest/playlist.xml
+++ b/system/otherLoadTest/playlist.xml
@@ -46,22 +46,16 @@
 			<variation>Mode103</variation>
 			<variation>Mode104</variation>
 			<variation>Mode107</variation>
-			<variation>Mode108</variation>
-			<variation>Mode109</variation>
-			<variation>Mode109-CS</variation>
 			<variation>Mode110</variation>
 			<variation>Mode112</variation>
 			<variation>Mode113</variation>
 			<variation>Mode121</variation>
 			<variation>Mode122</variation>
 			<variation>Mode140</variation>
-			<variation>Mode159</variation>
-			<variation>Mode159-CS</variation>
 			<variation>Mode187</variation>
 			<variation>Mode301</variation>
 			<variation>Mode351</variation>
 			<variation>Mode501</variation>
-			<variation>Mode550</variation>
 			<variation>Mode551</variation>
 			<variation>Mode553</variation>
 			<variation>Mode554</variation>
@@ -78,6 +72,7 @@
 			<variation>Mode110-OSRG</variation>
 			<variation>Mode610-OSRG</variation>
 			<variation>Mode612-OSRG</variation>
+			<!--Note: -Xint modes Mode108, Mode109, Mode109-CS, Mode159, Mode159-CS, Mode550 should be run manually -->
 		</variations>
 		<command>perl $(SYSTEMTEST_RESROOT)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl  \
 	-test-root=$(Q)$(SYSTEMTEST_RESROOT)$(D)stf;$(SYSTEMTEST_RESROOT)$(D)openjdk-systemtest$(Q) \


### PR DESCRIPTION
Related to : https://github.com/eclipse/openj9-systemtest/issues/95

> Running the system tests with -Xint is way too slow. We don't need to run these modes on a regular basis, they can be disabled and available to run manually.

Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>

FYI @pshipton @ShelleyLambert 