### PR TITLE
Update JDK14 Problem List

### DIFF
--- a/openjdk/ProblemList_openjdk14-openj9.txt
+++ b/openjdk/ProblemList_openjdk14-openj9.txt
@@ -204,6 +204,8 @@ java/io/Serializable/records/WriteReplaceTest.java          https://github.com/e
 java/io/Serializable/records/migration/AssignableFromTest.java      https://github.com/eclipse/openj9/issues/7945 generic-all
 java/io/Serializable/records/migration/DefaultValuesTest.java       https://github.com/eclipse/openj9/issues/7945 generic-all
 java/io/Serializable/records/migration/SuperStreamFieldsTest.java   https://github.com/eclipse/openj9/issues/7945 generic-all
+java/lang/reflect/records/RecordPermissionsTest.java    https://github.com/eclipse/openj9/issues/7945 generic-all
+java/lang/reflect/records/RecordReflectionTest.java     https://github.com/eclipse/openj9/issues/7945 generic-all
 
 ############################################################################
 

--- a/openjdk/ProblemList_openjdk14-openj9.txt
+++ b/openjdk/ProblemList_openjdk14-openj9.txt
@@ -186,6 +186,24 @@ java/io/CharArrayReader/OverflowInRead.java	https://github.com/AdoptOpenJDK/open
 java/io/FileInputStream/UnreferencedFISClosesFd.java  https://github.com/eclipse/openj9/issues/3543 generic-all
 java/io/FileOutputStream/UnreferencedFOSClosesFd.java https://github.com/eclipse/openj9/issues/3543 generic-all
 
+java/io/Serializable/records/AbsentStreamValuesTest.java    https://github.com/eclipse/openj9/issues/7945 generic-all
+java/io/Serializable/records/BadCanonicalCtrTest.java       https://github.com/eclipse/openj9/issues/7945 generic-all
+java/io/Serializable/records/BasicRecordSer.java            https://github.com/eclipse/openj9/issues/7945 generic-all
+java/io/Serializable/records/ConstructorAccessTest.java     https://github.com/eclipse/openj9/issues/7945 generic-all
+java/io/Serializable/records/ConstructorPermissionTest.java https://github.com/eclipse/openj9/issues/7945 generic-all
+java/io/Serializable/records/CycleTest.java                 https://github.com/eclipse/openj9/issues/7945 generic-all
+java/io/Serializable/records/ProhibitedMethods.java         https://github.com/eclipse/openj9/issues/7945 generic-all
+java/io/Serializable/records/ReadResolveTest.java           https://github.com/eclipse/openj9/issues/7945 generic-all
+java/io/Serializable/records/RecordClassTest.java           https://github.com/eclipse/openj9/issues/7945 generic-all
+java/io/Serializable/records/SerialPersistentFieldsTest.java    https://github.com/eclipse/openj9/issues/7945 generic-all
+java/io/Serializable/records/SerialVersionUIDTest.java      https://github.com/eclipse/openj9/issues/7945 generic-all
+java/io/Serializable/records/StreamRefTest.java             https://github.com/eclipse/openj9/issues/7945 generic-all
+java/io/Serializable/records/ThrowingConstructorTest.java   https://github.com/eclipse/openj9/issues/7945 generic-all
+java/io/Serializable/records/WriteReplaceTest.java          https://github.com/eclipse/openj9/issues/7945 generic-all
+java/io/Serializable/records/migration/AssignableFromTest.java      https://github.com/eclipse/openj9/issues/7945 generic-all
+java/io/Serializable/records/migration/DefaultValuesTest.java       https://github.com/eclipse/openj9/issues/7945 generic-all
+java/io/Serializable/records/migration/SuperStreamFieldsTest.java   https://github.com/eclipse/openj9/issues/7945 generic-all
+
 ############################################################################
 
 # jdk_jdi

--- a/openjdk/ProblemList_openjdk14-openj9.txt
+++ b/openjdk/ProblemList_openjdk14-openj9.txt
@@ -215,6 +215,7 @@ java/io/Serializable/records/migration/SuperStreamFieldsTest.java   https://gith
 java/nio/Buffer/DirectBufferAllocTest.java https://github.com/eclipse/openj9/issues/4473 generic-all
 java/nio/Buffer/LimitDirectMemory.java	https://github.com/eclipse/openj9/issues/8063	generic-all
 java/nio/Buffer/LimitDirectMemoryNegativeTest.java	https://github.com/eclipse/openj9/issues/8065	generic-all
