### PR TITLE
Update double mapping option for SyntheticGCWorkload_DoubleMap_J9

### DIFF
--- a/functional/SyntheticGCWorkload/playlist.xml
+++ b/functional/SyntheticGCWorkload/playlist.xml
@@ -149,7 +149,7 @@
 	<test>
                 <testCaseName>SyntheticGCWorkload_DoubleMap_J9</testCaseName>
                 <variations>
-                        <variation>-Xmx2g -Xms2g -Xdump:none -Xgcpolicy:balanced -verbose:gc -XXgc:enableDoubleMapping</variation>
+                        <variation>-Xmx2g -Xms2g -Xdump:none -Xgcpolicy:balanced -verbose:gc</variation>
                 </variations>
                 <command>mkdir -p $(REPORTDIR); \
         cd $(TEST_RESROOT); \


### PR DESCRIPTION
Remove double mapping command line option since double mapping is 
enabled by default

Related to issue: https://github.com/eclipse/openj9/issues/8349

Signed-off-by: Igor Braga <higorb1@gmail.com>