### PR TITLE
Echo the current job iteration

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -375,6 +375,7 @@ def runTest( ) {
 		timestamps{
 			echo 'Running tests...'
 			def CUSTOM_OPTION = ''
+			int iterationCount = 1
 			
 			TARGET = "${params.TARGET}";
 			if (TARGET.contains('custom') && CUSTOM_TARGET!='') {
@@ -382,6 +383,7 @@ def runTest( ) {
 			}
 			RUNTEST_CMD = "./openjdk-tests _${params.TARGET} ${CUSTOM_OPTION}"
 			for (int i = 0; i < ITERATIONS; i++) {
+				echo "ITERATION: ${iterationCount}/${ITERATIONS}"
 				if (env.BUILD_LIST == 'openjdk') {
 					if (env.SPEC.startsWith('linux_x86-64')) {
 						wrap([$class: 'Xvfb', autoDisplayName: true]) {
@@ -418,6 +420,7 @@ def runTest( ) {
 				} else {
 					makeTest("${RUNTEST_CMD}")
 				}
+				iterationCount++
 			}
 		}
 	}


### PR DESCRIPTION
Print out the current job iteration to the console log. This helps identify how long a running job will take to finish as you can see what stage it is currently working on.

Search the log of https://ci.adoptopenjdk.net/view/Test_grinder/job/Grinder/1877/console for `ITERATION:` as an example or see this file [exampleLog.txt](https://github.com/AdoptOpenJDK/openjdk-tests/files/4107641/exampleLog.txt)

Closes: #1574

Signed-off-by: Morgan Davies <morgan.davies@ibm.com>