### PR TITLE
Set JTREG concurrency based on cores and memory size

### DIFF
--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -12,21 +12,46 @@
 # limitations under the License.
 ##############################################################################
 NPROCS:=1
+# Memory size in MB
+MEMORY_SIZE:=1024
+
 OS:=$(shell uname -s)
 
 ifeq ($(OS),Linux)
 	NPROCS:=$(shell grep -c ^processor /proc/cpuinfo)
+	MEMORY_SIZE:=$(shell \
+		expr `cat /proc/meminfo | grep MemTotal | awk '{print $$2}'` / 1024 \
+		)
 endif
 ifeq ($(OS),Darwin)
 	NPROCS:=$(shell sysctl -n hw.ncpu)
+	MEMORY_SIZE:=$(shell expr `sysctl -n hw.memsize` / 1024 / 1024)
 endif
 ifeq ($(OS),FreeBSD)
 	NPROCS:=$(shell sysctl -n hw.ncpu)
+	MEMORY_SIZE:=$(shell expr `sysctl -n hw.memsize` / 1024 / 1024)
 endif
 ifeq ($(CYGWIN),1)
  	NPROCS:=$(NUMBER_OF_PROCESSORS)
+	MEMORY_SIZE:=$(shell \
+		expr `wmic computersystem get totalphysicalmemory -value | grep = \
+		| cut -d "=" -f 2-` / 1024 / 1024 \
+		)
 endif
-EXTRA_JTREG_OPTIONS += -concurrency:$(NPROCS)
+# Upstream OpenJDK, roughly, sets concurrency based on the
+# following: min(NPROCS/2, MEM_IN_GB/2).
+MEM := $(shell expr $(MEMORY_SIZE) / 2048)
+CORE := $(shell expr $(NPROCS) / 2)
+CONC := $(CORE)
+ifeq ($(shell expr $(CORE) \> $(MEM)), 1)
+	CONC := $(MEM)
+endif
+JTREG_CONC ?= 0
+# Allow JTREG_CONC be set via parameter
+ifeq ($(JTREG_CONC), 0)
+	JTREG_CONC := $(CONC)
+endif
+EXTRA_JTREG_OPTIONS += -concurrency:$(JTREG_CONC)
 
 JTREG_BASIC_OPTIONS += -agentvm
 # Only run automatic tests


### PR DESCRIPTION
Upstream OpenJDK test framework, roughly, sets it to
min(NPROCS/2, MEM_IN_GB/2). Set it to a similar value
so as to avoid test reliability issues due to memory
limits.