### PR TITLE
Merge all platform specific files into one file

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -29,7 +29,7 @@ def setupEnv() {
 
 	env.SPEC = "${SPEC}"
 
-	JENKINS_FILE = params.JenkinsFile ? params.JenkinsFile : ""
+	PLATFORM = params.PLATFORM ? params.PLATFORM : ""
 	ADOPTOPENJDK_REPO = params.ADOPTOPENJDK_REPO ? params.ADOPTOPENJDK_REPO : (env.SPEC.startsWith('zos') ? "git@github.com:AdoptOpenJDK/openjdk-tests.git" : "https://github.com/AdoptOpenJDK/openjdk-tests.git")
 	ADOPTOPENJDK_BRANCH = params.ADOPTOPENJDK_BRANCH ? params.ADOPTOPENJDK_BRANCH : "master"
 	CLONE_OPENJ9 = params.CLONE_OPENJ9 ? params.CLONE_OPENJ9 : "true"
@@ -171,7 +171,7 @@ def setupParallelEnv() {
 						string(name: 'KEEP_REPORTDIR', value: KEEP_REPORTDIR),
 						string(name: 'EXTRA_OPTIONS', value: EXTRA_OPTIONS),
 						string(name: 'JVM_OPTIONS', value: JVM_OPTIONS),
-						string(name: 'JenkinsFile', value: JENKINS_FILE),
+						string(name: 'PLATFORM', value: PLATFORM),
 						string(name: 'ITERATIONS', value: "1"),
 						string(name: 'LABEL', value: LABEL),
 						string(name: 'JCK_GIT_REPO', value: JCK_GIT_REPO),
@@ -623,7 +623,7 @@ def addGrinderLink() {
 	+ "JDK_VERSION=${params.JDK_VERSION}" \
 	+ "&JDK_IMPL=${params.JDK_IMPL}" \
 	+ "&BUILD_LIST=${params.BUILD_LIST}" \
-	+ "&JenkinsFile=${params.JenkinsFile}" \
+	+ "&PLATFORM=${params.PLATFORM}" \
 	+ "&TARGET=${params.TARGET}" \
 	+ "${sdkSourceOpt}${sdkUrlOpt}${sdkUrlCredentialOpt}${customTargetOpt}${upstreamJobNameOpt}${upstreamJobNumOpt}"
 

--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -1,0 +1,146 @@
+#!groovy
+
+def PLATFORM_MAP = [ 
+    'aarch32_linux' : [
+        'SPEC' : 'linux_arm',
+        'LABEL' : 'ci.role.test&&sw.os.linux&&hw.arch.aarch32',
+    ],
+    'aarch64_linux' : [
+        'SPEC' : 'linux_aarch64_cmprssptrs',
+        'LABEL' : 'ci.role.test&&sw.os.linux&&hw.arch.aarch64',
+    ],
+    'aarch64_linux_xl' : [
+        'SPEC' : 'linux_aarch64',
+        'LABEL' : 'ci.role.test&&sw.os.linux&&hw.arch.aarch64',
+    ],
+    'ppc32_aix' : [
+        'SPEC' : 'aix_ppc',
+        'LABEL' : 'ci.role.test&&hw.arch.ppc64&&sw.os.aix',
+    ],
+    'ppc32_linux' : [
+        'SPEC' : 'linux_ppc',
+        'LABEL' : 'ci.role.test&&hw.arch.ppc64&&sw.os.linux',
+    ],
+    'ppc64_aix' : [
+        'SPEC' : 'aix_ppc-64_cmprssptrs',
+        'LABEL' : 'ci.role.test&&hw.arch.ppc64&&sw.os.aix',
+    ],
+    'ppc64_aix_xl' : [
+        'SPEC' : 'aix_ppc-64',
+        'LABEL' : 'ci.role.test&&hw.arch.ppc64&&sw.os.aix',
+    ],
+    'ppc64_linux' : [
+        'SPEC' : 'linux_ppc-64_cmprssptrs',
+        'LABEL' : 'ci.role.test&&hw.arch.ppc64&&sw.os.linux',
+    ],
+    'ppc64_linux_xl' : [
+        'SPEC' : 'linux_ppc-64',
+        'LABEL' : 'ci.role.test&&hw.arch.ppc64&&sw.os.linux',
+    ],
+    'ppc64le_linux' : [
+        'SPEC' : 'linux_ppc-64_cmprssptrs_le',
+        'LABEL' : 'ci.role.test&&hw.arch.ppc64le&&sw.os.linux',
+    ],
+    'ppc64le_linux_xl' : [
+        'SPEC' : 'linux_ppc-64_le',
+        'LABEL' : 'ci.role.test&&hw.arch.ppc64le&&sw.os.linux',
+    ],
+    's390_linux' : [
+        'SPEC' : 'linux_390',
+        'LABEL' : 'ci.role.test&&hw.arch.s390x&&sw.os.linux&&hw.bits.32',
+    ],
+    's390_zos' : [
+        'SPEC' : 'zos_390',
+        'LABEL' : 'ci.role.test&&hw.arch.s390x&&sw.os.zos',
+    ],
+    's390x_linux' : [
+        'SPEC' : 'linux_390-64_cmprssptrs',
+        'LABEL' : 'ci.role.test&&hw.arch.s390x&&sw.os.linux',
+    ],
+    's390x_linux_xl' : [
+        'SPEC' : 'linux_390-64',
+        'LABEL' : 'ci.role.test&&hw.arch.s390x&&sw.os.linux',
+    ],
+    's390x_zos' : [
+        'SPEC' : 'zos_390-64_cmprssptrs',
+        'LABEL' : 'ci.role.test&&hw.arch.s390x&&sw.os.zos',
+    ],
+    's390x_zos_xl' : [
+        'SPEC' : 'zos_390-64',
+        'LABEL' : 'ci.role.test&&hw.arch.s390x&&sw.os.zos',
+    ],
+    'sparcv9_solaris' : [
+        'SPEC' : 'sunos_sparcv9-64_cmprssptrs',
+        'LABEL' : 'ci.role.test&&hw.arch.sparcv9&&sw.os.sunos',
+    ],
+    'x86-32_linux' : [
+        'SPEC' : 'linux_x86',
+        'LABEL' : 'ci.role.test&&hw.arch.x86&&sw.os.linux',
+    ],
+    'x86-32_windows' : [
+        'SPEC' : 'win_x86',
+        'LABEL' : 'ci.role.test&&hw.arch.x86&&sw.os.windows',
+    ],
+    'x86-64_linux' : [
+        'SPEC' : 'linux_x86-64_cmprssptrs',
+        'LABEL' : 'ci.role.test&&hw.arch.x86&&sw.os.linux',
+    ],
+    'x86-64_linux_xl' : [
+        'SPEC' : 'linux_x86-64',
+        'LABEL' : 'ci.role.test&&hw.arch.x86&&sw.os.linux',
+    ],
+    'x86-64_mac' : [
+        'SPEC' : 'osx_x86-64_cmprssptrs',
+        'LABEL' : 'ci.role.test&&hw.arch.x86&&sw.os.osx',
+    ],
+    'x86-64_mac_xl' : [
+        'SPEC' : 'osx_x86-64',
+        'LABEL' : 'ci.role.test&&hw.arch.x86&&sw.os.osx',
+    ],
+    'x86-64_windows' : [
+        'SPEC' : 'win_x86-64_cmprssptrs',
+        'LABEL' : 'ci.role.test&&hw.arch.x86&&sw.os.windows',
+    ],
+    'x86-64_windows_xl' : [
+        'SPEC' : 'win_x86-64',
+        'LABEL' : 'ci.role.test&&hw.arch.x86&&sw.os.windows',
+    ]
+]
+
+
+if (PLATFORM_MAP.containsKey(params.PLATFORM)) {
+    SPEC = PLATFORM_MAP[params.PLATFORM]["SPEC"]
+    LABEL = params.LABEL ? params.LABEL : PLATFORM_MAP[params.PLATFORM]["LABEL"]
+
+    if (params.DOCKER_REQUIRED) {
+        LABEL="${LABEL}&&sw.tool.docker"
+    }
+
+    println "SPEC: ${SPEC}"
+    println "LABEL: ${LABEL}"
+
+    stage('Queue') {
+        node(LABEL) {
+            if (params.PLATFORM.contains('zos')) {
+                /* Ensure correct CC env */
+                env._CC_CCMODE = '1'
+                env._CXX_CCMODE = '1'
+                env._C89_CCMODE = '1'
+
+                def gitConfig = scm.getUserRemoteConfigs()[0]
+                def SCM_GIT_REPO = gitConfig.getUrl()
+                def SCM_GIT_BRANCH = scm.branches[0].name
+                cleanWs()
+                sh "git clone -b ${SCM_GIT_BRANCH} ${SCM_GIT_REPO} openjdk-tests"
+            } else {
+                checkout scm
+            }
+            jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
+            jenkinsfile.testBuild()
+        }
+    }
+    jenkinsfile.run_parallel_tests()
+} else {
+	println "Cannot find key PLATFORM: ${params.PLATFORM} in PLATFORM_MAP: ${PLATFORM_MAP}."
+}
+

--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -126,7 +126,7 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							stringParam('OPENJ9_SHA', "", "OpenJ9 sha")
 							stringParam('JDK_VERSION', "${JDK_VERSION}", "JDK version. i.e., 8, 11")
 							stringParam('JDK_IMPL', JDK_IMPL, "JDK implementation, e.g. hotspot, openj9, sap")
-							stringParam('JenkinsFile', "openjdk_${ARCH_OS}", "Jenkins file to be used")
+							stringParam('PLATFORM', "${ARCH_OS}", "Platform to be tested")
 							stringParam('BUILD_LIST', BUILD_LIST, "Specific test directory to compile, set blank for all projects to be compiled")
 							stringParam('TARGET', "${LEVEL}.${GROUP}", "Test TARGET to execute")
 							stringParam('CUSTOM_TARGET', "", "Only used when the custom target is specified in TARGET , e.g. jdk_custom, langtools_custom, etc., CUSTOM_TARGET=path to the test class to execute")
@@ -180,7 +180,7 @@ ARCH_OS_LIST.each { ARCH_OS ->
 										}
 									}
 								}
-								scriptPath("buildenv/jenkins/openjdk_${ARCH_OS}")
+								scriptPath("buildenv/jenkins/openjdk_tests")
 								lightweight(true)
 							}
 						}

