### PR TITLE
Add cleanWs() calls in zos jenkins metadata files

### DIFF
--- a/buildenv/jenkins/openjdk_s390_zos
+++ b/buildenv/jenkins/openjdk_s390_zos
@@ -14,6 +14,7 @@ stage('Queue') {
         def gitConfig = scm.getUserRemoteConfigs()[0]
         def SCM_GIT_REPO = gitConfig.getUrl()
         def SCM_GIT_BRANCH = scm.branches[0].name
+        cleanWs()
         sh "git clone -b ${SCM_GIT_BRANCH} ${SCM_GIT_REPO} openjdk-tests"
         jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
         jenkinsfile.testBuild()

--- a/buildenv/jenkins/openjdk_s390x_zos
+++ b/buildenv/jenkins/openjdk_s390x_zos
@@ -14,6 +14,7 @@ stage('Queue') {
         def gitConfig = scm.getUserRemoteConfigs()[0]
         def SCM_GIT_REPO = gitConfig.getUrl()
         def SCM_GIT_BRANCH = scm.branches[0].name
+        cleanWs()
         sh "git clone -b ${SCM_GIT_BRANCH} ${SCM_GIT_REPO} openjdk-tests"
         jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
         jenkinsfile.testBuild()

--- a/buildenv/jenkins/openjdk_s390x_zos_xl
+++ b/buildenv/jenkins/openjdk_s390x_zos_xl
@@ -14,6 +14,7 @@ stage('Queue') {
         def gitConfig = scm.getUserRemoteConfigs()[0]
         def SCM_GIT_REPO = gitConfig.getUrl()
         def SCM_GIT_BRANCH = scm.branches[0].name
+        cleanWs()
         sh "git clone -b ${SCM_GIT_BRANCH} ${SCM_GIT_REPO} openjdk-tests"
         jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
         jenkinsfile.testBuild()


### PR DESCRIPTION
- Add cleanWs() calls in zos jenkins metadata files, as on z/OS, the `checkout scm` command doesn't clean workspace before checkout, unlike other platforms. 

FYI @AdamBrousseau 

Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>