### PR TITLE
Add Jenkins file to test Linux x86 32 bits platforms

### DIFF
--- a/buildenv/jenkins/openjdk_x86-32_linux
+++ b/buildenv/jenkins/openjdk_x86-32_linux
@@ -1,0 +1,19 @@
+#!groovy
+
+if (params.DOCKER_REQUIRED) {
+    LABEL='ci.role.test&&hw.arch.x86&&sw.os.linux&&sw.tool.docker'
+} else {
+    LABEL='ci.role.test&&hw.arch.x86&&sw.os.linux'
+}
+
+stage('Queue') {
+    node((params.LABEL) ? params.LABEL : LABEL) {
+        PLATFORM = 'x32_linux'
+        SDK_RESOURCE = 'upstream'
+        SPEC='linux_x86'
+        checkout scm
+        jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
+        jenkinsfile.testBuild()
+    }
+}
+jenkinsfile.run_parallel_tests()


### PR DESCRIPTION
Add groovy script for Linux x86 32 bits test pipeline.

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>