+java/nio/MappedByteBuffer/MapSyncFail.java https://github.com/eclipse/openj9/issues/6831 generic-all
 java/nio/channels/AsyncCloseAndInterrupt.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1597	linux-all,aix-all
 java/nio/channels/AsynchronousFileChannel/Basic.java https://bugs.openjdk.java.net/browse/JDK-7052549 windows-all
 java/nio/channels/AsynchronousSocketChannel/Basic.java	https://bugs.openjdk.java.net/browse/JDK-7052549	windows-all

--- a/openjdk/ProblemList_openjdk14-openj9.txt
+++ b/openjdk/ProblemList_openjdk14-openj9.txt
@@ -117,6 +117,7 @@ java/lang/invoke/VarargsArrayTest.java	https://github.com/AdoptOpenJDK/openjdk-t
 java/lang/invoke/condy/CondyNestedTest.java https://github.com/eclipse/openj9/issues/4127 linux-ppc64le
 java/lang/invoke/condy/CondyNestedResolutionTest.java	https://github.com/eclipse/openj9/issues/7158	aix-all
 java/lang/invoke/lambda/LambdaStackTrace.java	https://github.com/eclipse/openj9/issues/3394	generic-all
+java/lang/invoke/lookup/LookupClassTest.java    https://github.com/eclipse/openj9/issues/8570   generic-all
 java/lang/ref/CleanerTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/ref/EarlyTimeout.java	https://github.com/eclipse/openj9/issues/7225	generic-all
 java/lang/ref/FinalizerHistogramTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all

--- a/openjdk/ProblemList_openjdk14-openj9.txt
+++ b/openjdk/ProblemList_openjdk14-openj9.txt
@@ -26,18 +26,19 @@
 
 # jdk_lang
 
-java/lang/Class/GetModuleTest.java	https://github.com/eclipse/openj9/issues/3040	generic-all
+java/lang/Class/GetModuleTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 #java/lang/Class/GetPackageBootLoaderChildLayer.java is also excluded for the issue https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267
 java/lang/Class/GetPackageBootLoaderChildLayer.java	https://github.com/eclipse/openj9/issues/5274	generic-all
 java/lang/Class/forName/NonJavaNames.sh	https://github.com/eclipse/openj9/issues/5225	generic-all
 java/lang/ClassLoader/Assert.java	https://github.com/eclipse/openj9/issues/6668	macosx-x64
 java/lang/ClassLoader/EndorsedDirs.java	https://github.com/eclipse/openj9/issues/3055	generic-all
 java/lang/ClassLoader/ExtDirs.java	https://github.com/eclipse/openj9/issues/3055	generic-all
-java/lang/ClassLoader/LibraryPathProperty.java	https://github.ibm.com/runtimes/openjdk-contribution/issues/606	generic-all
+java/lang/ClassLoader/LibraryPathProperty.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/ClassLoader/RecursiveSystemLoader.java	https://github.com/eclipse/openj9/issues/3178	generic-all
 java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	generic-all
 java/lang/Enum/ConstantDirectoryOptimalCapacity.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/ModuleLayer/BasicLayerTest.java	https://github.com/eclipse/openj9/issues/6462	generic-all
+java/lang/ProcessBuilder/Basic.java#id0		https://github.com/AdoptOpenJDK/openjdk-tests/issues/1397	aix-all
 java/lang/ProcessBuilder/SkipTest.java https://github.com/eclipse/openj9/issues/4124 windows-all
 java/lang/StackTraceElement/PublicConstructor.java	https://github.com/eclipse/openj9/issues/6659	generic-all
 java/lang/StackTraceElement/SerialTest.java	https://github.com/eclipse/openj9/issues/6659	generic-all
@@ -48,9 +49,9 @@ java/lang/StackWalker/LocalsAndOperands.java#id0  https://github.com/AdoptOpenJD
 java/lang/StackWalker/LocalsAndOperands.java#id1  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/StackWalker/ReflectionFrames.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/StackWalker/VerifyStackTrace.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1273	generic-all