--- a/buildenv/jenkins/upstream_openjdk_tests
+++ b/buildenv/jenkins/upstream_openjdk_tests
@@ -21,11 +21,11 @@ class ReleaseContext implements Serializable {
     }
 
     public String toString() {
-        return "$ARCH-$OS: $JDK_URL $JRE_URL " + ( TESTIMAGE_URL == null ? "" : " $TESTIMAGE_URL " ) + "$SOURCE_URL ${getJenkinsFile()}";
+        return "$ARCH-$OS: $JDK_URL $JRE_URL " + ( TESTIMAGE_URL == null ? "" : " $TESTIMAGE_URL " ) + "$SOURCE_URL ${getPlatform()}";
     }
 
-    public String getJenkinsFile() {
-        return "openjdk_" + getMappedArch() + "_" + OS;
+    public String getPlatform() {
+        return getMappedArch() + "_" + OS;
     }
 
     public String getMappedArch() {
@@ -267,7 +267,7 @@ node("ci.role.test&&hw.arch.x86&&sw.os.linux") {
                                 def jdk_url = r.JDK_URL
                                 def source_url = r.SOURCE_URL
                                 def jdk_version = version
-                                def jenkins_file = r.getJenkinsFile()
+                                def platform = r.getPlatform()
                                 def jdk_jre_url = "$r.JDK_URL $r.JRE_URL" + ( r.TESTIMAGE_URL == null ? "" : " $r.TESTIMAGE_URL" )
                                 def mapped_arch = r.getMappedArch()
                                 def target = testsTargetBuildList.get(testname).get("target")
@@ -276,7 +276,7 @@ node("ci.role.test&&hw.arch.x86&&sw.os.linux") {
                                 parallelJobs[job_branch_name] = {
                                     // Run a _sanity.openjdk test job with appropriate parameters
                                     build job: job_branch_name, parameters: [
-                                        string(name: 'JenkinsFile', value: jenkins_file),
+                                        string(name: 'PLATFORM', value: platform),
                                         string(name: 'JDK_IMPL', value: "hotspot"),
                                         // needs to be passed for 11 as default is 8, causing conflicts with AUTO_DETECT
                                         string(name: 'JDK_VERSION', value: jdk_version),

--- a/get.sh
+++ b/get.sh
@@ -178,12 +178,18 @@ getBinaryOpenjdk()
 		fi
 	elif [ "$SDK_RESOURCE" == "nightly" ] || [ "$SDK_RESOURCE" == "releases" ]; then
 		os=${PLATFORM#*_}
-		os=${os%_largeHeap}
+		os=${os%_xl}
 		arch=${PLATFORM%%_*}
 		OPENJDK_VERSION="openjdk${JDK_VERSION}"
 		heap_size="normal"
-		if [[ $PLATFORM = *"largeHeap"* ]]; then
+		if [[ $PLATFORM = *"_xl"* ]]; then
 			heap_size="large"
+		fi
+		if [[ $arch = *"x86-64"* ]]; then
+			arch="x64"
+		fi
+		if [[ $arch = *"x86-32"* ]]; then
+			arch="x32"
 		fi
 		download_url="https://api.adoptopenjdk.net/v2/binary/${SDK_RESOURCE}/${OPENJDK_VERSION}?openjdk_impl=${JDK_IMPL}&os=${os}&arch=${arch}&release=${RELEASES}&type=${TYPE}&heap_size=${heap_size}"
 	else


### PR DESCRIPTION
- PLATFORM_MAP contains all platform specific information (i.e., SPEC
and LABEL)
- Rename JENKINS_FILE to PLATFORM and remove prepended openjdk_ in the
original JENKINS_FILE value. For example, PLATFORM value is x86-64_linux
instead of openjdk_x86-64_linux
- Original PLATFORM parameter is removed

Signed-off-by: lanxia <lan_xia@ca.ibm.com>