### PR TITLE
Run double map test on all Linux 64bit machines

### DIFF
--- a/functional/SyntheticGCWorkload/playlist.xml
+++ b/functional/SyntheticGCWorkload/playlist.xml
@@ -155,7 +155,7 @@
         cd $(TEST_RESROOT); \
         $(JAVA_COMMAND) $(JVM_OPTIONS) -cp $(Q)$(TEST_RESROOT)$(D)SyntheticGCWorkload.jar$(Q) net.adoptopenjdk.casa.workload_sessions.Main config/config_doubleMapStress.xml -n; \
         ${TEST_STATUS}</command>
-                <platformRequirements>arch.x86,bits.64,os.linux</platformRequirements>
+                <platformRequirements>bits.64,os.linux</platformRequirements>
                 <levels>
                         <level>extended</level>
                 </levels>


### PR DESCRIPTION
Modify the playlist to run the double map test on all Linux 64bit machines

Signed-off-by: Andre Ha <Andre.Ha@ibm.com>