### PR TITLE
Revert back to silent curl output on SDK fetch

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -311,7 +311,7 @@ def get_sources_with_authentication() {
 }
 
 def get_sources() {
-	withEnv(['VERBOSE_CURL=VERBOSE']) {
+	withEnv(['VERBOSE_CURL=SILENT']) {
 		if (params.CUSTOMIZED_SDK_URL_CREDENTIAL_ID) {
 			// USERNAME and PASSWORD reference with a withCredentials block will not be visible within job output
 			withCredentials([usernamePassword(credentialsId: "${params.CUSTOMIZED_SDK_URL_CREDENTIAL_ID}", usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {


### PR DESCRIPTION
Leaving in the framework so it can be easily changed in the
future or by developers.

Related #1572 eclipse/openj9#8343

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>