-java/lang/String/CaseConvertSameInstance.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
-java/lang/String/CaseInsensitiveComparator.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
-java/lang/String/CompactString/IndexOf.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/String/CaseConvertSameInstance.java	https://github.com/eclipse/openj9/issues/6672	generic-all
+java/lang/String/CaseInsensitiveComparator.java	https://github.com/eclipse/openj9/issues/6665	generic-all
+java/lang/String/CompactString/IndexOf.java		https://github.com/eclipse/openj9/issues/6673	generic-all
 java/lang/String/EqualsIgnoreCase.java	https://github.com/eclipse/openj9/issues/6666	generic-all
 java/lang/String/StringRepeat.java	https://github.com/eclipse/openj9/issues/6667	generic-all
 java/lang/String/UnicodeCasingTest.java https://github.com/eclipse/openj9/issues/4597 linux-s390x
@@ -79,19 +80,17 @@ java/lang/invoke/ArrayConstructorTest.java	https://github.com/AdoptOpenJDK/openj
 java/lang/invoke/CallerSensitiveAccess.java	https://github.com/eclipse/openj9/issues/6768	generic-all
 java/lang/invoke/ClassSpecializerTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/invoke/DefineClassTest.java		https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
-java/lang/invoke/ExplicitCastArgumentsTest.java		https://github.com/eclipse/openj9/issues/6856	generic-all
+java/lang/invoke/ExplicitCastArgumentsTest.java		https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/invoke/FindAccessTest.java		https://github.com/eclipse/openj9/issues/6868	generic-all
-java/lang/invoke/InvokeWithArgumentsTest.java	https://github.com/eclipse/openj9/issues/6964	generic-all
 java/lang/invoke/LFCaching/LFMultiThreadCachingTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/invoke/LFCaching/LFSingleThreadCachingTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/invoke/LambdaFormTest.java		https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/invoke/LoopCombinatorTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
-java/lang/invoke/MethodHandlesGeneralTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
-java/lang/invoke/MethodHandlesInsertArgumentsTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/MethodHandlesGeneralTest.java	https://github.com/eclipse/openj9/issues/7043	generic-all
+java/lang/invoke/MethodHandlesInsertArgumentsTest.java	https://github.com/eclipse/openj9/issues/7057	generic-all
 java/lang/invoke/PrivateInterfaceCall.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
-java/lang/invoke/PrivateInvokeTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
-java/lang/invoke/RevealDirectTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
-java/lang/invoke/RicochetTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/invoke/PrivateInvokeTest.java	https://github.com/eclipse/openj9/issues/7071	generic-all
+java/lang/invoke/RevealDirectTest.java	https://github.com/eclipse/openj9/issues/8268	generic-all
 java/lang/invoke/SpecialInterfaceCall.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/invoke/SpreadCollectTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/invoke/TryFinallyTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
@@ -114,10 +113,10 @@ java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessShort.java	https://gi
 java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java	https://github.com/eclipse/openj9/issues/3940	generic-all
 java/lang/invoke/VarargsArrayTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/invoke/condy/CondyNestedTest.java https://github.com/eclipse/openj9/issues/4127 linux-ppc64le
+java/lang/invoke/condy/CondyNestedResolutionTest.java	https://github.com/eclipse/openj9/issues/7158	aix-all
 java/lang/invoke/lambda/LambdaStackTrace.java	https://github.com/eclipse/openj9/issues/3394	generic-all
-java/lang/module/ModuleFinderTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/749	windows-all
 java/lang/ref/CleanerTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
-java/lang/ref/EarlyTimeout.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/lang/ref/EarlyTimeout.java	https://github.com/eclipse/openj9/issues/7225	generic-all
 java/lang/ref/FinalizerHistogramTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/ref/NullQueue.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/ref/OOMEInReferenceHandler.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
@@ -132,7 +131,6 @@ java/lang/reflect/PublicMethods/PublicMethodsTest.java	https://github.com/eclips
 java/lang/reflect/exeCallerAccessTest/CallerAccessTest.java https://github.com/AdoptOpenJDK/openjdk-build/issues/248 generic-all
 jdk/modules/etc/DefaultModules.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
 jdk/modules/incubator/ImageModules.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
-jdk/modules/scenarios/automaticmodules/RunWithAutomaticModules.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/749	windows-all
 vm/JniInvocationTest.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	macosx-all
 
 ############################################################################
@@ -164,30 +162,12 @@ java/math/BigInteger/PrimeTest.java https://github.com/AdoptOpenJDK/openjdk-test
 
 # jdk_net
 
