### PR TITLE
Add test commandline to the output of failed tests in jck reporting

### DIFF
--- a/jck/xUnit.xsl
+++ b/jck/xUnit.xsl
@@ -39,10 +39,10 @@
 		<xsl:for-each select="//TestResult">
 			<xsl:element name="testcase">
 				<xsl:attribute name="classname"> 
-					<xsl:value-of select="DescriptionData/Property[@name='executeClass']/@value"/>
+					<xsl:value-of select="@url"/>
 				</xsl:attribute>
 				<xsl:attribute name="name"> 
-					<xsl:value-of select="DescriptionData/Property[@name='title']/@value"/>
+					<xsl:value-of select="DescriptionData/Property[@name='executeClass']/@value"/>
 				</xsl:attribute>
 				<xsl:attribute name="time"> 
 					<xsl:value-of select="format-number(ResultProperties/Property[@name='totalTime']/@value div 1000, '###,###.000')"/>
@@ -53,7 +53,8 @@
 				<xsl:variable name="failureCount" select="count(Sections/Section[@status='FAILED'])"/>
 				 <xsl:choose>
 					<xsl:when test="$failureCount > 0">
-						<xsl:element name="failure">  
+						<xsl:element name="failure">
+							<xsl:value-of select="Sections/Section[@status='FAILED']/Output[@title='messages']"/>
 							<xsl:value-of select="Sections/Section[@status='FAILED']/Output[@title='out1']"/>
 						</xsl:element>
 					</xsl:when>


### PR DESCRIPTION
- Updates xUnit xslt script to print out test path (url) in the junit output
- Also prints command line to reproduce the failed test - this will allow users to not have to download the output zip and look into .jtr file to find the command line to execute. 
- Related to backlog/issues/187

Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>