### PR TITLE
Add sleep time between child parallel jobs

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -153,7 +153,8 @@ def setupParallelEnv() {
 				repeatAmount = testSubDirs.size()
 				echo "repeatAmount is ${repeatAmount}, testSubDirs is ${testSubDirs}, running test in parallel mode"
 			}
-			
+
+			def sleepTimeBetweenParallel = params.SLEEP_TIME_BETWEEN_PARALLEL ? params.SLEEP_TIME_BETWEEN_PARALLEL.toInteger() : 300
 			parallel_tests = [:]
 
 			for (int i = 0; i < repeatAmount; i++) {
@@ -168,11 +169,14 @@ def setupParallelEnv() {
 					buildListName = env.BUILD_LIST
 				}
 				def TEST_JOB_NAME = "${JOB_NAME}"
+				int sleepTime = sleepTimeBetweenParallel * i;
 
 				//ToDo: need to find a better way to pass parameters to downstream builds.
 				//Ideally, we should only need to pass in modified parameters (i.e.,
 				//BUILD_LIST, IS_PARALLEL)
 				parallel_tests[childTest] = {
+					echo "Waiting ${sleepTime} seconds before starting parallel build ${childTest}"
+					sleep(sleepTime)
 					build job: TEST_JOB_NAME, parameters: [
 						string(name: 'ADOPTOPENJDK_REPO', value: ADOPTOPENJDK_REPO),
 						string(name: 'ADOPTOPENJDK_BRANCH', value: ADOPTOPENJDK_BRANCH),


### PR DESCRIPTION
- we have the SDK downloading issue when all child parallel jobs are
downloading at the same time. Add sleep time to delay starting each
child parallel job
- delay for each child job = SLEEP_TIME_BETWEEN_PARALLEL * index
- Set the default value of SLEEP_TIME_BETWEEN_PARALLEL to 300 secs in
script, so auto builds do not need to set the value
- Will set the default value for SLEEP_TIME_BETWEEN_PARALLEL in Grinder to 0.
User can modify SLEEP_TIME_BETWEEN_PARALLEL value in Grinder if needed.

Issue: https://github.com/eclipse/openj9/issues/7179

Signed-off-by: lanxia <lan_xia@ca.ibm.com>