### PR TITLE
Remove Java Version Constraint for BumbleBench

### DIFF
--- a/perf/bumbleBench/playlist.xml
+++ b/perf/bumbleBench/playlist.xml
@@ -18,11 +18,7 @@
 	<test>
 		<testCaseName>bumbleBench-ArrayListForEachConsumerAnonymousBench</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar ArrayListForEachConsumerAnonymousBench; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -33,11 +29,7 @@
 	<test>
 		<testCaseName>bumbleBench-ArrayListForEachConsumerFinalBench</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar ArrayListForEachConsumerFinalBench; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -48,11 +40,7 @@
 	<test>
 		<testCaseName>bumbleBench-ArrayListForEachLambdaBench</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar ArrayListForEachLambdaBench; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -63,11 +51,7 @@
 	<test>
 		<testCaseName>bumbleBench-ArrayListForEachTradBench</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar ArrayListForEachTradBench; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -78,11 +62,7 @@
 	<test>
 		<testCaseName>bumbleBench-ArrayListRemoveIfLambdaBench</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar ArrayListRemoveIfLambdaBench; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -93,11 +73,7 @@
 	<test>
 		<testCaseName>bumbleBench-ArrayListRemoveIfTradBench</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar ArrayListRemoveIfTradBench; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -108,11 +84,7 @@
 	<test>
 		<testCaseName>bumbleBench-ArrayListSortCollectionsBench</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar ArrayListSortCollectionsBench; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -123,11 +95,7 @@
 	<test>
 		<testCaseName>bumbleBench-ArrayListSortComparatorBench</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar ArrayListSortComparatorBench; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -138,11 +106,7 @@
 	<test>
 		<testCaseName>bumbleBench-ArrayListSortLambdaBench</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar ArrayListSortLambdaBench; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -153,11 +117,7 @@
 	<test>
 		<testCaseName>bumbleBench-HashMapForEachBiConsumerAnonymousBench</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar HashMapForEachBiConsumerAnonymousBench; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -168,11 +128,7 @@
 	<test>
 		<testCaseName>bumbleBench-HashMapForEachBiConsumerFinalBench</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar HashMapForEachBiConsumerFinalBench; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -183,11 +139,7 @@
 	<test>
 		<testCaseName>bumbleBench-HashMapForEachLambdaBench</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar HashMapForEachLambdaBench; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -198,11 +150,7 @@
 	<test>
 		<testCaseName>bumbleBench-HashMapForEachTradBench</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar HashMapForEachTradBench; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -213,11 +161,7 @@
 	<test>
 		<testCaseName>bumbleBench-HashMapReplaceAllLambdaBench</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar HashMapReplaceAllLambdaBench; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -228,11 +172,7 @@
 	<test>
 		<testCaseName>bumbleBench-HashMapReplaceAllTradBench</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar HashMapReplaceAllTradBench; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -244,11 +184,7 @@
 	<test>
 		<testCaseName>bumbleBench-CipherBench</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar CipherBench; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -259,11 +195,7 @@
 	<test>
 		<testCaseName>bumbleBench-DigestBench</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar DigestBench; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -275,11 +207,7 @@
 	<test>
 		<testCaseName>bumbleBench-EllipticCurveBench</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar EllipticCurveBench; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -290,11 +218,7 @@
 	<test>
 		<testCaseName>bumbleBench-GCMBench</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar GCMBench; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -305,11 +229,7 @@
 	<test>
 		<testCaseName>bumbleBench-HMACBench</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar HMACBench; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -321,11 +241,7 @@
 	<test>
 		<testCaseName>bumbleBench-KeyExchangeBench</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar KeyExchangeBench; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -336,11 +252,7 @@
 	<test>
 		<testCaseName>bumbleBench-RSABench</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar RSABench; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -351,11 +263,7 @@
 	<test>
 		<testCaseName>bumbleBench-SignatureBench</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar SignatureBench; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -366,11 +274,7 @@
 	<test>
 		<testCaseName>bumbleBench-SSLSocketBench</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar SSLSocketBench; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -383,11 +287,7 @@
 	<test>
 		<testCaseName>bumbleBench-BitonicBench-CPU</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar BitonicBench.CPU; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -398,11 +298,7 @@
 	<test>
 		<testCaseName>bumbleBench-BitonicBench-GPULambda</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar BitonicBench.GPULambda; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -413,11 +309,7 @@
 	<test>
 		<testCaseName>bumbleBench-DoitgenBench-CPU</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar DoitgenBench.CPU; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -429,10 +321,6 @@
 		<testCaseName>bumbleBench-DoitgenBench-GPULambda</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar DoitgenBench.GPULambda; \
 		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>
 		<impls>
 			<impl>openj9</impl> <!-- Issue for JDK 11 HotSpot: https://github.com/AdoptOpenJDK/openjdk-build/issues/1348 -->
 		</impls>				
