### PR TITLE
Adding MixedLoadTest to otherLoadTest as part of Load_Level_4 playlist

### DIFF
--- a/system/otherLoadTest/playlist.xml
+++ b/system/otherLoadTest/playlist.xml
@@ -314,6 +314,9 @@
 		<groups>
 			<group>system</group>
 		</groups>
+		<impls>
+			<impl>ibm</impl>
+		</impls>
 	</test>
 	
 </playlist>

--- a/system/otherLoadTest/playlist.xml
+++ b/system/otherLoadTest/playlist.xml
@@ -300,4 +300,20 @@
 		</impls>
 		<platformRequirements>bits.64,^arch.arm</platformRequirements>
 	</test>
+	
+	<test>
+		<testCaseName>MixedLoadTest</testCaseName>
+		<variations>
+			<variation>NoOptions</variation> 
+		</variations>
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MixedLoadTest; \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>system</group>
+		</groups>
+	</test>
+	
 </playlist>


### PR DESCRIPTION
I've added a new test called MixedLoadTest to otherLoadTest as part of Load_Level_4 playlist which is a mix of workloads.