### PR TITLE
Increase timeout and add reference repository for git clone in job DSL

### DIFF
--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -169,6 +169,10 @@ ARCH_OS_LIST.each { ARCH_OS ->
 										relativeTargetDirectory('openjdk-tests')
 										cleanBeforeCheckout()
 										pruneStaleBranch()
+										cloneOptions {
+											reference('$HOME/openjdk_cache')
+											timeout(60)
+										}
 									}
 								}
 								scriptPath("buildenv/jenkins/openjdk_${ARCH_OS}")


### PR DESCRIPTION
Add cloneOptions to git extensions:
- Increase timeout form 10 to 60 minutes
- Set reference repository

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>