### PR TITLE
Set JenkinsFile as a parameter

### DIFF
--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -124,6 +124,7 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							stringParam('OPENJ9_SHA', "", "OpenJ9 sha")
 							stringParam('JDK_VERSION', "${JDK_VERSION}", "JDK version. i.e., 8, 11")
 							stringParam('JDK_IMPL', JDK_IMPL, "JDK implementation, e.g. hotspot, openj9, sap")
+							stringParam('JenkinsFile', "openjdk_${ARCH_OS}", "Jenkins file to be used")
 							stringParam('BUILD_LIST', BUILD_LIST, "Specific test directory to compile, set blank for all projects to be compiled")
 							stringParam('TARGET', "${LEVEL}.${GROUP}", "Test TARGET to execute")
 							stringParam('CUSTOM_TARGET', "", "Only used when the custom target is specified in TARGET , e.g. jdk_custom, langtools_custom, etc., CUSTOM_TARGET=path to the test class to execute")


### PR DESCRIPTION
In nightly test builds (auto-generated), JenkinsFile is directly set as
Script Path in test job configure, not as a parameter. As a result,
Rerun in Ginder link cannot get JenkinsFile param value. This PR sets
JenkinsFile as a parameter in test job configure.

Signed-off-by: lanxia <lan_xia@ca.ibm.com>