### PR TITLE
Use enable preview option in 11+ sdks for HCRLateAttachWorkload test

### DIFF
--- a/system/otherLoadTest/playlist.xml
+++ b/system/otherLoadTest/playlist.xml
@@ -267,8 +267,6 @@
 		<platformRequirements>^os.win</platformRequirements>
 		<subsets>
 			<subset>8</subset>
-			<subset>11</subset>
-			<subset>13</subset>
 		</subsets>
 	</test>
 	
@@ -294,7 +292,7 @@
 		</groups>
 		<platformRequirements>^os.win</platformRequirements>
 		<subsets>
-			<subset>14+</subset>
+			<subset>11+</subset>
 		</subsets>
 	</test>
 	


### PR DESCRIPTION
We need to use `--enable-preview` option in the test target for the HCRLateAttachWorkload test from JDK 11 and up, as we now use `--enable-preview` to compile the test on JDK 11 and up (https://github.com/AdoptOpenJDK/openjdk-systemtest/pull/320). 

This PR fixes the error from https://github.com/AdoptOpenJDK/openjdk-tests/pull/1557 where we had only used `--enable-preview` option in the test's target for JDK 14 and up. 

Related to https://github.com/eclipse/openj9/issues/8356
Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>