### PR TITLE
Support running openj9 functional native in AdoptOpenJDK

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -355,6 +355,11 @@ def buildTest() {
 			if (fileExists('openjdkbinary/openjdk-test-image')) {
 				env.TESTIMAGE_PATH = "$WORKSPACE/openjdkbinary/openjdk-test-image"
 			}
+
+			if (fileExists('openjdkbinary/openjdk-test-image/openj9')) {
+				env.NATIVE_TEST_LIBS = "$WORKSPACE/openjdkbinary/openjdk-test-image/openj9"
+			}
+
 			// use sshagent with Jenkins credentials ID for all platforms except zOS
 			if (!env.SPEC.startsWith('zos')) {
 				sshagent (credentials: ["$params.SSH_AGENT_CREDENTIAL"], ignoreMissing: true) {


### PR DESCRIPTION
Supporting running openj9 functional native test as testimages are supported in AdoptOpenJDK 11+ builds.

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>