### PR TITLE
Update External system-test

### DIFF
--- a/external/system-test/dockerfile/Dockerfile
+++ b/external/system-test/dockerfile/Dockerfile
@@ -33,56 +33,25 @@ FROM $IMAGE_NAME:$IMAGE_VERSION
 RUN apt-get update \
 	&& apt-get -y install \
 	ant \
+	ant-contrib \
 	apt-transport-https \
 	ca-certificates \
 	dirmngr \
-	curl \
 	git \
 	make \
 	unzip \
-	vim \
 	wget \
 	cpio \
 	gcc
-
-# Install ant
-ENV ANT_VERSION 1.10.5
-RUN wget --no-check-certificate https://archive.apache.org/dist/ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.gz && \
-    gunzip apache-ant-${ANT_VERSION}-bin.tar.gz && \
-    tar -xvf apache-ant-${ANT_VERSION}-bin.tar
-
-RUN apt-get -y install \
-        libtext-csv-perl \
-        libjson-perl
-
-
-VOLUME ["/java"]
-#ENV JAVA_HOME=/java \
-#    PATH=/java/bin:$PATH \
-#    JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
-
-# Install Docker module to run test framework
-RUN apt-get -y install \
-	libtext-csv-perl \
-	libjson-perl \
-	libxml-parser-perl
 
 # This is the main script to run system tests.  
 COPY ./dockerfile/system-test.sh /system-test.sh
 
 # Clone the repo where the 3rd party application code and tests reside. 
 WORKDIR /
-RUN pwd
-
-ENV ANT_HOME ${WORKDIR}/apache-ant-${ANT_VERSION}
-
-RUN wget https://sourceforge.net/projects/ant-contrib/files/ant-contrib/1.0b3/ant-contrib-1.0b3-bin.tar.gz && \
-    tar -zxvf ant-contrib-1.0b3-bin.tar.gz && \
-    cp ant-contrib/ant-contrib-1.0b3.jar ${ANT_HOME}/lib
-
 
 # Clone AdoptOpenJDK openjdk-tests repo
 RUN git clone https://github.com/AdoptOpenJDK/openjdk-tests.git
 
 ENTRYPOINT ["/bin/bash", "/system-test.sh"]
-CMD ["--version"]
+CMD ["_sanity.system"]

--- a/external/system-test/dockerfile/system-test.sh
+++ b/external/system-test/dockerfile/system-test.sh
@@ -32,10 +32,8 @@ export TEST_JDK_HOME=$JAVA_HOME
 echo "TEST_JDK_HOME is : $TEST_JDK_HOME"
 export BUILD_LIST=system
 
-test=$@
-
 cd /openjdk-tests
-./get.sh -t /openjdk-tests --clone_openj9 false
+./get.sh -t /openjdk-tests
 
 cd /openjdk-tests/TKG
 
@@ -45,5 +43,5 @@ make -f run_configure.mk
 echo "Building system test material..." 
 make compile
 
-echo "Running test $test..."
-sh /openjdk-tests/maketest.sh /openjdk-tests _$test
+echo "Running system $1..."
+make $1

--- a/external/system-test/playlist.xml
+++ b/external/system-test/playlist.xml
@@ -15,32 +15,28 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TKG/playlist.xsd">
 	 <test>
                 <testCaseName>sanity_system</testCaseName>
-                <command>docker run --name system-test adoptopenjdk-system-test:latest sanity.system; \
-                 docker rm system-test; \
-                $(TEST_STATUS)</command>
-                <subsets>
-                        <subset>8</subset>
-                        <subset>9</subset>
-                </subsets>
+                <command>docker run --name sanity_system adoptopenjdk-system-test:latest ; \
+                	$(TEST_STATUS); \
+                	docker rm -f sanity_system; \
+                 	docker rmi -f adoptopenjdk-system-test
+                </command>
                 <levels>
-                        <level>special</level>
+                	<level>sanity</level>
                 </levels>
                 <groups>
-                        <group>system</group>
+                 	<group>system</group>
                 </groups>
         </test>
 
 	 <test>
                 <testCaseName>extended_system</testCaseName>
-                <command>docker run --name system-test adoptopenjdk-system-test:latest extended.system; \
-                 docker rm system-test; \
-                $(TEST_STATUS)</command>
-                <subsets>
-                        <subset>8</subset>
-                        <subset>9</subset>
-                </subsets>
+                <command>docker run --name extended_system adoptopenjdk-system-test:latest _extended.system; \
+					$(TEST_STATUS); \
+                	docker rm -f extended_system; \
+                 	docker rmi -f adoptopenjdk-system-test
+                </command>
                 <levels>
-                        <level>special</level>
+                        <level>extended</level>
                 </levels>
                 <groups>
                         <group>system</group>


### PR DESCRIPTION
1. Remove unnecessary installation
2. Running test by make target instead of using maketest.sh, which is
for jenkins build
3. Separate tests to sanity, extended and update to external group

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>