### PR TITLE
Locate java executable dynamically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ openjdk/*.gz
 
 /.classpath
 /.project
+/job.properties

--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -283,7 +283,20 @@ def setup() {
 				} else {
 					get_sources()
 				}
+				getJobProperties()
 			}
+		}
+	}
+}
+
+def getJobProperties() {
+	def jobProperties = "./openjdk-tests/job.properties"
+	if (fileExists("${jobProperties}")) {
+		echo "readProperties file: ${jobProperties}"
+		def properties = readProperties file: "${jobProperties}"
+		if (properties.TEST_JDK_HOME) {
+			env.TEST_JDK_HOME = properties.TEST_JDK_HOME
+			echo "Reset TEST_JDK_HOME to ${TEST_JDK_HOME}"
 		}
 	}
 }

--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -77,7 +77,7 @@ JTREG_BASIC_OPTIONS += $(EXTRA_JTREG_OPTIONS)
 
 ifndef JRE_IMAGE
 	JRE_ROOT := $(TEST_JDK_HOME)
-	JRE_IMAGE := $(JRE_ROOT)$(D)..$(D)j2re-image
+	JRE_IMAGE := $(subst j2sdk-image,j2re-image,$(JRE_ROOT))
 endif
 
 ifdef OPENJDK_DIR 


### PR DESCRIPTION
- change unzip logic to unzip into tmp folder and rename it as needed
because some sdk is packaged with root folder and some does not.
- default TEST_JDK_HOME is $SDKDIR/openjdkbinary/j2sdk-image
- if the script cannot find bin/java under this dir, the script will
search for javac under j2sdk-image (as java may not be unique)
- the script outputs TEST_JDK_HOME value into ${TESTDIR}/job.properties
- Jenkins script reads job.properties and resets env.TEST_JDK_HOME value
- remove the specific code for handling java path on mac
- set JRE_IMAGE path (assuming it has the same structure as JDK)

Resolves: #1462

Signed-off-by: lanxia <lan_xia@ca.ibm.com>