### PR TITLE
Move setup() out of try catch finally block

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -508,8 +508,8 @@ def testBuild() {
 			if( params.IS_PARALLEL == true ){
 				setupParallelEnv()
 			} else {
+				setup()
 				try {
-					setup()
 					//ToDo: temporary workaround for jck test parallel runs
 					// until build.xml is added into each subfolder
 					if( env.BUILD_LIST.startsWith('jck/')) {


### PR DESCRIPTION
In finally, we have post stage to archive the test logs and cores.
setup() is for downloading SDK and getting test material. In setup(),
there are no test logs or cores to archive. Move setup() out of try catch
finally block to avoid confusion.

Signed-off-by: lanxia <lan_xia@ca.ibm.com>