### PR TITLE
Fix indentation in jck build file

### DIFF
--- a/jck/build.xml
+++ b/jck/build.xml
@@ -84,28 +84,28 @@
 			</else>
 			
 		</if>
-                <if>
-                        <isset property="isZOS" />
-                        <then>
-                                <echo message="Performing hard reset of ${JCK_ROOT_USED} using .gitattributes.zos for file conversions..."/>
-                                <delete includeemptydirs="true" failonerror="false">
-                                   <fileset dir="${JCK_ROOT_USED}/.git/info" includes="**/*"/>
-                                </delete>
-                                <mkdir dir="${JCK_ROOT_USED}/.git/info" />
-                                <move file="${JCK_ROOT_USED}/.gitattributes.zos" tofile="${JCK_ROOT_USED}/.git/info/attributes" />
-                                <exec executable="git" dir="${JCK_ROOT_USED}" failonerror="false">
-                                    <arg value="rm" />
-                                    <arg value="--cached" />
-                                    <arg value="-r" />
-                                    <arg value="-q" />
-                                    <arg value="." />
-                               </exec>
-                                <exec executable="git" dir="${JCK_ROOT_USED}" failonerror="false">
-                                    <arg value="reset" />
-                                    <arg value="--hard" />
-                                </exec>
-                        </then>
-                </if>
+		<if>
+			<isset property="isZOS" />
+			<then>
+				<echo message="Performing hard reset of ${JCK_ROOT_USED} using .gitattributes.zos for file conversions..."/>
+				<delete includeemptydirs="true" failonerror="false">
+				   <fileset dir="${JCK_ROOT_USED}/.git/info" includes="**/*"/>
+				</delete>
+				<mkdir dir="${JCK_ROOT_USED}/.git/info" />
+				<move file="${JCK_ROOT_USED}/.gitattributes.zos" tofile="${JCK_ROOT_USED}/.git/info/attributes" />
+				<exec executable="git" dir="${JCK_ROOT_USED}" failonerror="false">
+					<arg value="rm" />
+					<arg value="--cached" />
+					<arg value="-r" />
+					<arg value="-q" />
+					<arg value="." />
+				</exec>
+				<exec executable="git" dir="${JCK_ROOT_USED}" failonerror="false">
+					<arg value="reset" />
+					<arg value="--hard" />
+				</exec>
+			</then>
+		</if>
 		<!--Make all .sh files below ${JCK_ROOT_USED} readable and executable for anyone on a UNIX system. 
 			This is especially needed to execute the shell scripts under devtools for JCK 8.
 		-->


### PR DESCRIPTION
- Use tab instead of space to indent the if block for z/OS

Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>