### PR TITLE
skip remaining ipv6 tests on macOS and skip TestZoneInfo310.java on all

### DIFF
--- a/openjdk/ProblemList_openjdk8.txt
+++ b/openjdk/ProblemList_openjdk8.txt
@@ -157,9 +157,9 @@ java/util/logging/TestLoggerWeakRefLeak.java	https://github.com/AdoptOpenJDK/ope
 com/sun/net/httpserver/Test1.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/827 linux-ppc64le
 java/net/MulticastSocket/Promiscuous.java               https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699    linux-s390x
 #java/net/MulticastSocket/SetLoopbackMode.java on aix issue	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1011
-java/net/MulticastSocket/SetLoopbackMode.java     https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699    linux-s390x,aix-all
+java/net/MulticastSocket/SetLoopbackMode.java     https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699    linux-s390x,aix-all,macosx-all
 #java/net/MulticastSocket/Test.java	on aix issue https://github.com/AdoptOpenJDK/openjdk-tests/issues/1011	aix-all
-java/net/MulticastSocket/Test.java                             https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699    linux-s390x,aix-all
+java/net/MulticastSocket/Test.java                             https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699    linux-s390x,aix-all,macosx-all
 java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java    https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699    linux-s390x
 java/nio/channels/DatagramChannel/Promiscuous.java                  https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699    linux-s390x
 #java/net/MulticastSocket/SetGetNetworkInterfaceTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1011	aix-all
@@ -261,6 +261,7 @@ java/util/TimeZone/HongKong.java https://bugs.openjdk.java.net/browse/JDK-803114
 java/util/Calendar/CalendarRegression.java https://bugs.openjdk.java.net/browse/JDK-8031145 generic-all
 java/util/Calendar/JapanEraNameCompatTest.java https://bugs.openjdk.java.net/browse/JDK-8218781 generic-all
 java/util/Locale/LocaleProviders.sh	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1261	windows-all
+sun/util/calendar/zi/TestZoneInfo310.java		https://github.com/eclipse/openj9/issues/1131	generic-all
 ############################################################################
 
 # svc_tools


### PR DESCRIPTION
skips `java/net/MulticastSocket/SetLoopbackMode.java` on macOS
skips `java/net/MulticastSocket/Test.java` on macOS

skips `sun/util/calendar/zi/TestZoneInfo310.java` on everything (already skipped in the j9 problemList)