### PR TITLE
Fix system test caused by openj9 TestConfig folder change

### DIFF
--- a/system/daaLoadTest/playlist.xml
+++ b/system/daaLoadTest/playlist.xml
@@ -7,7 +7,7 @@
 	To avoid test target duplication, this belongs to sanity, extended and special. Regular test should only belong to one level -->
 	<test>
 		<testCaseName>MachineInfo</testCaseName>
-		<command>$(JAVA_COMMAND) -cp $(JVM_TEST_ROOT)$(D)TestConfig$(D)TKGJ$(D)TestKitGen.jar org.openj9.envInfo.EnvDetector MachineInfo; \
+		<command>$(JAVA_COMMAND) -cp $(JVM_TEST_ROOT)$(D)TestConfig$(D)bin$(D)TestKitGen.jar org.openj9.envInfo.EnvDetector MachineInfo; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>

--- a/system/jlm/playlist.xml
+++ b/system/jlm/playlist.xml
@@ -13,7 +13,7 @@
 	To avoid test target duplication, this belongs to sanity, extended and special. Regular test should only belong to one level -->
 	<test>
 		<testCaseName>MachineInfo</testCaseName>
-		<command>$(JAVA_COMMAND) -cp $(JVM_TEST_ROOT)$(D)TestConfig$(D)TKGJ$(D)TestKitGen.jar org.openj9.envInfo.EnvDetector MachineInfo; \
+		<command>$(JAVA_COMMAND) -cp $(JVM_TEST_ROOT)$(D)TestConfig$(D)bin$(D)TestKitGen.jar org.openj9.envInfo.EnvDetector MachineInfo; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>

--- a/system/lambdaLoadTest/playlist.xml
+++ b/system/lambdaLoadTest/playlist.xml
@@ -6,7 +6,7 @@
 	To avoid test target duplication, this belongs to sanity, extended and special. Regular test should only belong to one level -->
 	<test>
 		<testCaseName>MachineInfo</testCaseName>
-		<command>$(JAVA_COMMAND) -cp $(JVM_TEST_ROOT)$(D)TestConfig$(D)TKGJ$(D)TestKitGen.jar org.openj9.envInfo.EnvDetector MachineInfo; \
+		<command>$(JAVA_COMMAND) -cp $(JVM_TEST_ROOT)$(D)TestConfig$(D)bin$(D)TestKitGen.jar org.openj9.envInfo.EnvDetector MachineInfo; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>

--- a/system/mathLoadTest/playlist.xml
+++ b/system/mathLoadTest/playlist.xml
@@ -7,7 +7,7 @@
 	To avoid test target duplication, this belongs to sanity, extended and special. Regular test should only belong to one level -->
 	<test>
 		<testCaseName>MachineInfo</testCaseName>
-		<command>$(JAVA_COMMAND) -cp $(JVM_TEST_ROOT)$(D)TestConfig$(D)TKGJ$(D)TestKitGen.jar org.openj9.envInfo.EnvDetector MachineInfo; \
+		<command>$(JAVA_COMMAND) -cp $(JVM_TEST_ROOT)$(D)TestConfig$(D)bin$(D)TestKitGen.jar org.openj9.envInfo.EnvDetector MachineInfo; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>

--- a/system/mauveLoadTest/playlist.xml
+++ b/system/mauveLoadTest/playlist.xml
@@ -7,7 +7,7 @@
 	To avoid test target duplication, this belongs to sanity, extended and special. Regular test should only belong to one level -->
 	<test>
 		<testCaseName>MachineInfo</testCaseName>
-		<command>$(JAVA_COMMAND) -cp $(JVM_TEST_ROOT)$(D)TestConfig$(D)TKGJ$(D)TestKitGen.jar org.openj9.envInfo.EnvDetector MachineInfo; \
+		<command>$(JAVA_COMMAND) -cp $(JVM_TEST_ROOT)$(D)TestConfig$(D)bin$(D)TestKitGen.jar org.openj9.envInfo.EnvDetector MachineInfo; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>

--- a/system/modularity/playlist.xml
+++ b/system/modularity/playlist.xml
@@ -13,7 +13,7 @@
 	To avoid test target duplication, this belongs to sanity, extended and special. Regular test should only belong to one level -->
 	<test>
 		<testCaseName>MachineInfo</testCaseName>
-		<command>$(JAVA_COMMAND) -cp $(JVM_TEST_ROOT)$(D)TestConfig$(D)TKGJ$(D)TestKitGen.jar org.openj9.envInfo.EnvDetector MachineInfo; \
+		<command>$(JAVA_COMMAND) -cp $(JVM_TEST_ROOT)$(D)TestConfig$(D)bin$(D)TestKitGen.jar org.openj9.envInfo.EnvDetector MachineInfo; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>

--- a/system/otherLoadTest/playlist.xml
+++ b/system/otherLoadTest/playlist.xml
@@ -7,7 +7,7 @@
 	To avoid test target duplication, this belongs to sanity, extended and special. Regular test should only belong to one level -->
 	<test>
 		<testCaseName>MachineInfo</testCaseName>
-		<command>$(JAVA_COMMAND) -cp $(JVM_TEST_ROOT)$(D)TestConfig$(D)TKGJ$(D)TestKitGen.jar org.openj9.envInfo.EnvDetector MachineInfo; \
+		<command>$(JAVA_COMMAND) -cp $(JVM_TEST_ROOT)$(D)TestConfig$(D)bin$(D)TestKitGen.jar org.openj9.envInfo.EnvDetector MachineInfo; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>

--- a/system/sharedClasses/playlist.xml
+++ b/system/sharedClasses/playlist.xml
@@ -14,7 +14,7 @@
 	To avoid test target duplication, this belongs to sanity, extended and special. Regular test should only belong to one level -->
 	<test>
 		<testCaseName>MachineInfo</testCaseName>
-		<command>$(JAVA_COMMAND) -cp $(JVM_TEST_ROOT)$(D)TestConfig$(D)TKGJ$(D)TestKitGen.jar org.openj9.envInfo.EnvDetector MachineInfo; \
+		<command>$(JAVA_COMMAND) -cp $(JVM_TEST_ROOT)$(D)TestConfig$(D)bin$(D)TestKitGen.jar org.openj9.envInfo.EnvDetector MachineInfo; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>


### PR DESCRIPTION
OpenJ9 introduced a change: https://github.com/eclipse/openj9/pull/7529
This change the `TestKitGen.jar` from `./TKGJ/TestKitGen.jar` to `./bin/TestKitGen.jar`
This commit is intended to update all the reference from `TKGJ` to `bin`