### PR TITLE
Disable SyntheticGCWorkload_DoubleMap_J9 test on OpenJ9 AArch64

### DIFF
--- a/functional/SyntheticGCWorkload/playlist.xml
+++ b/functional/SyntheticGCWorkload/playlist.xml
@@ -153,7 +153,8 @@
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -cp $(Q)$(TEST_RESROOT)$(D)SyntheticGCWorkload.jar$(Q) net.adoptopenjdk.casa.workload_sessions.Main $(TEST_RESROOT)/config/config_doubleMapStress.xml -n; \
 	${TEST_STATUS}</command>
-		<platformRequirements>bits.64,os.linux</platformRequirements>
+		<!-- Temporarily disable this test on AArch64; github.com/eclipse/openj9/issues/8034 -->
+		<platformRequirements>bits.64,os.linux,^arch.aarch64</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>


### PR DESCRIPTION
This commit disables SyntheticGCWorkload_DoubleMap_J9 test on OpenJ9
AArch64 until the balanced GC policy is supported.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>