@@ -446,11 +334,7 @@
 	<test>
 		<testCaseName>bumbleBench-KmeansBench-CPU</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar KmeansBench.CPU; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -461,11 +345,7 @@
 	<test>
 		<testCaseName>bumbleBench-KmeansBench-GPULambda</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar KmeansBench.GPULambda; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -476,11 +356,7 @@
 	<test>
 		<testCaseName>bumbleBench-MatMultBench-CPU</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar MatMultBench.CPU; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -491,11 +367,7 @@
 	<test>
 		<testCaseName>bumbleBench-MatMultBench-GPULambda</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar MatMultBench.GPULambda; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -508,10 +380,6 @@
 		<testCaseName>bumbleBench-DispatchBench-InnerClasses</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar DispatchBench.InnerClasses; \
 		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>
 		<impls>
 			<impl>openj9</impl> <!-- Issue for JDK 11 HotSpot: https://github.com/AdoptOpenJDK/bumblebench/issues/14 -->
 		</impls>		
@@ -525,11 +393,7 @@
 	<test>
 		<testCaseName>bumbleBench-FibBench-Vanilla</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar FibBench.Vanilla; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -540,11 +404,7 @@
 	<test>
 		<testCaseName>bumbleBench-FibBench-InnerClass</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar FibBench.InnerClass; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -555,11 +415,7 @@
 	<test>
 		<testCaseName>bumbleBench-FibBench-Lambda</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar FibBench.Lambda; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -570,11 +426,7 @@
 	<test>
 		<testCaseName>bumbleBench-FibBench-LocalLambda</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar FibBench.LocalLambda; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -585,11 +437,7 @@
 	<test>
 		<testCaseName>bumbleBench-FibBench-DynamicLambda</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar FibBench.DynamicLambda; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -600,11 +448,7 @@
 	<test>
 		<testCaseName>bumbleBench-FibBench-LocalMethodReferences</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar FibBench.LocalMethodReferences; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -615,11 +459,7 @@
 	<test>
 		<testCaseName>bumbleBench-GroupingBench-Serial</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar GroupingBench.Serial; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -630,11 +470,7 @@
 	<test>
 		<testCaseName>bumbleBench-GroupingBench-Parallel</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar GroupingBench.Parallel; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -645,11 +481,7 @@
 	<test>
 		<testCaseName>bumbleBench-SieveBench</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar SieveBench; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -661,11 +493,7 @@
 	<test>
 		<testCaseName>bumbleBench-ExactBench</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar ExactBench; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -676,11 +504,7 @@
 	<test>
 		<testCaseName>bumbleBench-SIMDDoubleMaxMinBench</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar SIMDDoubleMaxMinBench; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -692,11 +516,7 @@
 	<test>
 		<testCaseName>bumbleBench-StringConversionBench</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar StringConversionBench; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -707,11 +527,7 @@
 	<test>
 		<testCaseName>bumbleBench-StringHashBench</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar StringHashBench; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>
@@ -722,11 +538,7 @@
 	<test>
 		<testCaseName>bumbleBench-StringIndexOfBench</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar StringIndexOfBench; \
-		$(TEST_STATUS)</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>11</subset>
-		</subsets>		
+		$(TEST_STATUS)</command>		
 		<levels>
 			<level>special</level>
 		</levels>


### PR DESCRIPTION
•  Enabled BumbleBench to run for all Java versions:
	○ Earlier, BB could not build for Java 12 and up due to https://github.com/AdoptOpenJDK/bumblebench/issues/17

Related Issues:
https://github.com/AdoptOpenJDK/openjdk-tests/issues/1379
https://github.com/AdoptOpenJDK/openjdk-tests/issues/1541

Signed-off-by: Piyush Gupta <piyush286@gmail.com>