### PR TITLE
Add Jenkins files for Linux PPC BE platforms

### DIFF
--- a/buildenv/jenkins/openjdk_ppc32_linux
+++ b/buildenv/jenkins/openjdk_ppc32_linux
@@ -1,0 +1,20 @@
+#!groovy
+
+
+if (params.DOCKER_REQUIRED) {
+    LABEL='ci.role.test&&hw.arch.ppc64&&sw.os.linux&&sw.tool.docker'
+} else {
+    LABEL='ci.role.test&&hw.arch.ppc64&&sw.os.linux'
+}
+
+stage('Queue') {
+    node((params.LABEL) ? params.LABEL : LABEL) {
+        PLATFORM = 'ppc32_linux'
+        SDK_RESOURCE = 'upstream'
+        SPEC='linux_ppc'
+        checkout scm
+        jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
+        jenkinsfile.testBuild()
+    }
+}
+jenkinsfile.run_parallel_tests()

--- a/buildenv/jenkins/openjdk_ppc64_linux
+++ b/buildenv/jenkins/openjdk_ppc64_linux
@@ -1,0 +1,20 @@
+#!groovy
+
+
+if (params.DOCKER_REQUIRED) {
+    LABEL='ci.role.test&&hw.arch.ppc64&&sw.os.linux&&sw.tool.docker'
+} else {
+    LABEL='ci.role.test&&hw.arch.ppc64&&sw.os.linux'
+}
+
+stage('Queue') {
+    node((params.LABEL) ? params.LABEL : LABEL) {
+        PLATFORM = 'ppc64_linux'
+        SDK_RESOURCE = 'upstream'
+        SPEC='linux_ppc-64_cmprssptrs'
+        checkout scm
+        jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
+        jenkinsfile.testBuild()
+    }
+}
+jenkinsfile.run_parallel_tests()

--- a/buildenv/jenkins/openjdk_ppc64_linux_xl
+++ b/buildenv/jenkins/openjdk_ppc64_linux_xl
@@ -1,0 +1,20 @@
+#!groovy
+
+
+if (params.DOCKER_REQUIRED) {
+    LABEL='ci.role.test&&hw.arch.ppc64&&sw.os.linux&&sw.tool.docker'
+} else {
+    LABEL='ci.role.test&&hw.arch.ppc64&&sw.os.linux'
+}
+
+stage('Queue') {
+    node((params.LABEL) ? params.LABEL : LABEL) {
+        PLATFORM = 'ppc64_linux_largeHeap'
+        SDK_RESOURCE = 'upstream'
+        SPEC='linux_ppc-64'
+        checkout scm
+        jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
+        jenkinsfile.testBuild()
+    }
+}
+jenkinsfile.run_parallel_tests()


### PR DESCRIPTION
Add groovy scripts to test the following platforms:
- Linux PPC 32 bits
- Linux PPC 64 bits
- Linux PPC 64 bits Large Heap

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>