### PR TITLE
Add Lambda Benchmarks From BumbleBench

### DIFF
--- a/perf/bumbleBench/build.xml
+++ b/perf/bumbleBench/build.xml
@@ -19,16 +19,25 @@
 	<description>BumbleBench Suite</description>
 
 	<!-- Set global properties for this build -->
+	<property environment="env" />
 	<property name="DEST" value="${BUILD_ROOT}/perf/bumbleBench" />
 	<property name="SRC" location="." />
 	
+	<condition property="isZOS" value="true">
+		<equals arg1="${os.name}" arg2="z/OS"/>
+	</condition>
+		
+	<condition property="git-prefix" value="git" else="https">
+		<isset property="isZOS"/>
+	</condition>	
+		
 	<target name="init">
 		<mkdir dir="${DEST}" />
 	</target>
 
 	<target name="getBumbleBench" depends="init" description="Clone the distribution">
 		<echo message="Cloning BumbleBench"/>
-		<var name="git_command" value="clone --depth 1 https://github.com/AdoptOpenJDK/bumblebench.git"/>
+		<var name="git_command" value="clone --depth 1 -b master ${git-prefix}://github.com/AdoptOpenJDK/bumblebench.git"/>
 		<echo message="git ${git_command}" />
 		<exec executable="git" failonerror="false" dir=".">
 			<arg line="${git_command}" />

--- a/perf/bumbleBench/playlist.xml
+++ b/perf/bumbleBench/playlist.xml
@@ -14,15 +14,19 @@
 -->
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:noNamespaceSchemaLocation="../../TestConfig/playlist.xsd">
-	<!-- Math Tests -->
+	<!-- Lambda Benchmarks -->
 	<test>
-		<testCaseName>bumbleBench-SIMDDoubleMaxMinBench</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar SIMDDoubleMaxMinBench; \
+		<testCaseName>bumbleBench-DispatchBench-InnerClasses</testCaseName>
+		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar DispatchBench.InnerClasses; \
 		$(TEST_STATUS)</command>
 		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
 		<subsets>
 			<subset>8</subset>
+			<subset>11</subset>
 		</subsets>
+		<impls>
+			<impl>openj9</impl>
+		</impls>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -31,13 +35,62 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>bumbleBench-ExactBench</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar ExactBench; \
+		<testCaseName>bumbleBench-FibBench-Vanilla</testCaseName>
+		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar FibBench.Vanilla; \
 		$(TEST_STATUS)</command>
 		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
 		<subsets>
 			<subset>8</subset>
-		</subsets>
+			<subset>11</subset>
+		</subsets>		
+		<levels>
+			<level>special</level>
+		</levels>
+		<groups>
+			<group>perf</group>
+		</groups>
+	</test>
+	<test>
+		<testCaseName>bumbleBench-FibBench-InnerClass</testCaseName>
+		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar FibBench.InnerClass; \
+		$(TEST_STATUS)</command>
+		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
+		<subsets>
+			<subset>8</subset>
+			<subset>11</subset>
+		</subsets>		
+		<levels>
+			<level>special</level>
+		</levels>
+		<groups>
+			<group>perf</group>
+		</groups>
+	</test>
+	<test>
+		<testCaseName>bumbleBench-FibBench-Lambda</testCaseName>
+		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar FibBench.Lambda; \
+		$(TEST_STATUS)</command>
+		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
+		<subsets>
+			<subset>8</subset>
+			<subset>11</subset>
+		</subsets>		
+		<levels>
+			<level>special</level>
+		</levels>
+		<groups>
+			<group>perf</group>
+		</groups>
+	</test>
+	<test>
+		<testCaseName>bumbleBench-FibBench-LocalLambda</testCaseName>
+		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar FibBench.LocalLambda; \
+		$(TEST_STATUS)</command>
+		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
+		<subsets>
+			<subset>8</subset>
+			<subset>11</subset>
+		</subsets>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -45,7 +98,120 @@
 			<group>perf</group>
 		</groups>
 	</test>	
