### PR TITLE
Disable ConcurrentScavenge tests for OpenJ9 AArch64

### DIFF
--- a/system/daaLoadTest/playlist.xml
+++ b/system/daaLoadTest/playlist.xml
@@ -113,7 +113,8 @@
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
-		<platformRequirements>bits.64,^arch.arm</platformRequirements>
+		<!-- concurrentScavenge is unsupported on aarch64; github.com/eclipse/openj9/issues/8762 -->
+		<platformRequirements>bits.64,^arch.arm,^arch.aarch64</platformRequirements>
 	</test>
 	
 	<test>
@@ -133,7 +134,8 @@
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
-		<platformRequirements>bits.64,^arch.arm</platformRequirements>
+		<!-- concurrentScavenge is unsupported on aarch64; github.com/eclipse/openj9/issues/8762 -->
+		<platformRequirements>bits.64,^arch.arm,^arch.aarch64</platformRequirements>
 	</test>
 	
 	<test>
@@ -153,7 +155,8 @@
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
-		<platformRequirements>bits.64,^arch.arm</platformRequirements>
+		<!-- concurrentScavenge is unsupported on aarch64; github.com/eclipse/openj9/issues/8762 -->
+		<platformRequirements>bits.64,^arch.arm,^arch.aarch64</platformRequirements>
 	</test>
 	
 	<test>
@@ -173,7 +176,8 @@
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
-		<platformRequirements>bits.64,^arch.arm</platformRequirements>
+		<!-- concurrentScavenge is unsupported on aarch64; github.com/eclipse/openj9/issues/8762 -->
+		<platformRequirements>bits.64,^arch.arm,^arch.aarch64</platformRequirements>
 	</test>
 	
 	<test>

--- a/system/lambdaLoadTest/playlist.xml
+++ b/system/lambdaLoadTest/playlist.xml
@@ -111,7 +111,8 @@
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
-		<platformRequirements>bits.64,^arch.arm,^spec.linux_ppc-64_le,^spec.linux_x86-64</platformRequirements>
+		<!-- concurrentScavenge is unsupported on aarch64; github.com/eclipse/openj9/issues/8762 -->
+		<platformRequirements>bits.64,^arch.arm,^arch.aarch64,^spec.linux_ppc-64_le,^spec.linux_x86-64</platformRequirements>
 	</test>
 	
 	<test>

--- a/system/mathLoadTest/playlist.xml
+++ b/system/mathLoadTest/playlist.xml
@@ -81,7 +81,8 @@
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
-		<platformRequirements>bits.64,^arch.arm</platformRequirements>
+		<!-- concurrentScavenge is unsupported on aarch64; github.com/eclipse/openj9/issues/8762 -->
+		<platformRequirements>bits.64,^arch.arm,^arch.aarch64</platformRequirements>
 	</test>
 	
 	<test>
@@ -101,7 +102,8 @@
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
-		<platformRequirements>bits.64,^arch.arm</platformRequirements>
+		<!-- concurrentScavenge is unsupported on aarch64; github.com/eclipse/openj9/issues/8762 -->
+		<platformRequirements>bits.64,^arch.arm,^arch.aarch64</platformRequirements>
 	</test>
 	
 	<test>
@@ -121,7 +123,8 @@
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
-		<platformRequirements>bits.64,^arch.arm</platformRequirements>
+		<!-- concurrentScavenge is unsupported on aarch64; github.com/eclipse/openj9/issues/8762 -->
+		<platformRequirements>bits.64,^arch.arm,^arch.aarch64</platformRequirements>
 	</test>
 	
 	<test>

--- a/system/mauveLoadTest/playlist.xml
+++ b/system/mauveLoadTest/playlist.xml
@@ -127,7 +127,8 @@
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
-		<platformRequirements>bits.64,^arch.arm</platformRequirements>
+		<!-- concurrentScavenge is unsupported on aarch64; github.com/eclipse/openj9/issues/8762 -->
+		<platformRequirements>bits.64,^arch.arm,^arch.aarch64</platformRequirements>
 		<disabled>AdoptOpenJDK/openjdk-systemtest/issues/75</disabled>
 	</test>
 	

--- a/system/otherLoadTest/playlist.xml
+++ b/system/otherLoadTest/playlist.xml
@@ -298,6 +298,7 @@
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
-		<platformRequirements>bits.64,^arch.arm</platformRequirements>
+		<!-- concurrentScavenge is unsupported on aarch64; github.com/eclipse/openj9/issues/8762 -->
+		<platformRequirements>bits.64,^arch.arm,^arch.aarch64</platformRequirements>
 	</test>
 </playlist>


### PR DESCRIPTION
This commit disables tests that use -Xgc:oncurrentScavenge for OpenJ9
on AArch64.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>