### PR TITLE
Add ibm tag to all openj9 system tests 

### DIFF
--- a/system/common.xml
+++ b/system/common.xml
@@ -178,7 +178,10 @@
 			</else>
 		</if>
 		<if>
-			<contains string="${JVM_VERSION}" substring="openj9"/>
+			<or>
+				<contains string="${JVM_VERSION}" substring="openj9"/>
+				<contains string="${JVM_VERSION}" substring="ibm"/>
+			</or>
 			<then>
 				<if>
 					<not>
@@ -198,7 +201,10 @@
 	
 	<target name="configure_systemtest" depends="check_systemtest">
 		<if>
-			<contains string="${JVM_VERSION}" substring="openj9"/>
+			<or>
+				<contains string="${JVM_VERSION}" substring="openj9"/>
+				<contains string="${JVM_VERSION}" substring="ibm"/>
+			</or>
 			<then>
 				<ant antfile="${SYSTEMTEST_ROOT}/openj9-systemtest/openj9.build/build.xml" dir="${SYSTEMTEST_ROOT}/openj9-systemtest/openj9.build/" target="configure" inheritAll="false"/>
 			</then>
@@ -228,7 +234,11 @@
 	<!-- Also make sure stf is built -->
 	<target name="build-dependencies" depends="configure_systemtest">
 		<if>
-			<contains string="${JVM_VERSION}" substring="openj9"/>
+			<or>
+				<contains string="${JVM_VERSION}" substring="openj9"/>
+				<contains string="${JVM_VERSION}" substring="ibm"/>
+			</or>
+
 			<then>
 				<ant antfile="${SYSTEMTEST_ROOT}/openj9-systemtest/openj9.build/build.xml" dir="${SYSTEMTEST_ROOT}/openj9-systemtest/openj9.build" inheritAll="false"/>
 			</then>
@@ -248,7 +258,10 @@
 	<target name="clean">
 		<ant antfile="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build/build.xml" dir="${SYSTEMTEST_ROOT}/openjdk-systemtest/openjdk.build" inheritAll="false" target="clean"/>
 		<if>
-			<contains string="${JVM_VERSION}" substring="openj9"/>
+			<or>
+				<contains string="${JVM_VERSION}" substring="openj9"/>
+				<contains string="${JVM_VERSION}" substring="ibm"/>
+			</or>
 			<then>
 				<ant antfile="${SYSTEMTEST_ROOT}/openj9-systemtest/openj9.build/build.xml" dir="${SYSTEMTEST_ROOT}/openj9-systemtest/openj9.build" inheritAll="false" target="clean"/>
 			</then>

--- a/system/daaLoadTest/playlist.xml
+++ b/system/daaLoadTest/playlist.xml
@@ -41,6 +41,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 	</test>
 	
@@ -65,6 +66,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 	</test>
 	
@@ -89,6 +91,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 	</test>
 	
@@ -112,6 +115,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 	</test>
 	
@@ -136,6 +140,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 		<platformRequirements>bits.64,^arch.arm</platformRequirements>
 	</test>
@@ -161,6 +166,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 		<platformRequirements>bits.64,^arch.arm</platformRequirements>
 	</test>
@@ -186,6 +192,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 		<platformRequirements>bits.64,^arch.arm</platformRequirements>
 	</test>
@@ -210,6 +217,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 		<platformRequirements>bits.64,^arch.arm</platformRequirements>
 	</test>
@@ -265,6 +273,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 	</test>
 
@@ -319,6 +328,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 	</test>
 
@@ -373,6 +383,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 	</test>
 
@@ -426,6 +437,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 	</test>
 

--- a/system/jlm/playlist.xml
+++ b/system/jlm/playlist.xml
@@ -50,6 +50,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 	</test>
 	
@@ -101,10 +102,6 @@
 		<groups>
 			<group>system</group>
 		</groups>
-		<impls>
-			<impl>hotspot</impl>
-			<impl>openj9</impl>
-		</impls>
 	</test>
 
 	<test>
@@ -128,10 +125,6 @@
 		<groups>
 			<group>system</group>
 		</groups>
-		<impls>
-			<impl>hotspot</impl>
-			<impl>openj9</impl>
-		</impls>
 		<platformRequirements>^os.linux</platformRequirements> 
 	</test>
 	<test>
