### PR TITLE
Override LABEL variable when params.LABEL is passed

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -508,7 +508,7 @@ def addJobDescription() {
 	def description = (currentBuild.description) ? currentBuild.description + "<br>" : ""
 	currentBuild.description = description \
 		+ "TARGET: ${params.TARGET}<br/>" \
-		+ "LABEL: <a href=${JENKINS_URL}label/${LABEL}>${LABEL}</a><br/>" \
+		+ "<a href=${JENKINS_URL}label/${LABEL}>${LABEL}</a><br/>" \
 		+ "<a href=${JENKINS_URL}computer/${NODE_NAME}>${NODE_NAME}</a>"
 }
 

--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -50,9 +50,9 @@ def setupEnv() {
 	env.KEEP_REPORTDIR = params.KEEP_REPORTDIR ? params.KEEP_REPORTDIR : ''
 	SDK_RESOURCE = params.SDK_RESOURCE ? params.SDK_RESOURCE : "upstream"
 	env.AUTO_DETECT = params.AUTO_DETECT
-	
+
 	ITERATIONS = params.ITERATIONS ? "${params.ITERATIONS}".toInteger() : 1
-	
+
 	if (params.JDK_IMPL) {
 		env.JDK_IMPL = params.JDK_IMPL
 	} else if (params.JVM_VERSION) {
@@ -95,13 +95,13 @@ def setupEnv() {
 def setupParallelEnv() {
 	stage('setupParallelEnv') {
 		timestamps{
-			setupEnv()		
-			
+			setupEnv()
+
 			//Initialization for things in common between both multiple iterations and many subtests
 			//repeatAmount is the number of times the loops go through
 			def testSubDirs = []
 			int repeatAmount = ITERATIONS
-			
+
 			//Setup for option-specific parameters
 			//If ITERATIONS is 1, then parallel is based on subfolders
 			if (repeatAmount == 1) {
@@ -117,7 +117,7 @@ def setupParallelEnv() {
 				repeatAmount = testSubDirs.size()
 				echo "repeatAmount is ${repeatAmount}, testSubDirs is ${testSubDirs}, running test in parallel mode"
 			}
-			
+
 			parallel_tests = [:]
 
 			for (int i = 0; i < repeatAmount; i++) {
@@ -256,7 +256,7 @@ def setup() {
 			VENDOR_TEST_DIRS = (params.VENDOR_TEST_DIRS) ? "--vendor_dirs \"${params.VENDOR_TEST_DIRS}\"" : ""
 			VENDOR_TEST_SHAS = (params.VENDOR_TEST_SHAS) ? "--vendor_shas \"${params.VENDOR_TEST_SHAS}\"" : ""
 			GET_SH_CMD = "./openjdk-tests/get.sh -s `pwd` -t `pwd`/openjdk-tests -p $PLATFORM -r ${SDK_RESOURCE} ${JDK_VERSION_OPTION} ${JDK_IMPL_OPTION} ${CUSTOMIZED_SDK_URL_OPTION} ${CUSTOMIZED_SDK_SOURCE_URL_OPTION} ${OPENJ9_REPO_OPTION} ${OPENJ9_BRANCH_OPTION} ${OPENJ9_SHA_OPTION} ${VENDOR_TEST_REPOS} ${VENDOR_TEST_BRANCHES} ${VENDOR_TEST_DIRS} ${VENDOR_TEST_SHAS}"
-			
+
 			dir( WORKSPACE) {
 				// use sshagent with Jenkins credentials ID for all platforms except zOS
 				// on zOS use the user's ssh key
@@ -315,7 +315,7 @@ def buildTest() {
 			} catch (Exception e) {
 				echo 'Cannot run copyArtifacts from systemtest.getDependency. Skipping copyArtifacts...'
 			}
-			
+
 			if (fileExists('openjdkbinary/openjdk-test-image')) {
 				env.TESTIMAGE_PATH = "$WORKSPACE/openjdkbinary/openjdk-test-image"
 			}
@@ -341,7 +341,7 @@ def runTest( ) {
 		timestamps{
 			echo 'Running tests...'
 			def CUSTOM_OPTION = ''
-			
+
 			TARGET = "${params.TARGET}";
 			if (TARGET.contains('custom') && CUSTOM_TARGET!='') {
 				CUSTOM_OPTION = "${TARGET.toUpperCase()}_TARGET='${CUSTOM_TARGET}'"

--- a/buildenv/jenkins/getDependency
+++ b/buildenv/jenkins/getDependency
@@ -1,6 +1,6 @@
 #!groovy
 
-LABEL='ci.role.test&&hw.arch.x86&&sw.os.linux'
+LABEL = 'ci.role.test&&hw.arch.x86&&sw.os.linux'
 
 stage('Queue') {
     node("$LABEL") {

--- a/buildenv/jenkins/openjdk_aarch32_linux
+++ b/buildenv/jenkins/openjdk_aarch32_linux
@@ -1,11 +1,12 @@
 #!groovy
+
 LABEL='ci.role.test&&sw.os.linux&&hw.arch.aarch32'
 
 stage('Queue') {
     node((params.LABEL) ? params.LABEL : LABEL) {
         PLATFORM = 'aarch32_linux'
         SDK_RESOURCE = 'upstream'
-        SPEC='linux_arm'
+        SPEC = 'linux_arm'
         checkout scm
         jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
         jenkinsfile.testBuild()

--- a/buildenv/jenkins/openjdk_aarch64_linux
+++ b/buildenv/jenkins/openjdk_aarch64_linux
@@ -1,11 +1,12 @@
 #!groovy
+
 LABEL='ci.role.test&&sw.os.linux&&hw.arch.aarch64'
 
 stage('Queue') {
     node((params.LABEL) ? params.LABEL : LABEL) {
         PLATFORM = 'aarch64_linux'
         SDK_RESOURCE = 'upstream'
-        SPEC='linux_aarch64_cmprssptrs'
+        SPEC = 'linux_aarch64_cmprssptrs'
         checkout scm
         jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
         jenkinsfile.testBuild()

--- a/buildenv/jenkins/openjdk_aarch64_linux_xl
+++ b/buildenv/jenkins/openjdk_aarch64_linux_xl
@@ -1,11 +1,12 @@
 #!groovy
+
 LABEL='ci.role.test&&sw.os.linux&&hw.arch.aarch64'
 
 stage('Queue') {
     node((params.LABEL) ? params.LABEL : LABEL) {
         PLATFORM = 'aarch64_linux_largeHeap'
         SDK_RESOURCE = 'upstream'
-        SPEC='linux_aarch64'
+        SPEC = 'linux_aarch64'
         checkout scm
         jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
         jenkinsfile.testBuild()

--- a/buildenv/jenkins/openjdk_ppc32_linux
+++ b/buildenv/jenkins/openjdk_ppc32_linux
@@ -1,17 +1,16 @@
 #!groovy
 
-
 if (params.DOCKER_REQUIRED) {
-    LABEL='ci.role.test&&hw.arch.ppc64&&sw.os.linux&&sw.tool.docker'
+    LABEL = 'ci.role.test&&hw.arch.ppc64&&sw.os.linux&&sw.tool.docker'
 } else {
-    LABEL='ci.role.test&&hw.arch.ppc64&&sw.os.linux'
+    LABEL = 'ci.role.test&&hw.arch.ppc64&&sw.os.linux'
 }
 
 stage('Queue') {
     node((params.LABEL) ? params.LABEL : LABEL) {
         PLATFORM = 'ppc32_linux'
         SDK_RESOURCE = 'upstream'
-        SPEC='linux_ppc'
+        SPEC = 'linux_ppc'
         checkout scm
         jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
         jenkinsfile.testBuild()

--- a/buildenv/jenkins/openjdk_ppc64_aix
+++ b/buildenv/jenkins/openjdk_ppc64_aix
@@ -1,11 +1,12 @@
 #!groovy
+
 LABEL='ci.role.test&&hw.arch.ppc64&&sw.os.aix'
 
 stage('Queue') {
     node((params.LABEL) ? params.LABEL : LABEL) {
         PLATFORM = 'ppc64_aix'
         SDK_RESOURCE = 'upstream'
-        SPEC='aix_ppc-64_cmprssptrs'
+        SPEC = 'aix_ppc-64_cmprssptrs'
         checkout scm
         jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
         jenkinsfile.testBuild()

--- a/buildenv/jenkins/openjdk_ppc64_linux
+++ b/buildenv/jenkins/openjdk_ppc64_linux
@@ -1,17 +1,16 @@
 #!groovy
 
-
 if (params.DOCKER_REQUIRED) {
-    LABEL='ci.role.test&&hw.arch.ppc64&&sw.os.linux&&sw.tool.docker'
+    LABEL = 'ci.role.test&&hw.arch.ppc64&&sw.os.linux&&sw.tool.docker'
 } else {
-    LABEL='ci.role.test&&hw.arch.ppc64&&sw.os.linux'
+    LABEL = 'ci.role.test&&hw.arch.ppc64&&sw.os.linux'
 }
 
 stage('Queue') {
     node((params.LABEL) ? params.LABEL : LABEL) {
         PLATFORM = 'ppc64_linux'
         SDK_RESOURCE = 'upstream'
-        SPEC='linux_ppc-64_cmprssptrs'
+        SPEC = 'linux_ppc-64_cmprssptrs'
         checkout scm
         jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
         jenkinsfile.testBuild()

--- a/buildenv/jenkins/openjdk_ppc64_linux_xl
+++ b/buildenv/jenkins/openjdk_ppc64_linux_xl
@@ -1,17 +1,16 @@
 #!groovy
 
-
 if (params.DOCKER_REQUIRED) {
-    LABEL='ci.role.test&&hw.arch.ppc64&&sw.os.linux&&sw.tool.docker'
+    LABEL = 'ci.role.test&&hw.arch.ppc64&&sw.os.linux&&sw.tool.docker'
 } else {
-    LABEL='ci.role.test&&hw.arch.ppc64&&sw.os.linux'
+    LABEL = 'ci.role.test&&hw.arch.ppc64&&sw.os.linux'
 }
 
 stage('Queue') {
     node((params.LABEL) ? params.LABEL : LABEL) {
         PLATFORM = 'ppc64_linux_largeHeap'
         SDK_RESOURCE = 'upstream'
-        SPEC='linux_ppc-64'
+        SPEC = 'linux_ppc-64'
         checkout scm
         jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
         jenkinsfile.testBuild()

--- a/buildenv/jenkins/openjdk_ppc64le_linux
+++ b/buildenv/jenkins/openjdk_ppc64le_linux
@@ -1,16 +1,16 @@
 #!groovy
 
 if (params.DOCKER_REQUIRED) {
-    LABEL='ci.role.test&&hw.arch.ppc64le&&sw.os.linux&&sw.tool.docker'
+    LABEL = 'ci.role.test&&hw.arch.ppc64le&&sw.os.linux&&sw.tool.docker'
 } else {
-    LABEL='ci.role.test&&hw.arch.ppc64le&&sw.os.linux'
+    LABEL = 'ci.role.test&&hw.arch.ppc64le&&sw.os.linux'
 }
 
 stage('Queue') {
     node((params.LABEL) ? params.LABEL : LABEL) { //ppc64le build use "fedora" too, for now leave as is
         PLATFORM = 'ppc64le_linux'
         SDK_RESOURCE = 'upstream'
-        SPEC='linux_ppc-64_cmprssptrs_le'
+        SPEC = 'linux_ppc-64_cmprssptrs_le'
         checkout scm
         jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
         jenkinsfile.testBuild()

--- a/buildenv/jenkins/openjdk_s390_linux
+++ b/buildenv/jenkins/openjdk_s390_linux
@@ -1,17 +1,16 @@
 #!groovy
 
-
 if (params.DOCKER_REQUIRED) {
-    LABEL='ci.role.test&&hw.arch.s390x&&sw.os.linux&&sw.tool.docker&&hw.bits.32'
+    LABEL = 'ci.role.test&&hw.arch.s390x&&sw.os.linux&&sw.tool.docker&&hw.bits.32'
 } else {
-    LABEL='ci.role.test&&hw.arch.s390x&&sw.os.linux&&hw.bits.32'
+    LABEL = 'ci.role.test&&hw.arch.s390x&&sw.os.linux&&hw.bits.32'
 }
 
 stage('Queue') {
     node((params.LABEL) ? params.LABEL : LABEL) {
         PLATFORM = 's390_linux'
         SDK_RESOURCE = 'upstream'
-        SPEC='linux_390'
+        SPEC = 'linux_390'
         checkout scm
         jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
         jenkinsfile.testBuild()

--- a/buildenv/jenkins/openjdk_s390_zos
+++ b/buildenv/jenkins/openjdk_s390_zos
@@ -1,0 +1,22 @@
+#!groovy
+/* Template for test jobs on z/OS. Configure test job as parameterized.
+    Set parameter TARGET(openjdk, system, external, perf, jck etc.).
+    Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_s390x)
+    Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
+LABEL='ci.role.test&&hw.arch.s390x&&sw.os.zos'
+
+stage('Queue') {
+    node((params.LABEL) ? params.LABEL : LABEL) {
+        PLATFORM = 's390_zos'
+        SDK_RESOURCE = 'upstream'
+        SPEC='zos_390'
+
+        def gitConfig = scm.getUserRemoteConfigs()[0]
+        def SCM_GIT_REPO = gitConfig.getUrl()
+        def SCM_GIT_BRANCH = scm.branches[0].name
+        sh "git clone -b ${SCM_GIT_BRANCH} ${SCM_GIT_REPO} openjdk-tests"
+        jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
+        jenkinsfile.testBuild()
+    }
+}
+jenkinsfile.run_parallel_tests()

--- a/buildenv/jenkins/openjdk_s390_zos
+++ b/buildenv/jenkins/openjdk_s390_zos
@@ -1,8 +1,12 @@
 #!groovy
-/* Template for test jobs on z/OS. Configure test job as parameterized.
-    Set parameter TARGET(openjdk, system, external, perf, jck etc.).
-    Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_s390x)
-    Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
+
+/*
+ *  Template for test jobs on z/OS. Configure test job as parameterized.
+ *  Set parameter TARGET(openjdk, system, external, perf, jck etc.).
+ *  Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_s390x)
+ *  Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.
+ */
+
 LABEL='ci.role.test&&hw.arch.s390x&&sw.os.zos'
 
 stage('Queue') {

--- a/buildenv/jenkins/openjdk_s390x_linux
+++ b/buildenv/jenkins/openjdk_s390x_linux
@@ -1,17 +1,16 @@
 #!groovy
 
-
 if (params.DOCKER_REQUIRED) {
-    LABEL='ci.role.test&&hw.arch.s390x&&sw.os.linux&&sw.tool.docker'
+    LABEL = 'ci.role.test&&hw.arch.s390x&&sw.os.linux&&sw.tool.docker'
 } else {
-    LABEL='ci.role.test&&hw.arch.s390x&&sw.os.linux'
+    LABEL = 'ci.role.test&&hw.arch.s390x&&sw.os.linux'
 }
 
 stage('Queue') {
     node((params.LABEL) ? params.LABEL : LABEL) {
         PLATFORM = 's390x_linux'
         SDK_RESOURCE = 'upstream'
-        SPEC='linux_390-64_cmprssptrs'
+        SPEC = 'linux_390-64_cmprssptrs'
         checkout scm
         jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
         jenkinsfile.testBuild()

--- a/buildenv/jenkins/openjdk_s390x_linux_xl
+++ b/buildenv/jenkins/openjdk_s390x_linux_xl
@@ -1,17 +1,16 @@
 #!groovy
 
-
 if (params.DOCKER_REQUIRED) {
-    LABEL='ci.role.test&&hw.arch.s390x&&sw.os.linux&&sw.tool.docker'
+    LABEL = 'ci.role.test&&hw.arch.s390x&&sw.os.linux&&sw.tool.docker'
 } else {
-    LABEL='ci.role.test&&hw.arch.s390x&&sw.os.linux'
+    LABEL = 'ci.role.test&&hw.arch.s390x&&sw.os.linux'
 }
 
 stage('Queue') {
     node((params.LABEL) ? params.LABEL : LABEL) {
         PLATFORM = 's390x_linux_largeHeap'
         SDK_RESOURCE = 'upstream'
-        SPEC='linux_390-64'
+        SPEC = 'linux_390-64'
         checkout scm
         jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
         jenkinsfile.testBuild()

--- a/buildenv/jenkins/openjdk_s390x_zos
+++ b/buildenv/jenkins/openjdk_s390x_zos
@@ -1,15 +1,19 @@
 #!groovy
-/* Template for test jobs on z/OS. Configure test job as parameterized.
-    Set parameter TARGET(openjdk, system, external, perf, jck etc.).
-    Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_s390x)
-    Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
-LABEL='ci.role.test&&hw.arch.s390x&&sw.os.zos'
+
+/*
+ *  Template for test jobs on z/OS. Configure test job as parameterized.
+ *  Set parameter TARGET(openjdk, system, external, perf, jck etc.).
+ *  Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_s390x)
+ *  Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.
+ */
+
+LABEL = 'ci.role.test&&hw.arch.s390x&&sw.os.zos'
 
 stage('Queue') {
     node((params.LABEL) ? params.LABEL : LABEL) {
         PLATFORM = 's390x_zos'
         SDK_RESOURCE = 'upstream'
-        SPEC='zos_390-64_cmprssptrs'
+        SPEC = 'zos_390-64_cmprssptrs'
 
         def gitConfig = scm.getUserRemoteConfigs()[0]
         def SCM_GIT_REPO = gitConfig.getUrl()

--- a/buildenv/jenkins/openjdk_s390x_zos_xl
+++ b/buildenv/jenkins/openjdk_s390x_zos_xl
@@ -1,0 +1,22 @@
+#!groovy
+/* Template for test jobs on z/OS. Configure test job as parameterized.
+    Set parameter TARGET(openjdk, system, external, perf, jck etc.).
+    Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_s390x)
+    Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
+LABEL='ci.role.test&&hw.arch.s390x&&sw.os.zos'
+
+stage('Queue') {
+    node((params.LABEL) ? params.LABEL : LABEL) {
+        PLATFORM = 's390x_zos_largeHeap'
+        SDK_RESOURCE = 'upstream'
+        SPEC='zos_390-64'
+
+        def gitConfig = scm.getUserRemoteConfigs()[0]
+        def SCM_GIT_REPO = gitConfig.getUrl()
+        def SCM_GIT_BRANCH = scm.branches[0].name
+        sh "git clone -b ${SCM_GIT_BRANCH} ${SCM_GIT_REPO} openjdk-tests"
+        jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
+        jenkinsfile.testBuild()
+    }
+}
+jenkinsfile.run_parallel_tests()

--- a/buildenv/jenkins/openjdk_s390x_zos_xl
+++ b/buildenv/jenkins/openjdk_s390x_zos_xl
@@ -1,15 +1,19 @@
 #!groovy
-/* Template for test jobs on z/OS. Configure test job as parameterized.
-    Set parameter TARGET(openjdk, system, external, perf, jck etc.).
-    Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_s390x)
-    Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
+
+/*
+ *  Template for test jobs on z/OS. Configure test job as parameterized.
+ *  Set parameter TARGET(openjdk, system, external, perf, jck etc.).
+ *  Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_s390x)
+ *  Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.
+ */
+
 LABEL='ci.role.test&&hw.arch.s390x&&sw.os.zos'
 
 stage('Queue') {
     node((params.LABEL) ? params.LABEL : LABEL) {
         PLATFORM = 's390x_zos_largeHeap'
         SDK_RESOURCE = 'upstream'
-        SPEC='zos_390-64'
+        SPEC = 'zos_390-64'
 
         def gitConfig = scm.getUserRemoteConfigs()[0]
         def SCM_GIT_REPO = gitConfig.getUrl()

--- a/buildenv/jenkins/openjdk_sparcv9_solaris
+++ b/buildenv/jenkins/openjdk_sparcv9_solaris
@@ -1,16 +1,16 @@
 #!groovy
 
 if (params.DOCKER_REQUIRED) {
-    LABEL='ci.role.test&&hw.arch.sparcv9&&sw.os.sunos&&sw.tool.docker'
+    LABEL = 'ci.role.test&&hw.arch.sparcv9&&sw.os.sunos&&sw.tool.docker'
 } else {
-    LABEL='ci.role.test&&hw.arch.sparcv9&&sw.os.sunos'
+    LABEL = 'ci.role.test&&hw.arch.sparcv9&&sw.os.sunos'
 }
 
 stage('Queue') {
     node((params.LABEL) ? params.LABEL : LABEL) {
         PLATFORM = 'sparcv9_solaris'
         SDK_RESOURCE = 'upstream'
-        SPEC='sunos_sparcv9-64_cmprssptrs'
+        SPEC = 'sunos_sparcv9-64_cmprssptrs'
         checkout scm
         jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
         jenkinsfile.testBuild()

--- a/buildenv/jenkins/openjdk_x86-32_linux
+++ b/buildenv/jenkins/openjdk_x86-32_linux
@@ -1,16 +1,16 @@
 #!groovy
 
 if (params.DOCKER_REQUIRED) {
-    LABEL='ci.role.test&&hw.arch.x86&&sw.os.linux&&sw.tool.docker'
+    LABEL = 'ci.role.test&&hw.arch.x86&&sw.os.linux&&sw.tool.docker'
 } else {
-    LABEL='ci.role.test&&hw.arch.x86&&sw.os.linux'
+    LABEL = 'ci.role.test&&hw.arch.x86&&sw.os.linux'
 }
 
 stage('Queue') {
     node((params.LABEL) ? params.LABEL : LABEL) {
         PLATFORM = 'x32_linux'
         SDK_RESOURCE = 'upstream'
-        SPEC='linux_x86'
+        SPEC = 'linux_x86'
         checkout scm
         jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
         jenkinsfile.testBuild()

--- a/buildenv/jenkins/openjdk_x86-32_windows
+++ b/buildenv/jenkins/openjdk_x86-32_windows
@@ -1,14 +1,19 @@
 #!groovy
-/* Template for test jobs on openjdk8 linux. Configure test job as parameterized.
-	Set parameter TARGET(openjdk, system, external, perf, jck etc.).
-	Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_x86-64_linux)
-	Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.*/
+
+/*
+ *  Template for test jobs on openjdk8 linux. Configure test job as parameterized.
+ *  Set parameter TARGET(openjdk, system, external, perf, jck etc.).
+ *  Set UPSTREAM_JOB_NAME(version_build_arch_os, for example: openjdk8_build_x86-64_linux)
+ *  Set JVM_VERSION(openjdk8, openjdk8-openj9, openjdk9, openjdk8-openj9, etc.
+ */
+
 LABEL='ci.role.test&&hw.arch.x86&&sw.os.windows'
+
 stage('Queue') {
     node((params.LABEL) ? params.LABEL : LABEL) {
         PLATFORM = 'x32_windows'
         SDK_RESOURCE = 'upstream'
-        SPEC='win_x86'
+        SPEC = 'win_x86'
         checkout scm
         jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
         jenkinsfile.testBuild()

--- a/buildenv/jenkins/openjdk_x86-64_linux
+++ b/buildenv/jenkins/openjdk_x86-64_linux
@@ -1,16 +1,16 @@
 #!groovy
 
 if (params.DOCKER_REQUIRED) {
-    LABEL='ci.role.test&&hw.arch.x86&&sw.os.linux&&sw.tool.docker'
+    LABEL = 'ci.role.test&&hw.arch.x86&&sw.os.linux&&sw.tool.docker'
 } else {
-    LABEL='ci.role.test&&hw.arch.x86&&sw.os.linux'
+    LABEL = 'ci.role.test&&hw.arch.x86&&sw.os.linux'
 }
 
 stage('Queue') {
     node((params.LABEL) ? params.LABEL : LABEL) {
         PLATFORM = 'x64_linux'
         SDK_RESOURCE = 'upstream'
-        SPEC='linux_x86-64_cmprssptrs'
+        SPEC = 'linux_x86-64_cmprssptrs'
         checkout scm
         jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
         jenkinsfile.testBuild()

--- a/buildenv/jenkins/openjdk_x86-64_linux_xl
+++ b/buildenv/jenkins/openjdk_x86-64_linux_xl
@@ -1,11 +1,12 @@
 #!groovy
+
 LABEL='ci.role.test&&hw.arch.x86&&sw.os.linux'
 
 stage('Queue') {
     node((params.LABEL) ? params.LABEL : LABEL) {
         PLATFORM = 'x64_linux_largeHeap'
         SDK_RESOURCE = 'upstream'
-        SPEC='linux_x86-64'
+        SPEC = 'linux_x86-64'
         checkout scm
         jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
         jenkinsfile.testBuild()

--- a/buildenv/jenkins/openjdk_x86-64_mac
+++ b/buildenv/jenkins/openjdk_x86-64_mac
@@ -1,11 +1,12 @@
 #!groovy
+
 LABEL='ci.role.test&&hw.arch.x86&&sw.os.osx'
 
 stage('Queue') {
     node((params.LABEL) ? params.LABEL : LABEL) {
         PLATFORM = 'x64_mac'
         SDK_RESOURCE = 'upstream'
-        SPEC='osx_x86-64_cmprssptrs'
+        SPEC = 'osx_x86-64_cmprssptrs'
         checkout scm
         jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
         jenkinsfile.testBuild()

--- a/buildenv/jenkins/openjdk_x86-64_mac_xl
+++ b/buildenv/jenkins/openjdk_x86-64_mac_xl
@@ -1,11 +1,12 @@
 #!groovy
+
 LABEL='ci.role.test&&hw.arch.x86&&sw.os.osx'
 
 stage('Queue') {
     node((params.LABEL) ? params.LABEL : LABEL) {
         PLATFORM = 'x64_mac_largeHeap'
         SDK_RESOURCE = 'upstream'
-        SPEC='osx_x86-64'
+        SPEC = 'osx_x86-64'
         checkout scm
         jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
         jenkinsfile.testBuild()

--- a/buildenv/jenkins/openjdk_x86-64_windows
+++ b/buildenv/jenkins/openjdk_x86-64_windows
@@ -1,11 +1,12 @@
 #!groovy
+
 LABEL='ci.role.test&&hw.arch.x86&&sw.os.windows'
 
 stage('Queue') {
     node((params.LABEL) ? params.LABEL : LABEL) {
         PLATFORM = 'x64_windows'
         SDK_RESOURCE = 'upstream'
-        SPEC='win_x86-64_cmprssptrs'
+        SPEC = 'win_x86-64_cmprssptrs'
         checkout scm
         jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
         jenkinsfile.testBuild()

--- a/buildenv/jenkins/openjdk_x86-64_windows_xl
+++ b/buildenv/jenkins/openjdk_x86-64_windows_xl
@@ -1,11 +1,12 @@
 #!groovy
+
 LABEL='ci.role.test&&hw.arch.x86&&sw.os.windows'
 
 stage('Queue') {
     node((params.LABEL) ? params.LABEL : LABEL) {
         PLATFORM = 'x64_windows_largeHeap'
         SDK_RESOURCE = 'upstream'
-        SPEC='win_x86-64'
+        SPEC = 'win_x86-64'
         checkout scm
         jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
         jenkinsfile.testBuild()


### PR DESCRIPTION
- When LABEL is passed as a param, the build
  description would still use LABEL rather
  than params.LABEL. Overiding the variable
  LABEL with params.LABEL will ensure the
  right LABEL is used for the description.
- Minor formatting and whitespace fixes

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>