### PR TITLE
Allow AUTO_DETECT to be set in template

### DIFF
--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -28,6 +28,7 @@ if (!binding.hasVariable('JCK_GIT_REPO')) JCK_GIT_REPO = ""
 if (!binding.hasVariable('JCK_GIT_REPO_PREFIX')) JCK_GIT_REPO_PREFIX = ""
 if (!binding.hasVariable('SSH_AGENT_CREDENTIAL')) SSH_AGENT_CREDENTIAL = ""
 if (!binding.hasVariable('KEEP_REPORTDIR')) KEEP_REPORTDIR = "true"
+if (!binding.hasVariable('AUTO_DETECT')) AUTO_DETECT = true
 
 if (!binding.hasVariable('BUILDS_TO_KEEP')) {
 	BUILDS_TO_KEEP = 10
@@ -159,7 +160,7 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							stringParam('VENDOR_TEST_DIRS', "", "Optional. Addtional test dirs")
 							stringParam('KEEP_REPORTDIR', KEEP_REPORTDIR, "Keep the test report dir if the test passes?")
 							stringParam('BUILD_IDENTIFIER', "", "build identifier")
-							booleanParam('AUTO_DETECT', true, "Optional. Default is to enable AUTO_DETECT")
+							booleanParam('AUTO_DETECT', AUTO_DETECT.toBoolean(), "Optional. Default is to enable AUTO_DETECT")
 							stringParam('TIME_LIMIT', TIME_LIMIT, "time limit")
 							stringParam('RELEASE_TAG', "", "SCM tag from which to run tests")
 							stringParam('OPENJDK_SHA', "", "OpenJDK SHA from which to run tests")


### PR DESCRIPTION
Having the ability to set AUTO_DETECT to false, will allow
us to generate Valhalla builds with this value set to false
by default. Therefore not having to pass it to the test job.
Since the Valhalla test jobs will be separate, this will
not affect other jobs. Default value will still be true.

Related eclipse/openj9#4719

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>