-java/net/CookieHandler/B6791927.java	https://bugs.openjdk.java.net/browse/JDK-8234007	generic-all
-java/net/HttpURLConnection/SetAuthenticator/HTTPSetAuthenticatorTest.java https://github.com/eclipse/openj9/issues/3568 generic-all
-java/net/InetAddress/IPv4Formats.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
-java/net/Inet6Address/B6206527.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/694 linux-all
+java/net/Inet4Address/PingThis.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1127	aix-all
 java/net/MulticastSocket/Promiscuous.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699 linux-s390x
 java/net/MulticastSocket/PromiscuousIPv6.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699	linux-s390x
 java/net/MulticastSocket/SetLoopbackMode.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699 linux-s390x
 java/net/MulticastSocket/Test.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699 linux-s390x
-java/net/Socket/asyncClose/AsyncClose.java https://github.com/eclipse/openj9/issues/4560 linux-all,windows-all,macosx-all
-java/net/SocketImpl/BadUsages.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/897 linux-all
-java/net/SocketOption/OptionsTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
-java/net/SocketOption/UnsupportedOptionsTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
-java/net/SocketPermission/SocketPermissionCollection.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
-java/net/SocketPermission/Wildcard.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
-java/net/Socks/SocksV4Test.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
-java/net/URL/OpenStream.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
-java/net/httpclient/ConnectExceptionTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
-java/net/httpclient/ConnectTimeoutNoProxyAsync.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/915	linux-s390x
-java/net/httpclient/ConnectTimeoutNoProxySync.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/915	linux-s390x
-java/net/httpclient/ConnectTimeoutWithProxyAsync.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/915	linux-s390x
-java/net/httpclient/ConnectTimeoutWithProxySync.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/915	linux-s390x
-java/net/httpclient/InvalidInputStreamSubscriptionRequest.java	https://github.com/eclipse/openj9/issues/4054	windows-all
-java/net/httpclient/RetryWithCookie.java	https://github.com/eclipse/openj9/issues/5140	windows-all
-java/net/httpclient/UnknownBodyLengthTest.java https://github.com/eclipse/openj9/issues/4593 windows-all,macosx-all
+java/net/Socket/asyncClose/AsyncClose.java https://github.com/eclipse/openj9/issues/4560 generic-all
 java/net/httpclient/websocket/BlowupOutputQueue.java https://github.com/eclipse/openj9/issues/4298 macosx-all
 java/net/httpclient/websocket/PendingBinaryPingClose.java https://github.com/eclipse/openj9/issues/4298 macosx-all
 java/net/httpclient/websocket/PendingBinaryPongClose.java https://github.com/eclipse/openj9/issues/4298 macosx-all
@@ -197,18 +177,14 @@ java/net/httpclient/websocket/PendingPongBinaryClose.java https://github.com/ecl
 java/net/httpclient/websocket/PendingPongTextClose.java https://github.com/eclipse/openj9/issues/4298 macosx-all
 java/net/httpclient/websocket/PendingTextPingClose.java https://github.com/eclipse/openj9/issues/4298 macosx-all
 java/net/httpclient/websocket/PendingTextPongClose.java https://github.com/eclipse/openj9/issues/4298 macosx-all
-java/net/ipv6tests/B6521014.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/694 linux-all
-com/sun/net/httpserver/bugs/B6361557.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1272	windows-all
 
 ############################################################################
 
 # jdk_io
 
-java/io/CharArrayReader/OverflowInRead.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
+java/io/CharArrayReader/OverflowInRead.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1500	generic-all
 java/io/FileInputStream/UnreferencedFISClosesFd.java  https://github.com/eclipse/openj9/issues/3543 generic-all
 java/io/FileOutputStream/UnreferencedFOSClosesFd.java https://github.com/eclipse/openj9/issues/3543 generic-all
-java/io/Serializable/concurrentClassDescLookup/ConcurrentClassDescLookup.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/602	windows-all
-java/io/StringBufferInputStream/OverflowInRead.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 
 ############################################################################
 
@@ -219,25 +195,18 @@ java/io/StringBufferInputStream/OverflowInRead.java https://github.com/AdoptOpen
 # jdk_nio
 
 java/nio/Buffer/DirectBufferAllocTest.java https://github.com/eclipse/openj9/issues/4473 generic-all
