### PR TITLE
Add testimage support for upstream testing

### DIFF
--- a/buildenv/jenkins/upstream_openjdk_tests
+++ b/buildenv/jenkins/upstream_openjdk_tests
@@ -12,6 +12,7 @@ class ReleaseContext implements Serializable {
     final String OS
     String JDK_URL
     String JRE_URL
+    String TESTIMAGE_URL
     String SOURCE_URL
 
     ReleaseContext(String arch, String os) {
@@ -20,7 +21,7 @@ class ReleaseContext implements Serializable {
     }
 
     public String toString() {
-        return "$ARCH-$OS: $JDK_URL $JRE_URL $SOURCE_URL ${getJenkinsFile()}";
+        return "$ARCH-$OS: $JDK_URL $JRE_URL " + ( TESTIMAGE_URL == null ? "" : " $TESTIMAGE_URL " ) + "$SOURCE_URL ${getJenkinsFile()}";
     }
 
     public String getJenkinsFile() {
@@ -109,6 +110,9 @@ class ReleaseRetriever implements Serializable {
                            }
                            if (a.name.contains("-jre")) {
                                r.JRE_URL = a.browser_download_url
+                           }
+                           if (a.name.contains("-testimage")) {
+                               r.TESTIMAGE_URL = a.browser_download_url
                            }
                            // if the name neither contains -jre, -jdk nor -testimage assume
                            // JDK (which was prior jre/jdk separation)
@@ -264,7 +268,7 @@ node("ci.role.test&&hw.arch.x86&&sw.os.linux") {
                                 def source_url = r.SOURCE_URL
                                 def jdk_version = version
                                 def jenkins_file = r.getJenkinsFile()
-                                def jdk_jre_url = "$r.JDK_URL $r.JRE_URL"
+                                def jdk_jre_url = "$r.JDK_URL $r.JRE_URL" + ( r.TESTIMAGE_URL == null ? "" : " $r.TESTIMAGE_URL" )
                                 def mapped_arch = r.getMappedArch()
                                 def target = testsTargetBuildList.get(testname).get("target")
                                 def buildList = testsTargetBuildList.get(testname).get("buildlist")


### PR DESCRIPTION
Add support for native tests in the upstream test pipeline. Grinder is currently running with this:

https://ci.adoptopenjdk.net/blue/organizations/jenkins/Grinder_Advanced/detail/Grinder_Advanced/498/pipeline/81

sanity.native currently fails for upstream tests because the test image binaries are not in place.