### PR TITLE
Update External functional-test

### DIFF
--- a/external/functional-test/dockerfile/Dockerfile
+++ b/external/functional-test/dockerfile/Dockerfile
@@ -39,17 +39,10 @@ RUN apt-get update \
 	apt-transport-https \
 	ca-certificates \
 	dirmngr \
-	curl \
 	git \
 	make \
-	unzip \
-	vim \
 	zip \
-	wget \
-	gcc \
-	libtext-csv-perl \
-	libjson-perl \
-	libxml-parser-perl
+	wget
 
 ENV  JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
 
@@ -58,14 +51,8 @@ COPY ./dockerfile/functional-test.sh /functional-test.sh
 
 # Clone the repo where the functional tests reside. 
 WORKDIR /
-RUN pwd
 
-# Clone OpenJ9 functional test repo
-RUN git clone https://github.com/eclipse/openj9.git
-
-WORKDIR /openj9/test/
-#Clone TKG
-RUN git clone https://github.com/AdoptOpenJDK/TKG.git
+RUN git clone https://github.com/AdoptOpenJDK/openjdk-tests.git
 
 ENTRYPOINT ["/bin/bash", "/functional-test.sh"]
-CMD ["--version"]
+CMD ["_sanity.functional.regular"]

--- a/external/functional-test/dockerfile/functional-test.sh
+++ b/external/functional-test/dockerfile/functional-test.sh
@@ -28,24 +28,23 @@ else
 fi
 
 export TEST_JDK_HOME=$JAVA_HOME
-
+echo "TEST_JDK_HOME is : $TEST_JDK_HOME"
+export BUILD_LIST=functional
 java -version
 
-TEST_SUITE=$1
+cd /openjdk-tests
+./get.sh -t /openjdk-tests
 
-echo "JAVA_HOME is : $JAVA_HOME"
-
-cd /openj9/test/TKG
+cd /openjdk-tests/TKG
 
 set -e
 # Generate make files 
 echo "Generating make files..."
 make -f run_configure.mk
 
-echo "Building openj9 functional test material..." 
+echo "Building functional test material..." 
 make compile
 
 echo "Running the functional tests" 
-#Run tests
-make _sanity.functional.regular
+make $1
 set +e

--- a/external/functional-test/playlist.xml
+++ b/external/functional-test/playlist.xml
@@ -14,24 +14,45 @@
 -->
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TKG/playlist.xsd">
 	<test>
-		<testCaseName>functional-test</testCaseName>
-		<variations>
-			<variation>-XX:+UseContainerSupport</variation>
-		</variations>
+		<testCaseName>sanity_functional</testCaseName>
 		<command>docker run --name functional-test adoptopenjdk-functional-test:latest ; \
 		 $(TEST_STATUS); \
-		 docker rm -f functional-test; \
-		 docker rmi -f adoptopenjdk-functional-test
+		 docker rm -f sanity_functional; \
+		 docker rmi adoptopenjdk-functional-test
+		 </command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>external</group>
+		</groups>
+	</test>
+		<test>
+		<testCaseName>extended_functional</testCaseName>
+		<command>docker run --name functional-test adoptopenjdk-functional-test:latest _extended.functional.regular; \
+		 $(TEST_STATUS); \
+		 docker rm -f extended_functional; \
+		 docker rmi adoptopenjdk-functional-test
+		 </command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>external</group>
+		</groups>
+	</test>
+	<test>
+		<testCaseName>example_functional</testCaseName>
+		<command>docker run --name example_functional adoptopenjdk-functional-test:latest _testExample; \
+		 $(TEST_STATUS); \
+		 docker rm -f example_functional; \
+		 docker rmi adoptopenjdk-functional-test
 		</command>
-		<subsets>
-			<subset>8</subset>
-			<subset>9</subset>
-		</subsets>
 		<levels>
 			<level>special</level>
 		</levels>
 		<groups>
-			<group>functional</group>
+			<group>external</group>
 		</groups>
 	</test>
 </playlist>


### PR DESCRIPTION
1. Remove unnecessary installation
2. Git clone functional test from adoptopenjdk/openjdk-tests to include
functional tests from adoptopenjdk and openj9
3. Separate tests to sanity, extended and update to external group
4. Add example testcase for PR build as special level

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>