### PR TITLE
Use pigz, but fallback to gzip if unavailable, for test output compression

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -438,7 +438,8 @@ def post(output_name) {
 				output_name = output_name.replace("/","_")
 			}
 			def tar_cmd = "tar -cf"
-			def tar_cmd_suffix = "| gzip -9"
+			// Use pigz if we can as it is faster - 2> hides fallback message
+			def tar_cmd_suffix = "| (pigz -9 2>/dev/null || gzip -9)"
 			def suffix = ".tar.gz"
 			def pax_opt = ""
 			if (SPEC.startsWith('zos')) {

--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -479,7 +479,11 @@ def post(output_name) {
 
 			if (currentBuild.result != 'SUCCESS' || params.ARCHIVE_TEST_RESULTS) {
 				def test_output_tar_name = "${output_name}_test_output${suffix}"
-				sh "${tar_cmd} ${test_output_tar_name} ${pax_opt} ./openjdk-tests/TKG/test_output_* ${tar_cmd_suffix}"
+				if (tar_cmd.startsWith('tar')) {
+					sh "${tar_cmd} - ${pax_opt} ./openjdk-tests/TKG/test_output_* ${tar_cmd_suffix} > ${test_output_tar_name}"
+				} else {
+					sh "${tar_cmd} ${test_output_tar_name} ${pax_opt} ./openjdk-tests/TKG/test_output_* ${tar_cmd_suffix}"
+				}
 
 				if (!params.ARTIFACTORY_SERVER) {
 					echo "ARTIFACTORY_SERVER is not set. Saving artifacts on jenkins."


### PR DESCRIPTION
Allow pigz to be used instead of gzip compression if available. This is due to https://ci.adoptopenjdk.net/view/Test_openjdk/job/Test_openjdk11_j9_sanity.openjdk_aarch64_linux_xl/ which is taking 1.5-2hrs to compress 3Gb of artefacts

Verification Grinders:
[Linux - x64](https://ci.adoptopenjdk.net/view/Test_grinder/job/Grinder/2149)
[AIX - ppc64](https://ci.adoptopenjdk.net/view/Test_grinder/job/Grinder/2151)
[macos - x64](https://ci.adoptopenjdk.net/view/Test_grinder/job/Grinder/2152)
[windows - x64](https://ci.adoptopenjdk.net/view/Test_grinder/job/Grinder/2153)
Linux-aarch64 [fell  over](https://ci.adoptopenjdk.net/view/Test_grinder/job/Grinder/2155) but that had nothing to do with this change