### PR TITLE
Fix capture of quarkus test exit code

### DIFF
--- a/external/quarkus/dockerfile/quarkus-test.sh
+++ b/external/quarkus/dockerfile/quarkus-test.sh
@@ -1,4 +1,5 @@
 #/bin/bash
+
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -10,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 # Set up Java to be used by the the quarkus-test
 
@@ -44,10 +44,8 @@ cd /quarkus
 pwd
 echo "Compile and run quarkus tests"
 
-test_exit_code=0
 ./mvnw -DargLine="-Djava.util.logging.manager=org.jboss.logmanager.LogManager" -pl '!:quarkus-documentation' clean install
-if [ $? -ne 0 ]; then
-	test_exit_code=$?
-fi
+test_exit_code=$?
+
 find ./ -type d -name 'surefire-reports' -exec cp -r "{}" /testResults \;
 exit $test_exit_code


### PR DESCRIPTION
The sequence below will always yield `X=0`:
```
  X=0
  some-command
  if [ $? -ne 0 ] ; then
    X=$?
  fi
```
If `some-command` succeeds, the 'if' body won't execute.
If `some-command` fails, `[` will succeed, setting `$?` to 0.

This fixes that for running quarkus testing.