### PR TITLE
Reintroducing tests excluded for openj9 bugs 6671 and 6778

### DIFF
--- a/openjdk/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/ProblemList_openjdk11-openj9.txt
@@ -54,8 +54,6 @@ java/lang/String/CompactString/IndexOf.java	https://github.com/eclipse/openj9/is
 java/lang/String/EqualsIgnoreCase.java	https://github.com/eclipse/openj9/issues/6666	generic-all
 java/lang/String/StringRepeat.java	https://github.com/eclipse/openj9/issues/6667	generic-all
 java/lang/String/nativeEncoding/StringPlatformChars.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	generic-all
-java/lang/StringBuffer/CompactStringBuffer.java https://github.com/eclipse/openj9/issues/6671 linux-s390x
-java/lang/StringBuilder/CompactStringBuilder.java https://github.com/eclipse/openj9/issues/6671 linux-s390x
 java/lang/System/Logger/custom/CustomLoggerTest.java	https://github.com/eclipse/openj9/issues/6674	generic-all
 java/lang/System/Logger/default/DefaultLoggerTest.java	https://github.com/eclipse/openj9/issues/6674	generic-all
 java/lang/System/LoggerFinder/BaseLoggerFinderTest/BaseLoggerFinderTest.java	https://github.com/eclipse/openj9/issues/6674	generic-all

--- a/openjdk/ProblemList_openjdk13-openj9.txt
+++ b/openjdk/ProblemList_openjdk13-openj9.txt
@@ -55,8 +55,6 @@ java/lang/String/EqualsIgnoreCase.java	https://github.com/eclipse/openj9/issues/
 java/lang/String/StringRepeat.java	https://github.com/eclipse/openj9/issues/6667	generic-all
 java/lang/String/UnicodeCasingTest.java https://github.com/eclipse/openj9/issues/4597 linux-s390x
 java/lang/String/nativeEncoding/StringPlatformChars.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	generic-all
-java/lang/StringBuilder/CompactStringBuilder.java https://github.com/eclipse/openj9/issues/6778 linux-s390x
-java/lang/StringBuffer/CompactStringBuffer.java https://github.com/eclipse/openj9/issues/6778 linux-s390x
 java/lang/System/Logger/custom/CustomLoggerTest.java	https://github.com/eclipse/openj9/issues/6674	generic-all
 java/lang/System/Logger/default/DefaultLoggerTest.java	https://github.com/eclipse/openj9/issues/6674	generic-all
 java/lang/System/LoggerFinder/BaseLoggerFinderTest/BaseLoggerFinderTest.java	https://github.com/eclipse/openj9/issues/6674	generic-all


### PR DESCRIPTION
These bugs have been resolved by the openj9 team. Reintroducing the tests.

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>