### PR TITLE
Disable concurrency.

### DIFF
--- a/buildenv/jenkins/JobTemplate.groovy
+++ b/buildenv/jenkins/JobTemplate.groovy
@@ -86,6 +86,7 @@ pipelineJob("$ROOTFOLDER/jobs/$JDK_VERSION/$JOB_NAME") {
 				lightweight(true)
 			}
 		}
+		concurrentBuild(false)
 		logRotator {
 			numToKeep(BUILDS_TO_KEEP)
 			artifactNumToKeep(BUILDS_TO_KEEP)


### PR DESCRIPTION
The current jenkins version requires no concurrency when generate jobs. This feature is
depreciated in newer jenkins version. 


Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>