### PR TITLE
Add framework to support generated Dockerfiles

### DIFF
--- a/external/build_image.sh
+++ b/external/build_image.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+set -o pipefail
+
+source ./common_functions.sh
+source ./dockerfile_functions.sh
+
+if [ $# -ne 6 ]; then
+	echo
+	echo "usage: $0 os test version vm package build"
+	echo "os      = ${all_os}"
+	echo "test    = ${all_tests}"
+	echo "version = ${all_versions}"
+	echo "vm      = ${all_jvms}"
+	echo "package = ${all_packages}"
+	echo "build   = ${all_builds}"
+	exit -1
+fi
+
+set_os $1
+set_test $2
+set_version $3
+set_vm $4
+set_package $5
+set_build $6
+
+# Build the Docker image with the given repo, build, build type and tags.
+#function build_image() {
+#	repo=$1; shift;
+#	build=$1; shift;
+#	btype=$1; shift;
+#
+#	tags=""
+#
+#	dockerfile="Dockerfile.${vm}.${build}.${btype}"
+#
+#	echo "#####################################################"
+#	echo "INFO: docker build --no-cache ${tags} -f ${dockerfile} ."
+#	echo "#####################################################"
+#	docker build --pull --no-cache ${tags} -f ${dockerfile} .
+#	if [ $? != 0 ]; then
+#		echo "ERROR: Docker build of image: ${tags} from ${dockerfile} failed."
+#		exit 1
+#	fi
+#}
+
+
+# Generate all the Dockerfiles for each of the builds and build types
+dir="${test}/dockerfile"
+file="${dir}/Dockerfile.${os}"
+generate_dockerfile ${file} ${os} ${test} ${version} ${vm} ${package} ${build}
+if [ ! -f ${file} ]; then
+    continue;
+fi
+

--- a/external/common_functions.sh
+++ b/external/common_functions.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# All supported JVMs
+all_jvms="hotspot openj9"
+
+# All supported packges
+all_packages="jdk jre"
+
+# All supported distros
+all_os="alpine debian debianslim ubi ubi-minimal centos clefos ubuntu windowsservercore-ltsc2016"
+
+# All support versions
+all_versions="8 9 10 11 12 13"
+
+# All supported builds
+all_builds="slim full"
+
+# All supported tests
+all_tests="derby elasticsearch jenkins kafka lucene-solr openliberty payara quarkus scala thorntail tomcat tomee wildfly wycheproof"
+
+function check_version() {
+	version=$1
+	case ${version} in
+	8|9|10|11|12|13)
+		;;
+	*)
+		echo "ERROR: Invalid version"
+		;;
+	esac
+}
+
+# Set a valid version
+function set_version() {
+	version=$1
+	if [ ! -z "$(check_version ${version})" ]; then
+		echo "ERROR: Invalid Version: ${version}"
+		echo "Usage: $0 [${all_versions}]"
+		exit 1
+	fi
+}
+
+function check_os() {
+	os=$1
+	case ${os} in
+	alpine|debian|debianslim|ubi|ubi-minimal|centos|clefos|ubuntu|windowsservercore-ltsc2016)
+		;;
+	*)
+		echo "ERROR: Invalid os"
+		;;
+	esac
+}
+
+# Set a valid os
+function set_os() {
+	os=$1
+	if [ ! -z "$(check_os ${os})" ]; then
+		echo "ERROR: Invalid OS: ${os}"
+		echo "Usage: $0 [${all_os}]"
+		exit 1
+	fi
+}
+
+function check_test() {
+	test=$1
+	case ${test} in
+	derby|elasticsearch|jenkins|kafka|lucene-solr|openliberty|payara|quarkus|scala|thorntail|tomcat|tomee|wildfly|wycheproof)
+		;;
+	*)
+		echo "ERROR: Invalid test"
+		;;
+	esac
+}
+
+# Set a valid test
+function set_test() {
+	test=$1
+	if [ ! -z "$(check_test ${test})" ]; then
+		echo "ERROR: Invalid Test: ${test}"
+		echo "Usage: $0 [${all_tests}]"
+		exit 1
+	fi
+}
+
+
+function check_vm() {
+	vm=$1
+	case ${vm} in
+	hotspot|openj9)
+		;;
+	*)
+		echo "ERROR: Invalid VM"
+		;;
+	esac
+}
+
+# Set a valid vm
+function set_vm() {
+	vm=$1
+	if [ ! -z "$(check_vm ${vm})" ]; then
+		echo "ERROR: Invalid VM: ${vm}"
+		echo "Usage: $0 [${all_jvms}]"
+		exit 1
+	fi
+}
+
+function check_package() {
+	package=$1
+	case ${package} in
+	jdk|jre)
+		;;
+	*)
+		echo "ERROR: Invalid Package"
+		;;
+	esac
+}
+
+# Set a valid package
+function set_package() {
+	package=$1
+	if [ ! -z "$(check_package ${package})" ]; then
+		echo "ERROR: Invalid Package: ${package}"
+		echo "Usage: $0 [${all_packages}]"
+		exit 1
+	fi
+}
+
+function check_build() {
+	build=$1
+	case ${build} in
+	slim|full)
+		;;
+	*)
+		echo "ERROR: Invalid Build"
+		;;
+	esac
+}
+
+# Set a valid build
+function set_build() {
+	build=$1
+	if [ ! -z "$(check_build ${build})" ]; then
+		echo "ERROR: Invalid Build: ${build}"
+		echo "Usage: $0 [${all_builds}]"
+		exit 1
+	fi
+}
+
+# Set the valid OSes for the current architecure.
+function set_test_info() {
+	test=$1
+	case ${test} in
+	derby)
+	    github_url="https://github.com/apache/derby.git"
+	    script="derby-test.sh"
+	    home_path="\${WORKDIR}/derby"
+	    tag_version="trunk"
+	    ant_version="1.10.6"
+		debian_packages="git wget tar"
+		debian_slim_packages="${debian_packages}"
+		ubuntu_packages="${debian_packages}"
+		alpine_packages="git wget tar"
+		centos_packages="git wget tar"
+		clefos_packages="${centos_packages}"
+		ubi_packages="git wget tar"
+		ubi_minimal_packages="${ubi_packages}"
+		;;
+	elasticsearch)
+		;;
+	jenkins)
+		;;
+	kafka)
+		;;
+	lucene-solr)
+		;;
+    openliberty)
+		;;
+	payara)
+		;;
+	quarkus)
+		;;
+	scala)
+	    github_url="https://github.com/scala/scala.git"
+	    script="scala-test.sh"
+	    home_path=""
+	    tag_version="v2.13.1"
+	    sbt_version="1.3.4"
+		debian_packages="git wget tar curl gpg gpg-agent"
+		debian_slim_packages="${debian_packages}"
+		ubuntu_packages="${debian_packages}"
+		alpine_packages="git wget tar curl gnupg"
+		centos_packages="git wget tar curl gpg"
+		clefos_packages="${centos_packages}"
+		ubi_packages="git wget tar curl gpg"
+		ubi_minimal_packages="${ubi_packages}"
+		;;
+	thorntail)
+		;;
+	tomcat)
+		;;
+	tomee)
+		;;
+	wildfly)
+		;;
+	wycheproof)
+		;;
+	*)
+		echo "ERROR: Unsupported test:${test}, Exiting"
+		exit 1
+		;;
+	esac
+}