@@ -155,10 +148,6 @@
 		<groups>
 			<group>system</group>
 		</groups>
-		<impls>
-			<impl>hotspot</impl>
-			<impl>openj9</impl>
-		</impls>
 		<platformRequirements>os.linux,^arch.ppc</platformRequirements>
 	</test>
 	
@@ -185,10 +174,6 @@
 		<groups>
 			<group>system</group>
 		</groups>
-		<impls>
-			<impl>hotspot</impl>
-			<impl>openj9</impl>
-		</impls>
 		<platformRequirements>^os.win</platformRequirements> 
 	</test>
 	
@@ -214,10 +199,6 @@
 		<groups>
 			<group>system</group>
 		</groups>
-		<impls>
-			<impl>hotspot</impl>
-			<impl>openj9</impl>
-		</impls>
 		<platformRequirements>^os.linux,^os.win</platformRequirements> 
 	</test>
 	
@@ -242,10 +223,6 @@
 		<groups>
 			<group>system</group>
 		</groups>
-		<impls>
-			<impl>hotspot</impl>
-			<impl>openj9</impl>
-		</impls>
 		<platformRequirements>os.linux,^arch.ppc</platformRequirements> 
 	</test>
 
@@ -271,10 +248,6 @@
 		<groups>
 			<group>system</group>
 		</groups>
-		<impls>
-			<impl>hotspot</impl>
-			<impl>openj9</impl>
-		</impls>
 	</test>
 	<test>
 		<testCaseName>TestJlmRemoteMemoryNoAuth_SE80</testCaseName>
@@ -297,10 +270,6 @@
 		<groups>
 			<group>system</group>
 		</groups>
-		<impls>
-			<impl>hotspot</impl>
-			<impl>openj9</impl>
-		</impls>
 		<platformRequirements>^os.linux</platformRequirements>
 	</test>
 	<test>
@@ -324,10 +293,6 @@
 		<groups>
 			<group>system</group>
 		</groups>
-		<impls>
-			<impl>hotspot</impl>
-			<impl>openj9</impl>
-		</impls>
 		<platformRequirements>os.linux,^arch.ppc</platformRequirements>
 	</test>
 
@@ -382,6 +347,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 		<platformRequirements>^os.win</platformRequirements>
 	</test>
@@ -408,6 +374,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 		<platformRequirements>^os.linux,^os.win</platformRequirements>
 	</test>
@@ -434,6 +401,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 		<platformRequirements>os.linux,^arch.ppc</platformRequirements>
 	</test>
@@ -459,6 +427,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 	</test>
 	
@@ -487,6 +456,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 		<platformRequirements>^os.win</platformRequirements> 
 	</test>
@@ -515,6 +485,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 		<platformRequirements>^os.linux,^os.win</platformRequirements>
 	</test>
@@ -542,6 +513,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 		<platformRequirements>os.linux,^arch.ppc</platformRequirements>
 	</test>
@@ -570,6 +542,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 	</test>
 	<test>
@@ -595,6 +568,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 		<platformRequirements>^os.linux</platformRequirements>
 	</test>
@@ -621,6 +595,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 		<platformRequirements>os.linux,^arch.ppc</platformRequirements>
 	</test>
@@ -650,6 +625,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 		<platformRequirements>^os.win</platformRequirements> 
 	</test>
@@ -678,6 +654,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 		<platformRequirements>^os.linux,^os.win</platformRequirements>
 	</test>
@@ -705,6 +682,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 		<platformRequirements>os.linux,^arch.ppc</platformRequirements>
 	</test>
@@ -733,6 +711,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 	</test>
 	<test>
@@ -758,6 +737,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 		<platformRequirements>^os.linux</platformRequirements>
 	</test>
@@ -784,6 +764,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 		<platformRequirements>os.linux,^arch.ppc</platformRequirements>
 	</test>

--- a/system/lambdaLoadTest/playlist.xml
+++ b/system/lambdaLoadTest/playlist.xml
@@ -63,6 +63,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 		<platformRequirements>^os.linux</platformRequirements> 
 	</test>
@@ -87,6 +88,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 		<platformRequirements>os.linux,vm.cmprssptrs</platformRequirements> 
 	</test>
