### PR TITLE
Support JDK_VERSION=next in jck tests

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -53,7 +53,6 @@ def setupEnv() {
 	CUSTOM_TARGET = params.CUSTOM_TARGET ? params.CUSTOM_TARGET : ""
 	UPSTREAM_JOB_NAME = params.UPSTREAM_JOB_NAME ? params.UPSTREAM_JOB_NAME : ""
 	UPSTREAM_JOB_NUMBER = params.UPSTREAM_JOB_NUMBER ? params.UPSTREAM_JOB_NUMBER : ""
-	JCK_GIT_REPO = params.JCK_GIT_REPO ? params.JCK_GIT_REPO : ""
 	SSH_AGENT_CREDENTIAL = params.SSH_AGENT_CREDENTIAL ? params.SSH_AGENT_CREDENTIAL : ""
 	KEEP_WORKSPACE = params.KEEP_WORKSPACE ? params.KEEP_WORKSPACE : false
 	OPENJ9_SHA = params.OPENJ9_SHA ? params.OPENJ9_SHA : ""
@@ -89,26 +88,9 @@ def setupEnv() {
 		env.PERF_ROOT = "$WORKSPACE/../../benchmarks"
 	}
 
-	if (env.BUILD_LIST.startsWith("jck")) {
-		if ( JDK_VERSION == "8" ) {
-			env.JCK_VERSION = "jck8b"
-		} else {
-			env.JCK_VERSION = "jck${JDK_VERSION}"
-		}
-		if( params.JCK_ROOT ) {
-			env.JCK_ROOT = params.JCK_ROOT
-		} else {
-			env.JCK_ROOT = "$WORKSPACE/../../jck_root/JCK${JDK_VERSION}-unzipped"
-		}
-		
-		echo "env.JCK_ROOT is: ${env.JCK_ROOT}, env.JCK_VERSION is: ${env.JCK_VERSION}"
-		if( params.JCK_GIT_REPO ) {
-			env.JCK_GIT_REPO = params.JCK_GIT_REPO
-			echo "env.JCK_GIT_REPO is ${env.JCK_GIT_REPO}"
-		} else {
-			echo "params.JCK_GIT_REPO was not defined"
-		}
-	}
+	env.JCK_VERSION = params.JCK_VERSION ? params.JCK_VERSION : ""
+	env.JCK_ROOT = params.JCK_ROOT ? params.JCK_ROOT : ""
+	env.JCK_GIT_REPO = params.JCK_GIT_REPO ? params.JCK_GIT_REPO : ""
 
 	if (env.BUILD_LIST == 'openjdk' ||  env.BUILD_LIST.contains('external')) {
 		env.DIAGNOSTICLEVEL ='noDetails'

--- a/jck/README.md
+++ b/jck/README.md
@@ -26,8 +26,7 @@
 * Otherwise put your unarchived jck test materials into the empty folder created in step 1 and point `JCK_GIT_REPO` to this folder. For example `export JCK_GIT_REPO=/jck/jck8b`
 
 3. Export `JCK_ROOT=/jck/<test_material_folder>` as an environment variable or pass it in when run as a make command. For example `export JCK_ROOT=/jck/jck8b`
-
-3. Export `JCK_VERSION=<your_jck_version>` as an environment variable or pass it in when run as a make command. For example `export JCK_VERSION=jck8b` 
+* Optional. The default value is `<openjdk-test>/../../../jck_root/JCK$(JDK_VERSION)-unzipped`
 
 4. Export `TEST_JDK_HOME=<your_JDK_root>` as an environment variable
 
@@ -97,7 +96,6 @@ export TEST_JDK_HOME=/java/openjdkbinary/j2sdk-image
 export BUILD_LIST=jck
 export JCK_GIT_REPO=git@github.com:mypretendcompany/jck8tests.git
 export JCK_ROOT=/jck/jck8tests
-export JCK_VERSION=jck8b
 
 cd TestConfig
 make -f run_configure.mk

--- a/jck/build.xml
+++ b/jck/build.xml
@@ -23,8 +23,7 @@
 	<property name="DEST" value="${BUILD_ROOT}/jck" />
 	<property name="SYSTEMTEST_BUILD_ROOT" value="${BUILD_ROOT}/system" />
 	<property environment="env" />
-	<propertyregex property="jck_short_version" input="${env.JCK_VERSION}" regexp="jck([^\.]*)" select="\1" casesensitive="false" />
-	
+
 	<condition property="git-prefix" value="git" else="https">
 		<isset property="isZOS"/>
 	</condition>
@@ -50,31 +49,31 @@
 		<!-- Starting downloading or updating JCK materials based on JCK GIT REPO and JCK VERSION-->
 		<if>
 			<not>
-				<available file="${env.JCK_ROOT}" type="dir" />
+				<available file="${JCK_ROOT_USED}" type="dir" />
 			</not>
 			<!-- jck materials don't exist, download them -->
 			<then>
-				<echo message="${env.JCK_ROOT} does not exist, 
-					clone from ${env.JCK_GIT_REPO}, ${jck_branch} branch, to ${env.JCK_ROOT}" />
-				<mkdir dir="${env.JCK_ROOT}/.." />
-				<exec executable="git" dir="${env.JCK_ROOT}/.." failonerror="true">
+				<echo message="${JCK_ROOT_USED} does not exist, 
+					clone from ${JCK_GIT_REPO_USED}, ${jck_branch} branch, to ${JCK_ROOT_USED}" />
+				<mkdir dir="${JCK_ROOT_USED}/.." />
+				<exec executable="git" dir="${JCK_ROOT_USED}/.." failonerror="true">
 					<arg value="clone" />
 					<arg value="--depth" />
 					<arg value="1" />
 					<arg value="--single-branch" />
 					<arg value="-b"/>
 					<arg value="${jck_branch}"/>
-					<arg value="${env.JCK_GIT_REPO}" />
+					<arg value="${JCK_GIT_REPO_USED}" />
 				</exec>
 			</then>
 			<!-- jck materials exist, update jck materials if needed-->
 			<else>
-				<echo message="${env.JCK_ROOT} exists, deleting previously built natives..." />
+				<echo message="${JCK_ROOT_USED} exists, deleting previously built natives..." />
 				<delete includeemptydirs="true" quiet="true" failonerror="false">
-				    <fileset dir="${env.JCK_ROOT}/natives" includes="**/*"/>
+				    <fileset dir="${JCK_ROOT_USED}/natives" includes="**/*"/>
 				</delete>
-				<echo message="Updating ${env.JCK_ROOT} with latest..." />
-				<exec executable="git" dir="${env.JCK_ROOT}" failonerror="true">
+				<echo message="Updating ${JCK_ROOT_USED} with latest..." />
+				<exec executable="git" dir="${JCK_ROOT_USED}" failonerror="true">
 					<arg value="pull" />
 					<arg value="origin" />
 					<arg value="master" />
@@ -164,8 +163,8 @@
 		<ant antfile="${SYSTEMTEST_ROOT}/stf/stf.build/build.xml" dir="${SYSTEMTEST_ROOT}/stf/stf.build/" target="configure" inheritAll="false"></ant>
 		<ant antfile="${SYSTEMTEST_ROOT}/stf/stf.build/build.xml" dir="${SYSTEMTEST_ROOT}/stf/stf.build/" target="build" inheritAll="false"></ant>
 		<ant antfile="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build/build.xml" dir="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build" target="build" inheritAll="false">
-			<property name="jck_runtimes_src_dir" value="${env.JCK_ROOT}/JCK-runtime-${jck_short_version} "/>
-			<property name="out_dir" value="${env.JCK_ROOT}/natives" />
+			<property name="jck_runtimes_src_dir" value="${JCK_ROOT_USED}/JCK-runtime-${jck_short_version} "/>
+			<property name="out_dir" value="${JCK_ROOT_USED}/natives" />
 		</ant>
 	</target>
 
@@ -192,33 +191,53 @@
 				<exclude name="README.md" />
 			</fileset>
 		</copy>
-		<copy todir="${env.JCK_ROOT}/">
+		<copy todir="${JCK_ROOT_USED}/">
 			<fileset dir="${basedir}/../systemtest_prereqs/" includes="**" />
 		</copy>
 	</target>
 
 	<target name="build">
+		<fail message="env.JCK_GIT_REPO: ${env.JCK_GIT_REPO} was not correctly set for running JCK tests. If you do not want to compile JCK tests, 
+						please use BUILD_LIST to include test folders you want to test.">
+			<condition>
+				<not>
+					<isset property="env.JCK_GIT_REPO"/>
+				</not>
+			</condition>
+		</fail>
+		<propertyregex property="JCK_GIT_REPO_USED" input="${env.JCK_GIT_REPO}" regexp="JCKnext-unzipped.git" replace="JCK${JDK_VERSION}-unzipped.git" casesensitive="false" defaultValue="${env.JCK_GIT_REPO}"/>
+		<echo>=== JCK_GIT_REPO_USED is set to ${JCK_GIT_REPO_USED} ===</echo>
+
+		<condition property="JCK_ROOT_USED" value="${env.JCK_ROOT}" else="${basedir}/../../../../jck_root/JCK${JDK_VERSION}-unzipped">
+			<isset property="env.JCK_ROOT" />
+		</condition>
+		<echo>=== JCK_ROOT_USED is set to ${JCK_ROOT_USED} ===</echo>
+
 		<if>
-			<and>
-				<isset property="env.JCK_ROOT" />
-				<isset property="env.JCK_VERSION" />
-				<isset property="env.JCK_GIT_REPO" />
-			</and>
+			<isset property="env.JCK_VERSION" />
 			<then>
-				<echo>=== env.JCK_ROOT is set to ${env.JCK_ROOT} ===</echo>
-				<echo>=== env.JCK_VERSION is set to ${env.JCK_VERSION} ===</echo>
-				<echo>=== env.JCK_GIT_REPO is set to ${env.JCK_GIT_REPO} ===</echo>
-				<echo>start staging jck materials</echo>
-				<antcall target="stage_jck_material" inheritall="true" />
-				<echo>start building stf, stf jck wrapper and jck itself</echo>
-				<antcall target="dist" inheritall="true" />
+				<property name="JCK_VERSION_USED" value="${env.JCK_VERSION}" />
 			</then>
 			<else>
-				<fail message="env.JCK_ROOT: ${env.JCK_ROOT} or env.JCK_VERSION: ${env.JCK_VERSION} or env.JCK_GIT_REPO: ${env.JCK_GIT_REPO}
-					was not corretly set. If you do not want to compile JCK tests, 
-					please use BUILD_LIST to include test folders you want to test." />
+				<if>
+					<equals arg1="${JDK_VERSION}" arg2="8" />
+					<then>
+						<property name="JCK_VERSION_USED" value="jck8b" />
+					</then>
+					<else>
+						<property name="JCK_VERSION_USED" value="jck${JDK_VERSION}" />
+					</else>
+				</if>
 			</else>
 		</if>
+		<echo>=== JCK_VERSION_USED is set to ${JCK_VERSION_USED} ===</echo>
+
+		<propertyregex property="jck_short_version" input="${JCK_VERSION_USED}" regexp="jck([^\.]*)" select="\1" casesensitive="false" />
+
+		<echo>start staging jck materials</echo>
+		<antcall target="stage_jck_material" inheritall="true" />
+		<echo>start building stf, stf jck wrapper and jck itself</echo>
+		<antcall target="dist" inheritall="true" />
 	</target>
 
 	<target name="clean">

--- a/jck/jck.mk
+++ b/jck/jck.mk
@@ -43,3 +43,16 @@ ifeq ($(CYGWIN),1)
    PERL:=$(dir $(PERL))
    export PATH:=$(PERL):$(PATH)
 endif
+
+
+ifndef JCK_VERSION
+  ifeq (8, $(JDK_VERSION))
+    export JCK_VERSION=jck8b
+  else
+    export JCK_VERSION=jck$(JDK_VERSION)
+  endif
+endif
+
+ifndef JCK_ROOT
+  export JCK_ROOT=$(TEST_ROOT)/../../../jck_root/JCK$(JDK_VERSION)-unzipped
+endif


### PR DESCRIPTION
- remove default jck values in Jenkinsfilebase as we do not know
JDK_VERSION if it is set to next
- Set JCK_VERSION and JCK_ROOT default value in both build.xml and
playlist.xml
- Set JCK_GIT_REPO value to JCK${JDK_VERSION}-unzipped.git if it matches
JCKnext-unzipped.git

With this PR, JCK_VERSION and JCK_ROOT are optional parameters. They
will be set based on detected JDK_VERSION

Issue: runtimes/backlog/issues/167

Signed-off-by: lanxia <lan_xia@ca.ibm.com>