-java/nio/Buffer/LimitDirectMemory.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
-java/nio/Buffer/LimitDirectMemoryNegativeTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
-java/nio/channels/AsyncCloseAndInterrupt.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/602	linux-all
+java/nio/Buffer/LimitDirectMemory.java	https://github.com/eclipse/openj9/issues/8063	generic-all
+java/nio/Buffer/LimitDirectMemoryNegativeTest.java	https://github.com/eclipse/openj9/issues/8065	generic-all
+java/nio/channels/AsyncCloseAndInterrupt.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1597	linux-all,aix-all
 java/nio/channels/AsynchronousFileChannel/Basic.java https://bugs.openjdk.java.net/browse/JDK-7052549 windows-all
 java/nio/channels/AsynchronousSocketChannel/Basic.java	https://bugs.openjdk.java.net/browse/JDK-7052549	windows-all
-java/nio/channels/DatagramChannel/ConnectExceptions.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 #java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/AdoptOpenJDK/openjdk-tests/issues/1016
 #java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699 linux-s390x
 java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267 macosx-all,linux-s390x
 #java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue	https://github.com/eclipse/openj9/issues/6669
 java/nio/channels/DatagramChannel/Promiscuous.java              https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699    linux-s390x,macosx-all
 java/nio/channels/DatagramChannel/PromiscuousIPv6.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699    linux-s390x
-java/nio/channels/DatagramChannel/SendExceptions.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
-java/nio/channels/DatagramChannel/SocketOptionTests.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
-java/nio/channels/FileChannel/TempDirectBuffersReclamation.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
-java/nio/channels/FileChannel/directio/DirectIOTest.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	generic-all
-java/nio/channels/ServerSocketChannel/SocketOptionTests.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 java/nio/channels/SocketChannel/AdaptSocket.java https://github.com/eclipse/openj9/issues/4317 macosx-all
-java/nio/channels/spi/SelectorProvider/inheritedChannel/InheritedChannelTest.java	https://github.com/eclipse/openj9/issues/7624	linux-s390x
 java/nio/file/Files/CopyAndMove.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/795 macosx-all
 jdk/nio/zipfs/ZipFSTester.java https://github.com/eclipse/openj9/issues/4679 linux-x64,macosx-all
 
@@ -248,8 +217,7 @@ jdk/nio/zipfs/ZipFSTester.java https://github.com/eclipse/openj9/issues/4679 lin
 java/rmi/activation/Activatable/checkAnnotations/CheckAnnotations https://github.com/eclipse/openj9/issues/6749 windows-all
 java/rmi/dgc/dgcAckFailure/DGCAckFailure.java	https://github.com/eclipse/openj9/issues/3347	generic-all
 java/rmi/dgc/retryDirtyCalls/RetryDirtyCalls.java	https://github.com/eclipse/openj9/issues/7592	generic-all
-java/rmi/module/ModuleTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/749	windows-all
-java/rmi/server/RemoteServer/AddrInUse.java	https://github.com/eclipse/openj9/issues/3377	generic-all
+java/rmi/server/RemoteServer/AddrInUse.java		https://github.com/eclipse/openj9/issues/3377	generic-all
 java/rmi/server/UnicastRemoteObject/serialFilter/FilterUROTest.java	https://github.com/eclipse/openj9/issues/3347	generic-all
 java/rmi/server/UnicastRemoteObject/unexportObject/UnexportLeak.java https://github.com/eclipse/openj9/issues/4094 generic-all
 java/rmi/server/UnicastServerRef/serialFilter/FilterUSRTest.java	https://github.com/eclipse/openj9/issues/3347	generic-all
@@ -292,7 +260,8 @@ java/util/BitSet/stream/BitSetStreamTest.java https://github.com/eclipse/openj9/
 java/util/Spliterator/SpliteratorCollisions.java	https://github.com/eclipse/openj9/issues/7090	generic-all
 java/util/concurrent/ArrayBlockingQueue/WhiteBox.java 	https://github.com/eclipse/openj9/issues/5988 	macosx-all
 java/util/concurrent/forkjoin/FJExceptionTableLeak.java	https://github.com/eclipse/openj9/issues/3209	generic-all
-java/util/concurrent/locks/Lock/TimedAcquireLeak.java	https://github.com/eclipse/openj9/issues/7125	macosx-all,linux-all
+java/util/concurrent/locks/Lock/TimedAcquireLeak.java	https://github.com/eclipse/openj9/issues/7125	macosx-all,linux-all,aix-all
+java/util/logging/CheckZombieLockTest.java	https://bugs.openjdk.java.net/browse/JDK-8148972	macosx-all,linux-all
 java/util/logging/TestLoggerWeakRefLeak.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1352	generic-all
 java/util/logging/LogManager/TestLoggerNames.java https://github.com/eclipse/openj9/issues/4561 generic-all
 java/util/stream/boottest/java.base/java/util/stream/NodeTest.java https://github.com/eclipse/openj9/issues/4129 macosx-all
