### PR TITLE
Do not require GNU tar options when downloading jtreg

### DIFF
--- a/openjdk/build.xml
+++ b/openjdk/build.xml
@@ -35,8 +35,11 @@
 				<exec executable="curl" failonerror="true">
 					<arg line="-OLJSks https://ci.adoptopenjdk.net/job/jtreg/lastSuccessfulBuild/artifact/jtreg-4.2.0-tip.tar.gz" />
 				</exec>
+				<exec executable="gzip" failonerror="true">
+					<arg line="-d jtreg-4.2.0-tip.tar.gz" />
+				</exec>
 				<exec executable="tar" failonerror="true">
-					<arg line="xf jtreg-4.2.0-tip.tar.gz -C ${DEST}" />
+					<arg line="xf jtreg-4.2.0-tip.tar -C ${DEST}" />
 				</exec>
 			</then>
 		</if>


### PR DESCRIPTION
Verified at https://ci.adoptopenjdk.net/view/Test_grinder/job/Grinder/1986/console and https://ci.adoptopenjdk.net/view/Test_grinder/job/Grinder/1987/console which were failing without this change with the following message:

```
21:14:28  
21:14:28  getJtreg:
21:14:28      [mkdir] Created dir: /home/jenkins/workspace/Grinder/jvmtest/openjdk
21:15:13       [exec] tar: 0511-169 A directory checksum error on media; 0 not equal to 71181.
21:15:13  
21:15:13  BUILD FAILED
21:15:13  /home/jenkins/workspace/Grinder/openjdk-tests/TKG/scripts/build_test.xml:58: The following error occurred while executing this line:
21:15:13  /home/jenkins/workspace/Grinder/openjdk-tests/openjdk/build.xml:144: The following error occurred while executing this line:
21:15:13  /home/jenkins/workspace/Grinder/openjdk-tests/openjdk/build.xml:38: exec returned: 1
21:15:13  
21:15:13  Total time: 43 seconds
21:15:13  1
21:15:13  /bin/sh[3]: test: 0403-004 Specify a parameter with this command.
21:15:13  gmake[1]: Leaving directory '/home/jenkins/workspace/Grinder/openjdk-tests/TKG'
```

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>