### PR TITLE
exclude some system test subfolders in parallel mode

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -140,12 +140,17 @@ def setupParallelEnv() {
 			
 			//Setup for option-specific parameters
 			//If ITERATIONS is 1, then parallel is based on subfolders
-			if (repeatAmount == 1){
-				dir("$WORKSPACE/openjdk-tests/${env.BUILD_LIST}") 
-				{
+			if (repeatAmount == 1) {
+				dir("$WORKSPACE/openjdk-tests/${env.BUILD_LIST}") {
 					testSubDirs = sh(returnStdout: true, script: "ls -d */").trim().tokenize()
-					repeatAmount = testSubDirs.size()
 				}
+
+				// We currently only run special.system in parallel mode and some subfolders do not have any system test in special level
+				// In order to save machine resources, exclude the following system test subfolders in parallel mode
+				def excludes = ["jlm/", "modularity/", "sharedClasses/"]
+				echo "exclude the following system test subfolders: ${excludes}"
+				testSubDirs = testSubDirs - excludes
+				repeatAmount = testSubDirs.size()
 				echo "repeatAmount is ${repeatAmount}, testSubDirs is ${testSubDirs}, running test in parallel mode"
 			}
 			

--- a/system/jlm/playlist.xml
+++ b/system/jlm/playlist.xml
@@ -1,7 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
 	<include>../systemtest.mk</include>
-	
+
+	<!--
+	We currently only run special.system in parallel mode and some subfolders do not have any system test in special level
+	In order to save machine resources, exclude jlm subfolder in parallel mode
+	To enable it, please update excludes array in JenkinsfileBase
+	-->
+
 	<!-- 
 	Special target to get machine information. This target is in each subfolder playlist.xml.
 	To avoid test target duplication, this belongs to sanity, extended and special. Regular test should only belong to one level -->

--- a/system/modularity/playlist.xml
+++ b/system/modularity/playlist.xml
@@ -2,6 +2,12 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
 	<include>../systemtest.mk</include>
 
+	<!--
+	We currently only run special.system in parallel mode and some subfolders do not have any system test in special level
+	In order to save machine resources, exclude modularity subfolder in parallel mode
+	To enable it, please update excludes array in JenkinsfileBase
+	-->
+
 	<!-- 
 	Special target to get machine information. This target is in each subfolder playlist.xml.
 	To avoid test target duplication, this belongs to sanity, extended and special. Regular test should only belong to one level -->

--- a/system/sharedClasses/playlist.xml
+++ b/system/sharedClasses/playlist.xml
@@ -2,6 +2,13 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
 	<include>../systemtest.mk</include>
 
+
+	<!--
+	We currently only run special.system in parallel mode and some subfolders do not have any system test in special level
+	In order to save machine resources, exclude sharedClasses subfolder in parallel mode
+	To enable it, please update excludes array in JenkinsfileBase
+	-->
+
 	<!-- 
 	Special target to get machine information. This target is in each subfolder playlist.xml.
 	To avoid test target duplication, this belongs to sanity, extended and special. Regular test should only belong to one level -->


### PR DESCRIPTION
We currently only run special.system in parallel mode and some system
test subfolders do not have any system test in special level. In order
to save machine resources, exclude the system test subfolders that do
not contain special level in parallel.

Signed-off-by: lanxia <lan_xia@ca.ibm.com>