@@ -317,7 +286,5 @@ sun/net/www/protocol/file/DirPermissionDenied.java https://github.com/AdoptOpenJ
 sun/nio/ch/TestMaxCachedBufferSize.java		https://github.com/eclipse/openj9/issues/5328		generic-all
 
 vm/verifier/VerifyProtectedConstructor.java	https://github.com/eclipse/openj9/issues/7336	generic-all
-
-native_sanity/simplenativelauncher/ProgramTest.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/964 windows-all
 
 ############################################################################

--- a/openjdk/ProblemList_openjdk14-openj9.txt
+++ b/openjdk/ProblemList_openjdk14-openj9.txt
@@ -88,6 +88,7 @@ java/lang/invoke/LFCaching/LFMultiThreadCachingTest.java	https://github.com/Adop
 java/lang/invoke/LFCaching/LFSingleThreadCachingTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/invoke/LambdaFormTest.java		https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/invoke/LoopCombinatorTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
+java/lang/invoke/MethodHandles/privateLookupIn/Driver.java https://github.com/eclipse/openj9/issues/8571 generic-all
 java/lang/invoke/MethodHandlesGeneralTest.java	https://github.com/eclipse/openj9/issues/7043	generic-all
 java/lang/invoke/MethodHandlesInsertArgumentsTest.java	https://github.com/eclipse/openj9/issues/7057	generic-all
 java/lang/invoke/PrivateInterfaceCall.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
@@ -118,6 +119,8 @@ java/lang/invoke/condy/CondyNestedTest.java https://github.com/eclipse/openj9/is
 java/lang/invoke/condy/CondyNestedResolutionTest.java	https://github.com/eclipse/openj9/issues/7158	aix-all
 java/lang/invoke/lambda/LambdaStackTrace.java	https://github.com/eclipse/openj9/issues/3394	generic-all
 java/lang/invoke/lookup/LookupClassTest.java    https://github.com/eclipse/openj9/issues/8570   generic-all
+java/lang/invoke/modules/Driver.java    https://github.com/eclipse/openj9/issues/8571   generic-all
+java/lang/invoke/modules/Driver1.java   https://github.com/eclipse/openj9/issues/8571   generic-all
 java/lang/ref/CleanerTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/ref/EarlyTimeout.java	https://github.com/eclipse/openj9/issues/7225	generic-all
 java/lang/ref/FinalizerHistogramTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all

--- a/openjdk/ProblemList_openjdk14-openj9.txt
+++ b/openjdk/ProblemList_openjdk14-openj9.txt
@@ -236,6 +236,7 @@ jdk/nio/zipfs/ZipFSTester.java https://github.com/eclipse/openj9/issues/4679 lin
 java/rmi/activation/Activatable/checkAnnotations/CheckAnnotations https://github.com/eclipse/openj9/issues/6749 windows-all
 java/rmi/dgc/dgcAckFailure/DGCAckFailure.java	https://github.com/eclipse/openj9/issues/3347	generic-all
 java/rmi/dgc/retryDirtyCalls/RetryDirtyCalls.java	https://github.com/eclipse/openj9/issues/7592	generic-all
+java/rmi/server/RMISocketFactory/useSocketFactory/unicast/TCPEndpointReadBug.java	https://github.com/eclipse/openj9/issues/8515	generic-all
 java/rmi/server/RemoteServer/AddrInUse.java		https://github.com/eclipse/openj9/issues/3377	generic-all
 java/rmi/server/UnicastRemoteObject/serialFilter/FilterUROTest.java	https://github.com/eclipse/openj9/issues/3347	generic-all
 java/rmi/server/UnicastRemoteObject/unexportObject/UnexportLeak.java https://github.com/eclipse/openj9/issues/4094 generic-all

--- a/openjdk/ProblemList_openjdk14-openj9.txt
+++ b/openjdk/ProblemList_openjdk14-openj9.txt
@@ -81,6 +81,7 @@ java/lang/invoke/ArrayConstructorTest.java	https://github.com/AdoptOpenJDK/openj
 java/lang/invoke/CallerSensitiveAccess.java	https://github.com/eclipse/openj9/issues/6768	generic-all
 java/lang/invoke/ClassSpecializerTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/invoke/DefineClassTest.java		https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
