### PR TITLE
Updated Derby Test Dockerfile

### DIFF
--- a/external/derby/dockerfile/Dockerfile
+++ b/external/derby/dockerfile/Dockerfile
@@ -29,7 +29,7 @@ ARG IMAGE_VERSION=latest
 FROM $IMAGE_NAME:$IMAGE_VERSION
 
 # Install test dependent executable files
-RUN    apt-get update; \
+RUN apt-get update; \
     apt-get install -y --no-install-recommends \
         git \
         wget \

--- a/external/derby/dockerfile/Dockerfile
+++ b/external/derby/dockerfile/Dockerfile
@@ -22,26 +22,35 @@
 #
 # Build example: `docker build --build-arg IMAGE_NAME=<image_name> --build-arg IMAGE_VERSION=<image_version >-t adoptopenjdk-derby-test .`
 
-ARG SDK=openjdk8
+ARG SDK=openjdk9
 ARG IMAGE_NAME=adoptopenjdk/$SDK
 ARG IMAGE_VERSION=latest
 
 FROM $IMAGE_NAME:$IMAGE_VERSION
 
 # Install test dependent executable files
-RUN apt-get update \
-	&& apt-get -y install \
-	apt-transport-https \
-	ca-certificates \
-	dirmngr \
-	curl \
-	git \
-	make \
-	unzip \
-	vim \
-	tar \
-	wget \
-	ant
+RUN    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        git \
+        wget \
+        tar \
+    ; \
+    rm -rf /var/lib/apt/lists/*
+
+ENV ANT_VERSION=1.10.6
+ENV ANT_HOME=/opt/ant
+
+# Install Ant
+RUN wget --no-check-certificate --no-cookies http://archive.apache.org/dist/ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.gz \
+    && wget --no-check-certificate --no-cookies http://archive.apache.org/dist/ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.gz.sha512 \
+    && echo "$(cat apache-ant-${ANT_VERSION}-bin.tar.gz.sha512) apache-ant-${ANT_VERSION}-bin.tar.gz" | sha512sum -c \
+    && tar -zvxf apache-ant-${ANT_VERSION}-bin.tar.gz -C /opt/ \
+    && ln -s /opt/apache-ant-${ANT_VERSION} /opt/ant \
+    && rm -f apache-ant-${ANT_VERSION}-bin.tar.gz \
+    && rm -f apache-ant-${ANT_VERSION}-bin.tar.gz.sha512
+
+# Add Ant to PATH
+ENV PATH ${PATH}:${ANT_HOME}/bin
 
 ENV  JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
 
@@ -52,7 +61,7 @@ ENV DERBY_HOME ${WORKDIR}/derby
 COPY ./dockerfile/derby-test.sh /derby-test.sh
 
 # Clone Derby source.
-RUN git clone https://github.com/apache/derby.git 
+RUN git clone https://github.com/apache/derby.git
 
 ENTRYPOINT ["/bin/bash", "/derby-test.sh"]
 CMD ["--version"]


### PR DESCRIPTION
I was running into this error on the old Dockerfile:

```
Using docker image default Java
Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF8
openjdk version "1.8.0_222"
OpenJDK Runtime Environment (AdoptOpenJDK)(build 1.8.0_222-b10)
OpenJDK 64-Bit Server VM (AdoptOpenJDK)(build 25.222-b10, mixed mode)
Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF8
openjdk version "1.8.0_222"
OpenJDK Runtime Environment (AdoptOpenJDK)(build 1.8.0_222-b10)
OpenJDK 64-Bit Server VM (AdoptOpenJDK)(build 25.222-b10, mixed mode)
/derby
Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF8
Buildfile: /derby/build.xml

clean:

cleangenerated:

cleanstate:

cleanreleasefiles:

clobber:

BUILD SUCCESSFUL
Total time: 0 seconds
Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF8
Buildfile: /derby/build.xml

checkCompilerLevel:

BUILD FAILED
/derby/build.xml:211: Compiler level must be Java 9 or later.

Total time: 0 seconds
Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF8
Buildfile: /derby/build.xml

version_check:

BUILD FAILED
/derby/build.xml:94: FATAL ERROR:  The running Ant version, 1.10.5, is too old.

Total time: 0 seconds
```

So I went ahead a revamped the Dockerfile to fix the errors. I bumped the default SDK to Java 9 and bumped the Ant version to `1.10.6`. On Ubuntu Ant did not have a package version of `1.10.6`, so I switched to manually installing it. 

I also removed a good number of unneeded packages from the container. 

The only other suggestion I wanted to make is not to pull from `https://github.com/apache/derby.git`. With pulling from this and *not* checking out a certain tag or branch we are tasking for issues down the line. We will continue to hit issues with Java version and Ant version. 

With that being said, I am not 100% sure with that you guys are testing here. So if the idea is to pull from always the latest code on Derby and see the errors maybe we should leave it. @ShelleyLambert can you weight in on this?