### PR TITLE
Check currentBuild.result value specifically

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -477,7 +477,7 @@ def post(output_name) {
 				)
 			}
 
-			if (currentBuild.result != 'SUCCESS' || params.ARCHIVE_TEST_RESULTS) {
+			if ((currentBuild.result == 'UNSTABLE' || currentBuild.result == 'FAILURE' || currentBuild.result == 'ABORTED') || params.ARCHIVE_TEST_RESULTS) {
 				def test_output_tar_name = "${output_name}_test_output${suffix}"
 				if (tar_cmd.startsWith('tar')) {
 					sh "${tar_cmd} - ${pax_opt} ./openjdk-tests/TKG/test_output_* ${tar_cmd_suffix} > ${test_output_tar_name}"


### PR DESCRIPTION
If there is no error, currentBuild.result value will not set until the
whole build is completed. In other words, if there is no error, we
can still get `currentBuild.result != 'SUCCESS'` during the build.
Therefore, change the logic to check currentBuild.result value
specifically.


Signed-off-by: lanxia <lan_xia@ca.ibm.com>