+java/lang/invoke/DropLookupModeTest.java    https://github.com/eclipse/openj9/issues/8570   generic-all
 java/lang/invoke/ExplicitCastArgumentsTest.java		https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/invoke/FindAccessTest.java		https://github.com/eclipse/openj9/issues/6868	generic-all
 java/lang/invoke/LFCaching/LFMultiThreadCachingTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all

--- a/openjdk/ProblemList_openjdk14-openj9.txt
+++ b/openjdk/ProblemList_openjdk14-openj9.txt
@@ -54,6 +54,7 @@ java/lang/String/CaseInsensitiveComparator.java	https://github.com/eclipse/openj
 java/lang/String/CompactString/IndexOf.java		https://github.com/eclipse/openj9/issues/6673	generic-all
 java/lang/String/EqualsIgnoreCase.java	https://github.com/eclipse/openj9/issues/6666	generic-all
 java/lang/String/StringRepeat.java	https://github.com/eclipse/openj9/issues/6667	generic-all
+java/lang/String/TranslateEscapes.java https://github.com/eclipse/openj9/issues/8563 generic-all
 java/lang/String/UnicodeCasingTest.java https://github.com/eclipse/openj9/issues/4597 linux-s390x
 java/lang/String/nativeEncoding/StringPlatformChars.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	generic-all
 java/lang/System/Logger/custom/CustomLoggerTest.java	https://github.com/eclipse/openj9/issues/6674	generic-all

--- a/openjdk/ProblemList_openjdk14.txt
+++ b/openjdk/ProblemList_openjdk14.txt
@@ -22,11 +22,10 @@
 
 # jdk_lang
 java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	generic-all
-java/lang/module/ModuleFinderTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/749	windows-all
 java/lang/String/nativeEncoding/StringPlatformChars.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	generic-all
-jdk/modules/scenarios/automaticmodules/RunWithAutomaticModules.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/749	windows-all
 vm/JniInvocationTest.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	macosx-all
 java/lang/reflect/exeCallerAccessTest/CallerAccessTest.java https://github.com/AdoptOpenJDK/openjdk-build/issues/248 generic-all
+java/lang/ProcessBuilder/Basic.java#id0		https://github.com/AdoptOpenJDK/openjdk-tests/issues/1397	aix-all
 java/lang/System/LoggerFinder/modules/JDKLoggerForImageTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
 java/lang/System/LoggerFinder/modules/LoggerInImageTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
 java/lang/System/LoggerFinder/modules/NamedLoggerForImageTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
@@ -36,6 +35,26 @@ jdk/modules/incubator/ImageModules.java	https://github.com/AdoptOpenJDK/openjdk-
 java/lang/Class/GetPackageBootLoaderChildLayer.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
 #java/lang/String/StringRepeat.java https://bugs.openjdk.java.net/browse/JDK-8221400
 java/lang/String/StringRepeat.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1272 windows-all
+java/lang/invoke/VarHandles/VarHandleTestAccessBoolean.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1118	linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessByte.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1118	linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessChar.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1118	linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessDouble.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1118	linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessFloat.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1118	linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessInt.java		https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1118	linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessLong.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1118  linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessShort.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1118  linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessString.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1118  linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestByteArrayAsDouble.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1118	linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestByteArrayAsFloat.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1118	linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessBoolean.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1118  linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessByte.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1118  linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessChar.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1118  linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessDouble.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1118  linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessFloat.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1118  linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessInt.java		https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1118  linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessLong.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1118  linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessShort.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1118  linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1118	linux-aarch64
 ############################################################################
 
 # jdk_management
@@ -55,21 +74,17 @@ java/lang/String/StringRepeat.java	https://github.com/AdoptOpenJDK/openjdk-tests
 ############################################################################
 
 # jdk_net
-java/net/CookieHandler/B6791927.java	https://bugs.openjdk.java.net/browse/JDK-8234007	generic-all
+java/net/Inet4Address/PingThis.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1127	aix-all
 java/net/InetAddress/BadDottedIPAddress.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/593	linux-all
 java/net/InetAddress/CachedUnknownHostName.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/593	linux-all
 java/net/InetAddress/IPv4Formats.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/593	linux-all
 java/net/MulticastSocket/PromiscuousIPv6.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699	linux-s390x
