### PR TITLE
Limit multiple builds to release or nightly source

### DIFF
--- a/buildenv/jenkins/testpipeline.groovy
+++ b/buildenv/jenkins/testpipeline.groovy
@@ -72,6 +72,13 @@ node('master') {
 				}
 				//SUFFIX = nightly, releases, personal, prtest
 				SUFFIX = '_personal'
+				if (JDK_VERSIONS.size() > 1 || JDK_IMPLS.size() > 1 || ARCH_OS_LIST.size() >1) {
+					if (SDK_RESOURCE != 'nightly' && SDK_RESOURCE != 'release') {
+						error("If grinder with multiple SDKs please set SDK_RESOURCE nightly or release")
+						exit
+					}
+				}
+				
 			}
 			checkout scm
 			ARCH_OS_LIST.each { ARCH_OS ->


### PR DESCRIPTION
Release or nightly source supports multiple SDKs

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>