### PR TITLE
Enable compiler api/lang test suites for JCK 11+

### DIFF
--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -93,6 +93,9 @@
 		<groups>
 			<group>jck</group>
 		</groups>
+		<subsets>
+			<subset>11+</subset>
+		</subsets>
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-java_lang-invoke</testCaseName>

--- a/jck/runtime.lang/playlist.xml
+++ b/jck/runtime.lang/playlist.xml
@@ -213,6 +213,9 @@
 		<groups>
 			<group>jck</group>
 		</groups>
+		<subsets>
+			<subset>11+</subset>
+		</subsets>
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-BINC</testCaseName>
@@ -233,6 +236,9 @@
 		<groups>
 			<group>jck</group>
 		</groups>
+		<subsets>
+			<subset>11+</subset>
+		</subsets>
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-DASG</testCaseName>
@@ -253,6 +259,9 @@
 		<groups>
 			<group>jck</group>
 		</groups>
+		<subsets>
+			<subset>11+</subset>
+		</subsets>
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-EXCP</testCaseName>
@@ -273,6 +282,9 @@
 		<groups>
 			<group>jck</group>
 		</groups>
+		<subsets>
+			<subset>11+</subset>
+		</subsets>
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-EXEC</testCaseName>
@@ -293,6 +305,9 @@
 		<groups>
 			<group>jck</group>
 		</groups>
+		<subsets>
+			<subset>11+</subset>
+		</subsets>
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-FP</testCaseName>
@@ -313,6 +328,9 @@
 		<groups>
 			<group>jck</group>
 		</groups>
+		<subsets>
+			<subset>11+</subset>
+		</subsets>
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-ICLS</testCaseName>
@@ -333,6 +351,9 @@
 		<groups>
 			<group>jck</group>
 		</groups>
+		<subsets>
+			<subset>11+</subset>
+		</subsets>
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-INFR</testCaseName>
@@ -353,6 +374,9 @@
 		<groups>
 			<group>jck</group>
 		</groups>
+		<subsets>
+			<subset>11+</subset>
+		</subsets>
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-INTF</testCaseName>
@@ -373,6 +397,9 @@
 		<groups>
 			<group>jck</group>
 		</groups>
+		<subsets>
+			<subset>11+</subset>
+		</subsets>
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-MOD</testCaseName>
@@ -393,6 +420,9 @@
 		<groups>
 			<group>jck</group>
 		</groups>
+		<subsets>
+			<subset>11+</subset>
+		</subsets>
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-NAME</testCaseName>
@@ -413,6 +443,9 @@
 		<groups>
 			<group>jck</group>
 		</groups>
+		<subsets>
+			<subset>11+</subset>
+		</subsets>
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-PKGS</testCaseName>
@@ -433,6 +466,9 @@
 		<groups>
 			<group>jck</group>
 		</groups>
+		<subsets>
+			<subset>11+</subset>
+		</subsets>
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-THRD</testCaseName>
@@ -453,6 +489,9 @@
 		<groups>
 			<group>jck</group>
 		</groups>
+		<subsets>
+			<subset>11+</subset>
+		</subsets>
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-TYPE</testCaseName>
@@ -473,6 +512,9 @@
 		<groups>
 			<group>jck</group>
 		</groups>
+		<subsets>
+			<subset>11+</subset>
+		</subsets>
 	</test>
 </playlist>
 


### PR DESCRIPTION
**Enable compiler api/lang test suites for JCK 11+**

Only enable `compiler api/lang` test suites for `JCK 11+` for now.

Note: The `JCK 11` test suites all passed but it appears there is a setup issue for `JCK 8`, disable it for now.

Reviewer: @ShelleyLambert 
FYI: @DanHeidinga @pshipton 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>