-java/net/SocketImpl/BadUsages.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/897 linux-all
 java/net/SocketPermission/SocketPermissionCollection.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/593	linux-all
 java/net/SocketPermission/Wildcard.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/593	linux-all
 java/net/Socks/SocksV4Test.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/593	linux-all
 java/net/URL/OpenStream.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/593	linux-all
 java/net/httpclient/ConnectExceptionTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/593	linux-all
-java/net/Inet6Address/B6206527.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/602	linux-all
-java/net/ipv6tests/B6521014.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/602	linux-all
 java/net/httpclient/AsFileDownloadTest.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/893	linux-all
-java/net/httpclient/InvalidInputStreamSubscriptionRequest.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/893	linux-all
 java/net/httpclient/StreamingBody.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/893	linux-all
 java/net/httpclient/http2/ContinuationFrameTest.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/893	linux-all
 java/net/httpclient/SpecialHeadersTest.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/893	linux-all
@@ -77,8 +92,6 @@ java/net/httpclient/http2/BadHeadersTest.java	https://github.com/AdoptOpenJDK/op
 java/net/httpclient/DigestEchoClientSSL.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/893	linux-all
 java/net/httpclient/ResponseBodyBeforeError.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/893	linux-all
 java/net/httpclient/ResponsePublisher.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/893	linux-all
-sun/net/www/protocol/file/DirPermissionDenied.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/760 windows-all
-java/net/httpclient/UnknownBodyLengthTest.java	https://bugs.openjdk.java.net/browse/JDK-8210130	windows-all
 java/net/MulticastSocket/Promiscuous.java               https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699    linux-s390x
 java/net/MulticastSocket/SetLoopbackMode.java     https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699    linux-s390x
 java/net/MulticastSocket/Test.java                             https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699    linux-s390x
@@ -87,15 +100,9 @@ java/net/MulticastSocket/Test.java                             https://github.co
 java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267 macosx-all,linux-s390x
 #java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue	https://github.com/AdoptOpenJDK/openjdk-tests/issues/602
 java/nio/channels/DatagramChannel/Promiscuous.java              https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699    linux-s390x,macosx-all
-com/sun/net/httpserver/bugs/B6361557.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1272	windows-all
-java/net/httpclient/ConnectTimeoutNoProxyAsync.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/915	linux-s390x
-java/net/httpclient/ConnectTimeoutNoProxySync.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/915	linux-s390x
-java/net/httpclient/ConnectTimeoutWithProxyAsync.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/915	linux-s390x
-java/net/httpclient/ConnectTimeoutWithProxySync.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/915	linux-s390x
 ############################################################################
 
 # jdk_io
-java/io/Serializable/concurrentClassDescLookup/ConcurrentClassDescLookup.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/602	windows-all
 
 ############################################################################
 
@@ -104,10 +111,9 @@ java/io/Serializable/concurrentClassDescLookup/ConcurrentClassDescLookup.java	ht
 ############################################################################
 
 # jdk_nio
-java/nio/channels/FileChannel/directio/DirectIOTest.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	generic-all
 java/nio/channels/spi/SelectorProvider/inheritedChannel/InheritedChannelTest.java https://github.com/AdoptOpenJDK/openjdk-build/issues/248	generic-all
 java/nio/file/attribute/BasicFileAttributeView/UnixSocketFile.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/593	linux-all
-java/nio/channels/AsyncCloseAndInterrupt.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/593	linux-all
+java/nio/channels/AsyncCloseAndInterrupt.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1597	linux-all,aix-all
 java/nio/charset/spi/CharsetProviderBasicTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/593	linux-all
 java/nio/channels/DatagramChannel/ConnectExceptions.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/593	linux-all
 java/nio/channels/DatagramChannel/SendExceptions.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/593	linux-all
@@ -120,7 +126,6 @@ java/nio/channels/DatagramChannel/PromiscuousIPv6.java	https://github.com/AdoptO
 ############################################################################ 
 
 # jdk_rmi
-java/rmi/module/ModuleTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/749	windows-all
 ############################################################################
 
 # jdk_security


### PR DESCRIPTION
Now that testing is enabled on JDK14, update the Problem lists with the final changes from jdk13
Also includes recent failures from m1 builds

Signed-off-by: Adam Thorpe <adam.thorpe@ibm.com>