### PR TITLE
OpenJ9 AArch64: Exclude some tests that depend on GC

### DIFF
--- a/openjdk/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/ProblemList_openjdk11-openj9.txt
@@ -249,12 +249,15 @@ java/rmi/server/UnicastServerRef/serialFilter/FilterUSRTest.java	https://github.
 java/util/Arrays/TimSortStackSize2.java	https://github.com/eclipse/openj9/issues/7086	generic-all
 java/util/Arrays/largeMemory/ParallelPrefix.java https://github.com/eclipse/openj9/issues/4100 linux-ppc64le
 java/util/BitSet/stream/BitSetStreamTest.java https://github.com/eclipse/openj9/issues/4720 linux-all
+java/util/WeakHashMap/GCDuringIteration.java	https://github.com/eclipse/openj9/issues/9043	linux-aarch64
 java/util/Spliterator/SpliteratorCollisions.java	https://github.com/eclipse/openj9/issues/7090	generic-all
+java/util/concurrent/ArrayBlockingQueue/WhiteBox.java	https://github.com/eclipse/openj9/issues/9044	linux-aarch64
 java/util/concurrent/atomic/VMSupportsCS8.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/util/concurrent/forkjoin/FJExceptionTableLeak.java	https://github.com/eclipse/openj9/issues/3209	generic-all
 java/util/concurrent/locks/Lock/TimedAcquireLeak.java	https://github.com/eclipse/openj9/issues/7125	macosx-all,linux-all,aix-all
 java/util/concurrent/TimeUnit/Basic.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1665 windows-all
 java/util/logging/CheckZombieLockTest.java	https://bugs.openjdk.java.net/browse/JDK-8148972	macosx-all,linux-all
+java/util/logging/LogManager/Configuration/ParentLoggerWithHandlerGC.java	https://github.com/eclipse/openj9/issues/8897	linux-aarch64
 java/util/logging/LogManager/TestLoggerNames.java https://github.com/eclipse/openj9/issues/4561 generic-all
 java/util/logging/TestLoggerWeakRefLeak.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/util/stream/boottest/java.base/java/util/stream/NodeTest.java https://github.com/eclipse/openj9/issues/4129 macosx-all


### PR DESCRIPTION
This commit excludes the following 3 tests.
- java/util/logging/LogManager/Configuration/ParentLoggerWithHandlerGC.java eclipse/openj9#8897
- java/util/WeakHashMap/GCDuringIteration.java eclipse/openj9#9043
- java/util/concurrent/ArrayBlockingQueue/WhiteBox.java eclipse/openj9#9044

These tests depend on GC behavior as discussed in eclipse/openj9#8897.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>