### PR TITLE
Fix test jobs not creating gzipped tarballs after yesterday's change

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -479,7 +479,11 @@ def post(output_name) {
 
 			if (currentBuild.result != 'SUCCESS' || params.ARCHIVE_TEST_RESULTS) {
 				def test_output_tar_name = "${output_name}_test_output${suffix}"
-				sh "${tar_cmd} ${test_output_tar_name} ${pax_opt} ./openjdk-tests/TKG/test_output_* ${tar_cmd_suffix}"
+				if (tar_cmd.startsWith('tar')) {
+					sh "${tar_cmd} - ${pax_opt} ./openjdk-tests/TKG/test_output_* ${tar_cmd_suffix} > ${test_output_tar_name}"
+				} else {
+					sh "${tar_cmd} ${test_output_tar_name} ${pax_opt} ./openjdk-tests/TKG/test_output_* ${tar_cmd_suffix}"
+				}
 
 				if (!params.ARTIFACTORY_SERVER) {
 					echo "ARTIFACTORY_SERVER is not set. Saving artifacts on jenkins."


### PR DESCRIPTION
I must have been half asleep when I made that change yesterday ...

This will do what I originally planned to do. It leaves the zos variant with `pax` alone to run the command as-is and only makes the adjustment (properly this time!) if the `tar_cmd` is set to `tar -cf` as it is on all platforms where this should be safe

Grinders to verify - they are now creating a gzipped tarball again:

macos: https://ci.adoptopenjdk.net/view/Test_grinder/job/Grinder/2038
windows: https://ci.adoptopenjdk.net/view/Test_grinder/job/Grinder/2037
xlinux: https://ci.adoptopenjdk.net/view/Test_grinder/job/Grinder/2039
aix: https://ci.adoptopenjdk.net/view/Test_grinder/job/Grinder/2040

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>