### PR TITLE
Enable CS testing on OSX

### DIFF
--- a/system/daaLoadTest/playlist.xml
+++ b/system/daaLoadTest/playlist.xml
@@ -137,7 +137,7 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
-		<platformRequirements>bits.64,^arch.arm,^os.osx</platformRequirements>
+		<platformRequirements>bits.64,^arch.arm</platformRequirements>
 	</test>
 	
 	<test>
@@ -162,7 +162,7 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
-		<platformRequirements>bits.64,^arch.arm,^os.osx</platformRequirements>
+		<platformRequirements>bits.64,^arch.arm</platformRequirements>
 	</test>
 	
 	<test>
@@ -187,7 +187,7 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
-		<platformRequirements>bits.64,^arch.arm,^os.osx</platformRequirements>
+		<platformRequirements>bits.64,^arch.arm</platformRequirements>
 	</test>
 	
 	<test>
@@ -211,7 +211,7 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
-		<platformRequirements>bits.64,^arch.arm,^os.osx</platformRequirements>
+		<platformRequirements>bits.64,^arch.arm</platformRequirements>
 	</test>
 	
 	<test>

--- a/system/lambdaLoadTest/playlist.xml
+++ b/system/lambdaLoadTest/playlist.xml
@@ -133,7 +133,7 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
-		<platformRequirements>bits.64,^arch.arm,^os.osx</platformRequirements>
+		<platformRequirements>bits.64,^arch.arm</platformRequirements>
 	</test>
 	
 	<test>

--- a/system/mathLoadTest/playlist.xml
+++ b/system/mathLoadTest/playlist.xml
@@ -102,7 +102,7 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
-		<platformRequirements>bits.64,^arch.arm,^os.osx</platformRequirements>
+		<platformRequirements>bits.64,^arch.arm</platformRequirements>
 	</test>
 	
 	<test>
@@ -127,7 +127,7 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
-		<platformRequirements>bits.64,^arch.arm,^os.osx</platformRequirements>
+		<platformRequirements>bits.64,^arch.arm</platformRequirements>
 	</test>
 	
 	<test>
@@ -152,7 +152,7 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
-		<platformRequirements>bits.64,^arch.arm,^os.osx</platformRequirements>
+		<platformRequirements>bits.64,^arch.arm</platformRequirements>
 	</test>
 	
 	<test>

--- a/system/mauveLoadTest/playlist.xml
+++ b/system/mauveLoadTest/playlist.xml
@@ -181,7 +181,7 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
-		<platformRequirements>bits.64,^arch.arm,^os.osx</platformRequirements>
+		<platformRequirements>bits.64,^arch.arm</platformRequirements>
 		<disabled>AdoptOpenJDK/openjdk-systemtest/issues/75</disabled>
 	</test>
 	
@@ -206,7 +206,7 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
-		<platformRequirements>bits.64,^arch.arm,^os.osx</platformRequirements>
+		<platformRequirements>bits.64,^arch.arm</platformRequirements>
 		<disabled>AdoptOpenJDK/openjdk-systemtest/issues/78</disabled>
 	</test>
 	
@@ -231,7 +231,7 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
-		<platformRequirements>bits.64,^arch.arm,^os.osx</platformRequirements>
+		<platformRequirements>bits.64,^arch.arm</platformRequirements>
 		<disabled>AdoptOpenJDK/openjdk-systemtest/issues/64</disabled>
 	</test>
 	<!-- The above tests are to be run using concurrentScavenge on z/OS, z/Linux, x/Linux and x/Windows using 64-bit OpenJ9 SDK -->

--- a/system/otherLoadTest/playlist.xml
+++ b/system/otherLoadTest/playlist.xml
@@ -335,6 +335,6 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
-		<platformRequirements>bits.64,^arch.arm,^os.osx</platformRequirements>
+		<platformRequirements>bits.64,^arch.arm</platformRequirements>
 	</test>
 </playlist>


### PR DESCRIPTION
Concurrent Scavenger  tests must be enabled for OSX now that CS has been  enabled for mac (https://github.com/eclipse/openj9/pull/7728). 

- Remove `^os.osx` from playlist `platformRequirements` so OSX has the  same coverage for testing concurrent scavenge on OSX as x86.

Following Tests enabled:
- `ClassLoadingTest_ConcurrentScavenge`
- `MauveMultiThreadLoadTest_ConcurrentScavenge`
- `MauveSingleThreadLoadTest_ConcurrentScavenge`
- `MauveSingleInvocationLoadTest_ConcurrentScavenge`
- `DaaLoadTest_daa1_ConcurrentScavenge`
- `DaaLoadTest_daa2_ConcurrentScavenge`
- `DaaLoadTest_daa3_ConcurrentScavenge`
- `DaaLoadTest_all_ConcurrentScavenge`
- `LambdaLoadTest_ConcurrentScavenge`
- `MathLoadTest_all_ConcurrentScavenge`
- `MathLoadTest_autosimd_ConcurrentScavenge`
- `MathLoadTest_bigdecimal_ConcurrentScavenge`

Signed-off-by: Salman Rana <salman.rana@ibm.com>