### PR TITLE
Fix system test command line for hs

### DIFF
--- a/system/systemtest.mk
+++ b/system/systemtest.mk
@@ -41,9 +41,14 @@ endif
 
 SYSTEMTEST_RESROOT=$(TEST_RESROOT)/../
 
+OPENJ9_PRAM=""
+ifeq (,$(findstring $(JDK_IMPL),hotspot))
+	OPENJ9_PRAM=;$(SYSTEMTEST_RESROOT)$(D)openj9-systemtest
+endif
+
 define SYSTEMTEST_CMD_TEMPLATE
 perl $(SYSTEMTEST_RESROOT)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl \
-	-test-root=$(Q)$(SYSTEMTEST_RESROOT)$(D)stf;$(SYSTEMTEST_RESROOT)$(D)openjdk-systemtest;$(SYSTEMTEST_RESROOT)$(D)openj9-systemtest$(Q) \
+	-test-root=$(Q)$(SYSTEMTEST_RESROOT)$(D)stf;$(SYSTEMTEST_RESROOT)$(D)openjdk-systemtest$(OPENJ9_PRAM)$(Q) \
 	-systemtest-prereqs=$(Q)$(SYSTEMTEST_RESROOT)$(D)systemtest_prereqs$(Q) \
 	-java-args=$(Q)$(JVM_OPTIONS)$(Q) \
 	-results-root=$(REPORTDIR)


### PR DESCRIPTION
- Resolves https://github.com/AdoptOpenJDK/openjdk-tests/issues/1654
- Creates two separate command templates - one with openj9-systemtest in path, and one without and uses the two templates appropriately in playlists. This solves the issue of system tests breaking in hotspot builds where we do not use openj9-systemtest.

Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>