### PR TITLE
Support checkout specific openjdk commit

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -82,6 +82,10 @@ def setupEnv() {
 	if( params.RELEASE_TAG ) {
 		env.RELEASE_TAG = params.RELEASE_TAG
 	}
+	// Optional parameter RELEASE_TAG and it is only used in openjdk regression test
+	if( params.OPENJDK_SHA) {
+		env.OPENJDK_SHA = params.OPENJDK_SHA
+	}
 	if( params.DOCKERIMAGE_TAG ) {
 		env.DOCKERIMAGE_TAG = params.DOCKERIMAGE_TAG
 	}

--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -156,6 +156,7 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							booleanParam('AUTO_DETECT', true, "Optional. Default is to enable AUTO_DETECT")
 							stringParam('TIME_LIMIT', TIME_LIMIT, "time limit")
 							stringParam('RELEASE_TAG', "", "SCM tag from which to run tests")
+							stringParam('OPENJDK_SHA', "", "OpenJDK SHA from which to run tests")
 						}
 						cpsScm {
 							scm {

--- a/openjdk/build.xml
+++ b/openjdk/build.xml
@@ -87,9 +87,11 @@
 		<if>
 			<isset property="env.RELEASE_TAG"/>
 			<then>
+				<echo message="git clone --depth 1 -q -b ${env.RELEASE_TAG} ${regressionRepo}" />
 				<exec executable="git" failonerror="true">
 					<arg line="clone --depth 1 -q -b ${env.RELEASE_TAG} ${regressionRepo}" />
 				</exec>
+				<move file="${jdkName}" tofile="openjdk-jdk"/>
 			</then>
 			<else>
 				<if>
@@ -101,13 +103,28 @@
 						<property name="defaultBranch" value=""/>
 					</else>
 				</if>
-				<echo message="git clone --depth 1 -q ${defaultBranch} ${regressionRepo}" />
-				<exec executable="git" failonerror="true">
-					<arg line="clone --depth 1 -q ${defaultBranch} ${regressionRepo}" />
-				</exec>
+				<if>
+					<isset property="env.OPENJDK_SHA"/>
+					<then>
+						<echo message="git clone -q ${defaultBranch} ${regressionRepo}" />
+						<exec executable="git" failonerror="true">
+							<arg line="clone -q ${defaultBranch} ${regressionRepo}" />
+						</exec>
+						<move file="${jdkName}" tofile="openjdk-jdk"/>
+						<exec executable="git" failonerror="true" dir="openjdk-jdk">
+							<arg line="checkout ${env.OPENJDK_SHA}" />
+						</exec>
+					</then>
+					<else>
+						<echo message="git clone --depth 1 -q ${defaultBranch} ${regressionRepo}" />
+						<exec executable="git" failonerror="true">
+							<arg line="clone --depth 1 -q ${defaultBranch} ${regressionRepo}" />
+						</exec>
+						<move file="${jdkName}" tofile="openjdk-jdk"/>
+					</else>
+				</if>
 			</else>
 		</if>
-		<move file="${jdkName}" tofile="openjdk-jdk"/>
 		<checkGitRepoSha repoDir="openjdk-jdk" />
 	</target>
 	

--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -103,7 +103,7 @@ JDK_NATIVE_OPTIONS :=
 JVM_NATIVE_OPTIONS :=
 CUSTOM_NATIVE_OPTIONS :=
 
-ifneq ($(JDK_VERSION),8))
+ifneq ($(JDK_VERSION),8)
 	ifdef TESTIMAGE_PATH
 		JDK_NATIVE_OPTIONS := -nativepath:"$(TESTIMAGE_PATH)$(D)jdk$(D)jtreg$(D)native"
 		ifeq ($(JDK_IMPL), hotspot)


### PR DESCRIPTION
There is possibility that PR is merged into openjdk repo at the gap between jdk build and jdk test build, which makes source and test code inconsistent and might cause test failure.

This PR makes sure test build can checkout specific commit. Hence be consistent with source build.

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>