### PR TITLE
Support running openjdk jtreg on zOS

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -234,7 +234,7 @@ getBinaryOpenjdk()
 			elif [[ "$jar_dir_name"  =~ native-test-libs*  &&  "$jar_dir_name" != "native-test-libs" ]]; then
 				mv $jar_dir_name native-test-libs
 			#The following only needed if openj9 has a different image name convention
-			elif [[ "$jar_dir_name" != "j2sdk-image"  &&  "$jar_dir_name" != "native-test-libs" ]]; then
+			elif [[ "$jar_dir_name" != "j2sdk-image"  &&  "$jar_dir_name" != "native-test-libs" && "$jar_dir_name" != "jtreg" ]]; then
 				mv $jar_dir_name j2sdk-image
 			fi
 		done

--- a/openjdk/build.xml
+++ b/openjdk/build.xml
@@ -30,7 +30,7 @@
 			<property name="gitReleaseTag" value="--branch ${env.RELEASE_TAG}"/>
 		</then>
 		<else>
-			<property name="gitReleaseTag" value=""/>
+		        <property name="gitReleaseTag" value=""/>
 		</else>
 	</if>
 	
@@ -95,7 +95,7 @@
                                 <if>
                                     <contains string="${PLATFORM}" substring="zos"/>
                                     <then>
-                                        <property name="regressionRepo" value="git@github.com:ibmruntimes/${jdkName}.git" />
+                                        <property name="regressionRepo" value="git@github.ibm.com:runtimes/openj9-openjdk-jdk11-zos.git" />
                                     </then>
                                     <else>
 				        <property name="regressionRepo" value="https://github.com/ibmruntimes/${jdkName}.git" />

--- a/openjdk/build.xml
+++ b/openjdk/build.xml
@@ -86,16 +86,31 @@
 				<if>
 					<equals arg1="${env.ORIGIN_JDK_VERSION}" arg2="next" />
 					<then>
-						<property name="jdkName" value="openj9-openjdk-jdk" />
+                                            <if>
+                                                <contains string="${PLATFORM}" substring="zos"/>
+                                                <then>
+                                                </then>
+                                                <else>
+    						    <property name="jdkName" value="openj9-openjdk-jdk" />
+                                                </else>
+                                            </if>
 					</then>					
 					<else>
-						<property name="jdkName" value="openj9-openjdk-jdk${JDK_VERSION}" />
+                                            <if>
+                                                <contains string="${PLATFORM}" substring="zos"/>
+                                                <then>
+                                                    <property name="jdkName" value="openj9-openjdk-jdk${JDK_VERSION}-zos" />
+                                                </then>
+                                                <else>
+                                                    <property name="jdkName" value="openj9-openjdk-jdk${JDK_VERSION}" />
+                                                </else>
+                                            </if>
 					</else>
 				</if>
                                 <if>
                                     <contains string="${PLATFORM}" substring="zos"/>
                                     <then>
-                                        <property name="regressionRepo" value="git@github.ibm.com:runtimes/openj9-openjdk-jdk11-zos.git" />
+                                        <property name="regressionRepo" value="git@github.ibm.com:runtimes/${jdkName}.git" />
                                     </then>
                                     <else>
 				        <property name="regressionRepo" value="https://github.com/ibmruntimes/${jdkName}.git" />

--- a/openjdk/build.xml
+++ b/openjdk/build.xml
@@ -41,12 +41,29 @@
 				<available file="jtreg-4.2.0-tip.tar.gz" />
 			</not>
 			<then>
-				<exec executable="wget" failonerror="true">
-					<arg line="-q --no-check-certificate https://ci.adoptopenjdk.net/job/jtreg/lastSuccessfulBuild/artifact/jtreg-4.2.0-tip.tar.gz" />
-				</exec>
-				<exec executable="tar" failonerror="true">
-					<arg line="xf jtreg-4.2.0-tip.tar.gz -C ${DEST}" />
-				</exec>
+                            <if>
+                                <contains string="${PLATFORM}" substring="zos"/>
+                                <then>
+                                    <move file="${BUILD_ROOT}/../openjdkbinary/jtreg-4.2-b14.tar.gz" tofile="jtreg-4.2.0-tip.tar.gz"/>
+                                    <exec executable="gunzip" failonerror="true">
+                                        <arg line="jtreg-4.2.0-tip.tar.gz" />
+                                    </exec>
+                                    <exec executable="tar" failonerror="true">
+                                        <arg line="-o -xf jtreg-4.2.0-tip.tar -C ${DEST}" />
+                                    </exec>
+                                    <exec executable="gzip" failonerror="true">
+                                        <arg line="jtreg-4.2.0-tip.tar" />
+                                    </exec>
+                                </then>
+                                <else>
+                                    <exec executable="wget" failonerror="true">
+                                        <arg line="-q --no-check-certificate https://ci.adoptopenjdk.net/job/jtreg/lastSuccessfulBuild/artifact/jtreg-4.2.0-tip.tar.gz" />
+                                    </exec>
+                                    <exec executable="tar" failonerror="true">
+                                        <arg line="xf jtreg-4.2.0-tip.tar.gz -C ${DEST}" />
+                                    </exec>
+                                </else>
+                            </if>
 			</then>
 		</if>
 	</target>
@@ -75,7 +92,15 @@
 						<property name="jdkName" value="openj9-openjdk-jdk${JDK_VERSION}" />
 					</else>
 				</if>
-				<property name="regressionRepo" value="https://github.com/ibmruntimes/${jdkName}.git" />
+                                <if>
+                                    <contains string="${PLATFORM}" substring="zos"/>
+                                    <then>
+                                        <property name="regressionRepo" value="git@github.com:ibmruntimes/${jdkName}.git" />
+                                    </then>
+                                    <else>
+				        <property name="regressionRepo" value="https://github.com/ibmruntimes/${jdkName}.git" />
+                                    </else>
+                                </if>
 			</then>
 			<else>
 				<if>

--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -46,7 +46,7 @@ JTREG_BASIC_OPTIONS += -retain:fail,error,*.dmp,javacore.*,heapdump.*,*.trc
 JTREG_IGNORE_OPTION = -ignore:quiet
 JTREG_BASIC_OPTIONS += $(JTREG_IGNORE_OPTION)
 # Multiple by 4 the timeout numbers
-JTREG_TIMEOUT_OPTION =  -timeoutFactor:8
+JTREG_TIMEOUT_OPTION =  -timeoutFactor:1
 JTREG_BASIC_OPTIONS += $(JTREG_TIMEOUT_OPTION)
 # Create junit xml
 JTREG_XML_OPTION = -xml:verify

--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -28,7 +28,11 @@ ifeq ($(CYGWIN),1)
 endif
 EXTRA_JTREG_OPTIONS += -concurrency:$(NPROCS)
 
-JTREG_BASIC_OPTIONS += -agentvm
+ifeq ($(OS),OS/390)
+    JTREG_BASIC_OPTIONS += -othervm
+else
+    JTREG_BASIC_OPTIONS += -agentvm
+endif
 # Only run automatic tests
 JTREG_BASIC_OPTIONS += -a
 # Always turn on assertions


### PR DESCRIPTION
Enable openjdk sanity jtreg testing
- Enable zOS jtreg.tar.gz binary download via customized URL (temporary until zOS jtreg build available)
- Utilize zOS tar options
- getOpenjdk using git@ protocol supported on zOS
- use -othervm jtreg mode on zOS (-agentvm currently not working)

Signed-off-by: andrew-m-leonard <andrew_m_leonard@uk.ibm.com>