### PR TITLE
Re-Enable JSR166TestCase for S390

### DIFF
--- a/openjdk/ProblemList_openjdk13-openj9.txt
+++ b/openjdk/ProblemList_openjdk13-openj9.txt
@@ -303,7 +303,6 @@ java/util/Spliterator/SpliteratorCollisions.java	https://github.com/eclipse/open
 java/util/concurrent/ArrayBlockingQueue/WhiteBox.java 	https://github.com/eclipse/openj9/issues/5988 	macosx-all
 java/util/concurrent/forkjoin/FJExceptionTableLeak.java	https://github.com/eclipse/openj9/issues/3209	generic-all
 java/util/concurrent/locks/Lock/TimedAcquireLeak.java	https://github.com/eclipse/openj9/issues/7125	macosx-all,linux-all
-java/util/concurrent/tck/JSR166TestCase.java		https://github.com/eclipse/openj9/issues/7011		linux-s390x
 java/util/logging/TestLoggerWeakRefLeak.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1352	generic-all
 java/util/logging/LogManager/TestLoggerNames.java https://github.com/eclipse/openj9/issues/4561 generic-all
 java/util/stream/boottest/java.base/java/util/stream/NodeTest.java https://github.com/eclipse/openj9/issues/4129 macosx-all


### PR DESCRIPTION
Firstly, the issue attached to this is a Power(PPC64LE) issue and this test was incorrectly disabled on S390.
The Power defect has been resolved, and this test should now be functional running on PPC64LE.

Signed-off-by: AlenBadel <Alen.Badel@ibm.com>