### PR TITLE
If junit test run there should always be test results

### DIFF
--- a/external/elasticsearch/dockerfile/elasticsearch-test.sh
+++ b/external/elasticsearch/dockerfile/elasticsearch-test.sh
@@ -44,13 +44,12 @@ cd /elasticsearch
 set -e
 echo "Building elasticsearch  using gradlew \"gradlew assemble\"" && \
 ./gradlew -q -g /tmp assemble
-
+set +e
 echo "Elasticsearch Build - Successful"
 
 echo "Running elasticsearch tests :"
 
 ./gradlew -q -g /tmp test -Dtests.haltonfailure=false $TEST_OPTIONS
-
-echo "Elasticsearch tests - Successful"
-set +e
+test_exit_code=$?
 find ./ -type d -name 'testJunit' -exec cp -r "{}" /testResults \;
+exit $test_exit_code

--- a/external/jenkins/dockerfile/jenkins-test.sh
+++ b/external/jenkins/dockerfile/jenkins-test.sh
@@ -41,11 +41,11 @@ cd /jenkins
 set -e
 echo "Build jenkins by using mvn \"mvn clean install -pl war -am -DskipTests\"" && \
 mvn --batch-mode clean install -pl war -am -DskipTests -Denforcer.fail=false
-
+set +e
 echo "Building jenkins completed"
 
 echo "Run jenkins test phase alone with cmd: \"mvn surefire:test\"" && \
 mvn --batch-mode surefire:test -Denforcer.fail=false
-set +e
-echo "Executing jenkins tests alone completed"
+test_exit_code=$?
 find ./ -type d -name 'surefire-reports' -exec cp -r "{}" /testResults \;
+exit $test_exit_code

--- a/external/openliberty-mp-tck/dockerfile/openliberty-mp-tck.sh
+++ b/external/openliberty-mp-tck/dockerfile/openliberty-mp-tck.sh
@@ -39,7 +39,7 @@ set -e
 #Build all projects and create the open-liberty image
 ./gradlew -q cnf:initialize
 ./gradlew -q releaseNeeded
-
+set +e
 echo "Build projects and create images done"
 
 #Following are not enabled tests, may need to enable later
@@ -70,5 +70,6 @@ echo "Build projects and create images done"
 ./gradlew -q com.ibm.ws.microprofile.openapi_fat_tck:clean
 ./gradlew -q com.ibm.ws.microprofile.openapi_fat_tck:buildandrun
 
-set +e
+test_exit_code=$?
 find ./ -type d -name 'surefire-reports' -exec cp -r "{}" /testResults \;
+exit $test_exit_code

--- a/external/payara-mp-tck/dockerfile/payara-mp-tck.sh
+++ b/external/payara-mp-tck/dockerfile/payara-mp-tck.sh
@@ -37,7 +37,7 @@ java -version
 TEST_OPTIONS=$1
 
 cd ${PAYARA_HOME}/MicroProfile-TCK-Runners
-set -e
 mvn --batch-mode clean verify -Dpayara.version=5.184 $TEST_OPTIONS
-set +e
+test_exit_code=$?
 find ./ -type d -name 'junitreports' -exec cp -r "{}" /testResults \;
+exit $test_exit_code

--- a/external/thorntail-mp-tck/dockerfile/thorntail-mp-tck.sh
+++ b/external/thorntail-mp-tck/dockerfile/thorntail-mp-tck.sh
@@ -38,12 +38,13 @@ cd ${THORNTAIL_HOME}/
 
 #Build Thorntail 
 cd ${THORNTAIL_HOME}/thorntail/ 
+set -e
 mvn --batch-mode clean install -Pmicroprofile-tck -Dmaven.test.skip=true
+set +e
 echo "build finished"
 
-set -e
 echo "microprofile tck testsuite start"
 mvn --batch-mode test -Pmicroprofile-tck $TEST_OPTIONS
-set +e
-echo "microprofile tck testsuite finish"
+test_exit_code=$?
 find ./ -type d -name 'surefire-reports' -exec cp -r "{}" /testResults \;
+exit $test_exit_code

--- a/external/tomee/dockerfile/tomee-test.sh
+++ b/external/tomee/dockerfile/tomee-test.sh
@@ -40,11 +40,12 @@ cd /tomee
 set -e
 echo "Build TomEE without running test"
 mvn --batch-mode -Pquick -Dsurefire.useFile=false -DdisableXmlReport=true -DuniqueVersion=false -ff -Dassemble -DskipTests -DfailIfNoTests=false clean install
+set +e
 echo "Build TomEE completed"
 
 echo "Run Microprofile TCK"
 cd tck/microprofile-tck
 mvn --batch-mode test -Denforcer.fail=false
-set +e
-echo "Tomee Microprofile TCK completed"
+test_exit_code=$?
 find ./ -type d -name 'surefire-reports' -exec cp -r "{}" /testResults \;
+exit $test_exit_code

--- a/external/wycheproof/dockerfile/wycheproof.sh
+++ b/external/wycheproof/dockerfile/wycheproof.sh
@@ -40,11 +40,14 @@ TEST_OPTIONS=$1
 
 cd ${WYCHEPROOF_HOME}/wycheproof
 
-set -e
 #Run OpenJDKAllTests 
 bazel test OpenJDKTest --genrule_strategy=standalone --spawn_strategy=standalone --verbose_failures
-
+OpenJDKTest_exit_code=$?
 #Run BouncyCastleAllTests tests 
 bazel test BouncyCastleTest --genrule_strategy=standalone --spawn_strategy=standalone --verbose_failures
-set +e
+BouncyCastle_exit_code=$?
 find /root/.cache -type d -name 'testlogs' -exec cp -r "{}" /testResults \;
+
+if [ "$(( OpenJDKTest_exit_code + BouncyCastle_exit_cod ))" -gt 0 ] {
+	exit 1
+}


### PR DESCRIPTION
1. Fix return status
2. Copy junit test result even if test exit early.

Fix #1509 

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>