--- a/external/dockerfile_functions.sh
+++ b/external/dockerfile_functions.sh
@@ -1,0 +1,348 @@
+#!/usr/bin/env bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+source ./common_functions.sh
+
+# Generate the common license and copyright header
+print_legal() {
+    local file=$1
+
+    echo -e "# ------------------------------------------------------------------------------" \
+          "\n#               NOTE: THIS DOCKERFILE IS GENERATED VIA \"build_image.sh\" or \"build_all.sh\"" \
+          "\n#" \
+          "\n#" \
+          "\n#                       PLEASE DO NOT EDIT IT DIRECTLY." \
+          "\n# ------------------------------------------------------------------------------" \
+          "\n#" \
+          "\n# Licensed under the Apache License, Version 2.0 (the \"License\");" \
+          "\n# you may not use this file except in compliance with the License." \
+          "\n# You may obtain a copy of the License at" \
+          "\n#" \
+          "\n#      https://www.apache.org/licenses/LICENSE-2.0" \
+          "\n#" \
+          "\n# Unless required by applicable law or agreed to in writing, software" \
+          "\n# distributed under the License is distributed on an \"AS IS\" BASIS," \
+          "\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied." \
+          "\n# See the License for the specific language governing permissions and" \
+          "\n# limitations under the License." \
+          "\n" > ${file}
+}
+
+# Generate the Adopt Test header
+print_adopt_test() {
+    local file=$1
+    local test=$2
+    local os=$3
+
+	echo -e "# This Dockerfile in external/${test}/dockerfile dir is used to create an image with" \
+          "\n# AdoptOpenJDK jdk binary installed. Basic test dependent executions" \
+          "\n# are installed during the building process." \
+          "\n#" \
+          "\n# Build example: \`docker build -t adoptopenjdk-${test}-test -f ${test}/dockerfile/Dockerfile.${os} .\`" \
+          "\n#" \
+          "\n# This Dockerfile builds image based on adoptopenjdk/openjdk8:latest." \
+          "\n# If you want to build image based on other images, please use" \
+          "\n# \`--build-arg list\` to specify your base image" \
+          "\n#" \
+          "\n# Build example: \`docker build --build-arg IMAGE_NAME=<image_name> --build-arg IMAGE_VERSION=<image_version> -t adoptopenjdk-${test}-test .\`" \
+          "\n" >> ${file}
+}
+
+print_image_args() {
+    local file=$1
+    local os=$2
+    local version=$3
+    local vm=$4
+    local package=$5
+    local build=$6
+
+    sdk="openjdk${version}"
+    if [[ "${vm}" == "openj9" ]]; then
+        sdk="${sdk}-openj9"
+    fi
+
+    echo -e "ARG SDK=${sdk}" \
+          "\nARG IMAGE_NAME=adoptopenjdk/\$SDK" \
+          "\nARG OS=${os}" \
+          "\nARG IMAGE_VERSION=nightly" >> ${file}
+
+
+    if [[ "${package}" == "jre" && "${build}" == "slim" ]]; then
+        echo -e "ARG TAG=\$OS-jre-\$IMAGE_VERSION-slim\n" >> ${file}
+    elif [[ "${package}" == "jre" && "${build}" == "full" ]]; then
+        echo -e "ARG TAG=\$OS-jre-\$IMAGE_VERSION\n" >> ${file}
+    elif [[ "${build}" == "slim" ]]; then
+        echo -e "ARG TAG=\$OS-\$IMAGE_VERSION-slim\n" >> ${file}
+    else
+        echo -e "ARG TAG=\$OS-\$IMAGE_VERSION\n" >> ${file}
+    fi
+
+    echo -e "FROM \$IMAGE_NAME:\$TAG\n" >> ${file}
+}
+
+print_test_tag_arg() {
+    local file=$1
+    local test=$2
+    local tag=$3
+
+    # Cause Test name to be capitalized
+    test="$(echo ${test} | tr a-z A-Z)_TAG"
+
+    echo -e "ARG ${test}=${tag}\n" >> ${file}
+}
+
+
+# Select the ubuntu OS packages
+print_ubuntu_pkg() {
+    local file=$1
+    local packages=$2
+
+    echo -e "RUN apt-get update \\" \
+            "\n\t&& apt-get install -y --no-install-recommends ${packages} \\" \
+            "\n\t&& rm -rf /var/lib/apt/lists/*" \
+            "\n" >> ${file}
+}
+
+print_debian_pkg() {
+    local file=$1
+    local packages=$2
+
+    print_ubuntu_pkg ${file} "${packages}"
+}
+
+print_debian-slim_pkg() {
+    local file=$1
+    local packages=$2
+
+    print_ubuntu_pkg ${file} "${packages}"
+}
+
+# Select the alpine OS packages.
+print_alpine_pkg() {
+    local file=$1
+    local packages=$2
+
+    echo -e "RUN apk add --no-cache ${packages} \\" \
+            "\n\t&& rm -rf /tmp/*.apk /var/cache/apk/*" \
+            "\n" >> ${file}
+}
+
+# Select the ubi OS packages.
+print_ubi_pkg() {
+    local file=$1
+    local packages=$2
+
+    echo -e "RUN dnf install -y ${packages} \\" \
+            "\n\t&& dnf update; dnf clean all"  \
+            "\n" >> ${file}
+}
+
+
+# Select the ubi OS packages.
+print_ubi-minimal_pkg() {
+    local file=$1
+    local packages=$2
+
+    echo -e "RUN microdnf install ${packages} \\" \
+            "\n\t&& microdnf update; microdnf clean all" \
+            "\n" >> ${file}
+}
+
+# Select the CentOS packages.
+print_centos_pkg() {
+    local file=$1
+    local packages=$2
+
+    echo -e "RUN yum install -y ${packages} \\" \
+            "\nt&& yum update; yum clean all" \
+            "\n" >> ${file}
+}
+
+
+# Select the ClefOS packages.
+print_clefos_pkg() {
+    local file=$1
+    local packages=$2
+    print_centos_pkg ${file} ${packages}
+}
+
+
+# Install Ant
+print_ant_install() {
+    local file=$1
+    local ant_version=$2
+    local os=$3
+
+    echo -e "ARG ANT_VERSION=${ant_version}" \
+          "\nENV ANT_VERSION=\$ANT_VERSION" \
+          "\nENV ANT_HOME=/opt/ant" \
+          "\n\n# Install Ant" \
+          "\nRUN wget --no-check-certificate --no-cookies http://archive.apache.org/dist/ant/binaries/apache-ant-\${ANT_VERSION}-bin.tar.gz \\" \
+          "\n\t&& wget --no-check-certificate --no-cookies http://archive.apache.org/dist/ant/binaries/apache-ant-\${ANT_VERSION}-bin.tar.gz.sha512 \\" >> ${file}
+
+    # Alpine sha512sum requires two spaces https://github.com/gliderlabs/docker-alpine/issues/174
+    if [[ "${os}" = "alpine" ]]; then
+        echo -e "\t&& echo \"\$(cat apache-ant-\${ANT_VERSION}-bin.tar.gz.sha512)  apache-ant-\${ANT_VERSION}-bin.tar.gz\" | sha512sum -c \\" >> ${file}
+    else
+        echo -e "\t&& echo \"\$(cat apache-ant-\${ANT_VERSION}-bin.tar.gz.sha512) apache-ant-\${ANT_VERSION}-bin.tar.gz\" | sha512sum -c \\" >> ${file}
+    fi
+
+    echo -e "\t&& tar -zvxf apache-ant-\${ANT_VERSION}-bin.tar.gz -C /opt/ \\" \
+            "\n\t&& ln -s /opt/apache-ant-\${ANT_VERSION} /opt/ant \\" \
+            "\n\t&& rm -f apache-ant-\${ANT_VERSION}-bin.tar.gz \\" \
+            "\n\t&& rm -f apache-ant-\${ANT_VERSION}-bin.tar.gz.sha512" \
+            "\n\n# Add Ant to PATH" \
+            "\nENV PATH \${PATH}:\${ANT_HOME}/bin" \
+            "\n" >> ${file}
+}
+
+# Install SBT
+print_sbt_install() {
+    local file=$1
+    local sbt_version=$2
+    local os=$3
+
+    echo -e "ARG SBT_VERSION=${sbt_version}" \
+          "\nENV SBT_VERSION=\$SBT_VERSION" \
+          "\nENV SBT_HOME=/opt/sbt" \
+          "\n\n# Install SBT" \
+          "\nRUN wget --no-check-certificate --no-cookies https://piccolo.link/sbt-\${SBT_VERSION}.tgz \\" \
+          "\n\t&& wget --no-check-certificate --no-cookies https://piccolo.link/sbt-\${SBT_VERSION}.tgz.asc \\" \
+          "\n\t&& curl \"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823\" | gpg --import \\" \
+          "\n\t&& gpg --verify sbt-\${SBT_VERSION}.tgz.asc sbt-\${SBT_VERSION}.tgz \\" \
+          "\n\t&& tar -zvxf sbt-\${SBT_VERSION}.tgz -C /opt/ \\" \
+          "\n\t&& rm -f sbt-\${SBT_VERSION}.tgz \\" \
+          "\n\t&& rm -f sbt-\${SBT_VERSION}.tgz.asc" \
+          "\n\n# Add SBT to PATH" \
+          "\nENV PATH \${PATH}:\${SBT_HOME}/bin" \
+          "\n" >> ${file}
+}
+
+# Prints Java Tool Options
+print_java_tool_options(){
+    local file=$1
+
+    echo -e "ENV JAVA_TOOL_OPTIONS=\"-Dfile.encoding=UTF8\"\n" >> ${file}
+}
+
+print_home_path(){
+    local file=$1
+    local test=$2
+    local path=$3
+
+    # Cause Test name to be capitalized
+    test="$(echo ${test} | tr a-z A-Z)_HOME"
+
+    echo -e "ENV ${test} ${path}\n" >> ${file}
+}
+
+print_test_script() {
+    local file=$1
+    local test=$2
+    local script=$3
+
+    echo -e "# This is the main script to run ${test} tests" \
+            "\nCOPY ./${test}/dockerfile/${script} /${script}\n" >> ${file}
+}
+
+print_clone_project() {
+    local file=$1
+    local test=$2
+    local github_url=$3
+
+    # Cause Test name to be capitalized
+    test_tag="$(echo ${test} | tr a-z A-Z)_TAG"
+
+    # Get Github folder name
+    folder="$(echo ${github_url} | awk -F'/' '{print $NF}' | sed 's/.git//g')"
+
+    echo -e "# Clone ${test} source" \
+            "\nENV ${test_tag}=\$${test_tag}" \
+            "\nRUN git clone ${github_url}" \
+            "\nWORKDIR /${folder}/" \
+            "\nRUN git checkout \$${test_tag}" \
+            "\nWORKDIR /" \
+            "\n" >> ${file}
+}
+
+print_entrypoint() {
+    local file=$1
+    local script=$2
+
+    echo -e "ENTRYPOINT [\"/bin/bash\", \"/${script}\"]" >> ${file}
+}
+
+remove_trailing_spaces() {
+    local file=$1
+
+    # Make the Dockerfile after we set the base image
+    if [[ "$(uname)" == 'Darwin' ]]; then
+        sed -i '' 's/[[:space:]]*$//g' ${file}
+    else
+        sed -i 's/[[:space:]]*$//g' ${file}
+    fi
+}
+
+
+# Generate the dockerfile for a given build
+generate_dockerfile() {
+	file=$1
+	os=$2
+	test=$3
+	version=$4
+	vm=$5
+	package=$6
+    build=$7
+
+    set_test_info ${test}
+    packages=$(echo ${os}_packages | sed 's/-/_/')
+
+	jhome="/opt/java/openjdk"
+
+	mkdir -p `dirname ${file}` 2>/dev/null
+	echo
+	echo -n "Writing ${file} ... "
+	print_legal ${file};
+	print_adopt_test ${file} ${test} ${os};
+	print_image_args ${file} ${os} ${version} ${vm} ${package} ${build};
+	print_test_tag_arg ${file} ${test} ${tag_version};
+	print_${os}_pkg ${file} "${!packages}";
+
+	if [[ ! -z ${ant_version} ]]; then
+	    print_ant_install ${file} ${ant_version} ${os};
+	fi
+
+	if [[ ! -z ${sbt_version} ]]; then
+	    print_sbt_install ${file} ${sbt_version} ${os};
+	fi
+
+    print_java_tool_options ${file};
+
+    if [[ ! -z ${home_path} ]]; then
+	    print_home_path ${file} ${test} ${home_path};
+	fi
+
+	if [[ ! -z ${script} ]]; then
+	    print_test_script ${file} ${test} ${script};
+	fi
+
+    print_clone_project ${file} ${test} ${github_url};
+    print_entrypoint ${file} ${script};
+
+    remove_trailing_spaces ${file};
+
+	echo "done"
+	echo
+}


### PR DESCRIPTION
Started to add support for Dockerfile generation. In my PR you will find 3 scripts. The main script is `build-images.sh`. This script takes in an OS, a test name, a version of Java, a JVM (hotspot/openJ9), a package (JRE/JDK), and a build (slim/full). With these parameters the script is able to generate a corresponding Dockerfile. 

This script enables the Adopt Test team to start testing an ever-growing list of distros that the Adopt Docker team puts out. 

Currently, the script only generates Dockerfiles for `scala` and `derby` external tests but can easily be expanded to support all the external tests the Adopt Test team supports. 


There is no need to pass in the parameter of architecture since when pulling from the Adopt Dockerhub we take advantage of manifests which are multi-arch. 

The Dockerfiles the script generates still supports all the functionality the Adopt Test team currently utilizes (build arguments). In theory you could generate all the possible test images and include them in the Adopt Test repo, like the Adopt Docker repo does, thus you would not need to call the `build-images.sh` script during a test. This is an option but there are **a lot** of variations of images and countless external tests. 

Future plans are to include a script called `build-all.sh` that does generate all the possible variations of the Docker images. This might be helpful down the line. 