@@ -132,6 +134,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 		<platformRequirements>bits.64,^arch.arm</platformRequirements>
 	</test>
@@ -186,6 +189,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 		<platformRequirements>^os.linux</platformRequirements> 
 	</test>
@@ -240,6 +244,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 		<platformRequirements>os.linux,vm.cmprssptrs</platformRequirements> 
 	</test>

--- a/system/mathLoadTest/playlist.xml
+++ b/system/mathLoadTest/playlist.xml
@@ -101,6 +101,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 		<platformRequirements>bits.64,^arch.arm</platformRequirements>
 	</test>
@@ -126,6 +127,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 		<platformRequirements>bits.64,^arch.arm</platformRequirements>
 	</test>
@@ -151,6 +153,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 		<platformRequirements>bits.64,^arch.arm</platformRequirements>
 	</test>
@@ -205,6 +208,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 	</test>
 
@@ -259,6 +263,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 	</test>
 
@@ -313,6 +318,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 	</test>
 </playlist>

--- a/system/mauveLoadTest/playlist.xml
+++ b/system/mauveLoadTest/playlist.xml
@@ -39,7 +39,8 @@
 			<group>system</group>
 		</groups>
 		<impls>	
-			<impl>openj9</impl>	
+			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 		<platformRequirements>^os.osx</platformRequirements>
 	</test>
@@ -86,7 +87,8 @@
 			<group>system</group>
 		</groups>
 		<impls>	
-			<impl>openj9</impl>	
+			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 		<platformRequirements>^os.osx</platformRequirements>
 	</test>
@@ -153,6 +155,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 		<platformRequirements>bits.64,^arch.arm</platformRequirements>
 		<disabled>AdoptOpenJDK/openjdk-systemtest/issues/75</disabled>
@@ -178,6 +181,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 		<platformRequirements>bits.64,^arch.arm</platformRequirements>
 		<disabled>AdoptOpenJDK/openjdk-systemtest/issues/78</disabled>
@@ -203,6 +207,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 		<platformRequirements>bits.64,^arch.arm</platformRequirements>
 		<disabled>AdoptOpenJDK/openjdk-systemtest/issues/64</disabled>
@@ -258,6 +263,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 		<subsets>
 			<subset>8</subset>
@@ -313,6 +319,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 		<subsets>
 			<subset>8</subset>
@@ -369,6 +376,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 		<subsets>
 			<subset>8</subset>

--- a/system/modularity/playlist.xml
+++ b/system/modularity/playlist.xml
@@ -774,6 +774,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 	</test>
 	<test>

--- a/system/otherLoadTest/playlist.xml
+++ b/system/otherLoadTest/playlist.xml
@@ -89,6 +89,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 	</test>
 	
@@ -222,6 +223,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 		<platformRequirements>^arch.arm</platformRequirements>
 	</test>
@@ -316,6 +318,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 	</test>
 	
@@ -339,6 +342,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 	</test>
 
@@ -363,6 +367,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 		<platformRequirements>bits.64,^arch.arm</platformRequirements>
 	</test>

--- a/system/sharedClasses/playlist.xml
+++ b/system/sharedClasses/playlist.xml
@@ -48,6 +48,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 	</test>
 	
@@ -71,6 +72,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 	</test>
 	
@@ -94,6 +96,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 	</test>
 	
@@ -117,6 +120,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 	</test>
 	
@@ -141,6 +145,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 		<platformRequirements>^os.linux</platformRequirements>
 	</test>
@@ -165,6 +170,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 		<platformRequirements>os.linux,^arch.ppc,^arch.390</platformRequirements>
 	</test>
@@ -190,6 +196,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 	</test>
 	
@@ -214,6 +221,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 	</test>
 	
@@ -238,6 +246,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 	</test>
 	
@@ -262,6 +271,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 	</test>
 	
@@ -286,6 +296,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 	</test>
 	
@@ -310,6 +321,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 	</test>
 	
@@ -334,6 +346,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 	</test>
 	
@@ -358,6 +371,7 @@
 		</groups>
 		<impls>
 			<impl>openj9</impl>
+			<impl>ibm</impl>
 		</impls>
 	</test>
 </playlist>


### PR DESCRIPTION
- Enable openj9 system tests to run with IBM SDKs

Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>