### PR TITLE
WIP: Do chmod 755 on unpacked sdk for all platforms

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -272,9 +272,7 @@ getBinaryOpenjdk()
 			cd $SDKDIR/openjdkbinary
 		done
 
-	if [[ "$PLATFORM" == "s390x_zos" ]]; then
-		chmod -R 755 j2sdk-image
-	fi
+	chmod -R 755 j2sdk-image
 }
 
 getOpenJDKSources() {


### PR DESCRIPTION
- Run chmod 755 on all cases of the unpacked sdk - this is especially required for the *.sdk.jar sdks from espresso  

Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>