### PR TITLE
Remove the downloaded file before retry

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -217,6 +217,13 @@ getBinaryOpenjdk()
 					sleep_time=300
 					echo "curl error code: $download_exit_code. Sleep $sleep_time secs, then retry $count..."
 					sleep $sleep_time
+
+					download_filename=${file##*/}
+					echo "check for $download_filename..."
+					if [ -f "$download_filename" ]; then
+						echo "remove $download_filename before retry..."
+						rm $download_filename
+					fi
 				fi
 
 				case "$VERBOSE_CURL" in


### PR DESCRIPTION
If curl fails to download a file, it may leave a damaged file on disk
(i.e., file that is partially downloaded). This PR removes the file if
it exists, so that retry can re-download the file without File exists
error.

Issue: #1667

Signed-off-by: lanxia <lan_xia@ca.ibm.com>