-	<!-- String Tests -->
+	<test>
+		<testCaseName>bumbleBench-FibBench-DynamicLambda</testCaseName>
+		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar FibBench.DynamicLambda; \
+		$(TEST_STATUS)</command>
+		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
+		<subsets>
+			<subset>8</subset>
+			<subset>11</subset>
+		</subsets>		
+		<levels>
+			<level>special</level>
+		</levels>
+		<groups>
+			<group>perf</group>
+		</groups>
+	</test>
+	<test>
+		<testCaseName>bumbleBench-FibBench-LocalMethodReferences</testCaseName>
+		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar FibBench.LocalMethodReferences; \
+		$(TEST_STATUS)</command>
+		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
+		<subsets>
+			<subset>8</subset>
+			<subset>11</subset>
+		</subsets>		
+		<levels>
+			<level>special</level>
+		</levels>
+		<groups>
+			<group>perf</group>
+		</groups>
+	</test>
+	<test>
+		<testCaseName>bumbleBench-GroupingBench-Serial</testCaseName>
+		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar GroupingBench.Serial; \
+		$(TEST_STATUS)</command>
+		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
+		<subsets>
+			<subset>8</subset>
+			<subset>11</subset>
+		</subsets>		
+		<levels>
+			<level>special</level>
+		</levels>
+		<groups>
+			<group>perf</group>
+		</groups>
+	</test>
+	<test>
+		<testCaseName>bumbleBench-GroupingBench-Parallel</testCaseName>
+		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar GroupingBench.Parallel; \
+		$(TEST_STATUS)</command>
+		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
+		<subsets>
+			<subset>8</subset>
+			<subset>11</subset>
+		</subsets>		
+		<levels>
+			<level>special</level>
+		</levels>
+		<groups>
+			<group>perf</group>
+		</groups>
+	</test>	
+	<test>
+		<testCaseName>bumbleBench-SieveBench</testCaseName>
+		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar SieveBench; \
+		$(TEST_STATUS)</command>
+		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
+		<subsets>
+			<subset>8</subset>
+			<subset>11</subset>
+		</subsets>		
+		<levels>
+			<level>special</level>
+		</levels>
+		<groups>
+			<group>perf</group>
+		</groups>
+	</test>
+	<!-- Math Benchmarks -->
+	<test>
+		<testCaseName>bumbleBench-ExactBench</testCaseName>
+		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar ExactBench; \
+		$(TEST_STATUS)</command>
+		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
+		<subsets>
+			<subset>8</subset>
+			<subset>11</subset>
+		</subsets>		
+		<levels>
+			<level>special</level>
+		</levels>
+		<groups>
+			<group>perf</group>
+		</groups>
+	</test>	
+	<test>
+		<testCaseName>bumbleBench-SIMDDoubleMaxMinBench</testCaseName>
+		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar SIMDDoubleMaxMinBench; \
+		$(TEST_STATUS)</command>
+		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
+		<subsets>
+			<subset>8</subset>
+			<subset>11</subset>
+		</subsets>		
+		<levels>
+			<level>special</level>
+		</levels>
+		<groups>
+			<group>perf</group>
+		</groups>
+	</test>	
+	<!-- String Benchmarks -->
 	<test>
 		<testCaseName>bumbleBench-StringConversionBench</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar StringConversionBench; \
@@ -53,7 +219,8 @@
 		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
 		<subsets>
 			<subset>8</subset>
-		</subsets>
+			<subset>11</subset>
+		</subsets>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -68,7 +235,8 @@
 		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
 		<subsets>
 			<subset>8</subset>
-		</subsets>
+			<subset>11</subset>
+		</subsets>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -83,7 +251,8 @@
 		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
 		<subsets>
 			<subset>8</subset>
-		</subsets>
+			<subset>11</subset>
+		</subsets>		
 		<levels>
 			<level>special</level>
 		</levels>


### PR DESCRIPTION
• Added parameters for changing BumbleBench repo and branch
• Added new benchmarks: DispatchBench, FibBench, GroupingBench & SieveBench
• Enabled new and existing tests for Java 11 along with Java 8

Issue: https://github.com/AdoptOpenJDK/openjdk-tests/issues/1379

Signed-off-by: Piyush Gupta <piyush286@gmail.com>