### PR TITLE
Fix compilation failures for Perf Testing

### DIFF
--- a/perf/dacapo/build.xml
+++ b/perf/dacapo/build.xml
@@ -27,12 +27,13 @@
 	</target>
 
 	<target name="getDacapoSuite" depends="init">
-		<echo message="wget -q https://sourceforge.net/projects/dacapobench/files/latest/download" />
-			<exec executable="wget" failonerror="true">
-				<arg line="-q -O dacapo.jar https://sourceforge.net/projects/dacapobench/files/latest/download" />
+		<var name="curl_options" value="-Lks https://sourceforge.net/projects/dacapobench/files/latest/download -o dacapo.jar"/>
+		<echo message="curl ${curl_options}" />
+			<exec executable="curl" failonerror="true">
+				<arg line="${curl_options}" />
 			</exec>
 	</target>
-
+	
 	<target name="dist" depends="getDacapoSuite" description="generate the distribution">
 		<copy todir="${DEST}">
 			<fileset dir="${src}"/>

--- a/perf/liberty/build.xml
+++ b/perf/liberty/build.xml
@@ -111,7 +111,7 @@
 		<copy todir="${DEST}">
 			<fileset dir="${src}"/>
 		</copy>
-		<chmod file="${DEST}/**" perm="a+x"/>
+		<chmod file="${DEST}/**" perm="a+x" maxparallel="10"/>
 	</target>
 	<target name="configure" depends="dist" description="configure Liberty">
 		<if>
@@ -121,7 +121,7 @@
 			</then>
 			<else>
 				<echo message="${DEST}/libertyBinaries/${BM_VERSION}/usr/shared/resources/data/tradedb7/service.properties doesn't exist. Configuring database." />						
-				<exec executable="/bin/bash">
+				<exec executable="bash">
 					<env key="DB_SETUP" value="1"/>
 				    <arg value="${DEST}/configs/benchmark.sh"/>
 				    <arg value="${DEST}"/>

--- a/perf/liberty/configs/benchmark.sh
+++ b/perf/liberty/configs/benchmark.sh
@@ -67,6 +67,6 @@ export APP_VERSION="daytrader-ee7"
 export WLP_SKIP_MAXPERMSIZE="1"
 
 #TODO: Need to soft-code these configs. Need to add various affinity tools in the perf pre-reqs ()
-export AFFINITY="numactl --physcpubind=0-3 --membind=0"
+export AFFINITY=""
 
 bash ${1}/scripts/bin/sufp_benchmark.sh 

--- a/perf/liberty/scripts/bin/common_utils.sh
+++ b/perf/liberty/scripts/bin/common_utils.sh
@@ -43,7 +43,7 @@ setMachinePlatform()
 .--------------------------
 | Setting Machine Platform
 "
-    export PLATFORM=`/bin/uname | cut -f1 -d_`
+    export PLATFORM=`uname | cut -f1 -d_`
     echo "Platform identified as: ${PLATFORM}"
 }
 
@@ -112,9 +112,9 @@ checkAndSetCommonEnvVars()
                 echo "AFFINITY not set. On Sun/HP so is ok"
                 ;;
             *)
-                echo "AFFINITY not set"
+                echo "!!! WARNING !!! AFFINITY not set"
                 usage
-                exit
+                #exit
                 ;;
         esac
     fi

--- a/perf/renaissance/build.xml
+++ b/perf/renaissance/build.xml
@@ -27,11 +27,12 @@
 	</target>
 
 	<target name="getRenaissanceSuite" depends="init">
-		<echo message="wget -q https://github.com/renaissance-benchmarks/renaissance/releases/download/v0.9.0/renaissance-mit-0.9.0.jar" />
-			<exec executable="wget" failonerror="true">
-				<arg line="-q -O renaissance-mit.jar https://github.com/renaissance-benchmarks/renaissance/releases/download/v0.9.0/renaissance-mit-0.9.0.jar" />
+		<var name="curl_options" value="-Lks https://github.com/renaissance-benchmarks/renaissance/releases/download/v0.9.0/renaissance-mit-0.9.0.jar -o renaissance-mit.jar"/>
+		<echo message="curl ${curl_options}" />
+			<exec executable="curl" failonerror="true">
+				<arg line="${curl_options}" />
 			</exec>
-	</target>
+	</target>	
 
 	<target name="dist" depends="getRenaissanceSuite" description="generate the distribution">
 		<copy todir="${DEST}">


### PR DESCRIPTION
	• Changed wget to curl to fetch benchmark binaries for Dacapo & Renaissance
		○ Curl is preferred over wget to reduce machine tool dependencies
	• Added maxparallel attribute to chmod command in Liberty build file to avoid "argument list too long" error on Mac
	• Removed the hard-coded location for bash to avoid failures on Windows
		○ Location of bash executable could be different and it doesn't have be under `/bin`. Bash is just expected to be on the $PATH.
	• Removed x86 Linux specific affinity command to allow Liberty to run on different platforms
		○ Avoid exiting the benchmark run if affinity isn't set for now
	• Removed the path before `uname` in Liberty since its location could vary from platform to platform

Closes https://github.com/AdoptOpenJDK/openjdk-tests/issues/1207
Related Issue: https://github.com/AdoptOpenJDK/openjdk-tests/issues/1127

Signed-off-by: Piyush Gupta <piyush286@gmail.com>