### PR TITLE
Add Humble Benchmarks

### DIFF
--- a/perf/bumbleBench/playlist.xml
+++ b/perf/bumbleBench/playlist.xml
@@ -375,6 +375,63 @@
 			<group>perf</group>
 		</groups>
 	</test>	
+	<!-- Humble Benchmarks -->
+	<test>
+		<testCaseName>bumbleBench-DistinctStringsEqualsBench</testCaseName>
+		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar DistinctStringsEqualsBench; \
+		$(TEST_STATUS)</command>
+		<impls>
+			<impl>openj9</impl> <!-- Issue for JDK 11 HotSpot: https://github.com/AdoptOpenJDK/bumblebench/issues/24 -->
+		</impls>				
+		<levels>
+			<level>special</level>
+		</levels>
+		<groups>
+			<group>perf</group>
+		</groups>
+	</test>
+	<test>
+		<testCaseName>bumbleBench-NewStringBufferWithCapacityBench</testCaseName>
+		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar NewStringBufferWithCapacityBench; \
+		$(TEST_STATUS)</command>
+		<impls>
+			<impl>openj9</impl> <!-- Issue for JDK 11 HotSpot: https://github.com/AdoptOpenJDK/bumblebench/issues/24 -->
+		</impls>				
+		<levels>
+			<level>special</level>
+		</levels>
+		<groups>
+			<group>perf</group>
+		</groups>
+	</test>
+	<test>
+		<testCaseName>bumbleBench-NewStringBuilderWithCapacityBench</testCaseName>
+		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar NewStringBuilderWithCapacityBench; \
+		$(TEST_STATUS)</command>
+		<impls>
+			<impl>openj9</impl> <!-- Issue for JDK 11 HotSpot: https://github.com/AdoptOpenJDK/bumblebench/issues/24 -->
+		</impls>				
+		<levels>
+			<level>special</level>
+		</levels>
+		<groups>
+			<group>perf</group>
+		</groups>
+	</test>	
+	<test>
+		<testCaseName>bumbleBench-SameStringsEqualsBench</testCaseName>
+		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar SameStringsEqualsBench; \
+		$(TEST_STATUS)</command>
+		<impls>
+			<impl>openj9</impl> <!-- Issue for JDK 11 HotSpot: https://github.com/AdoptOpenJDK/bumblebench/issues/24 -->
+		</impls>		
+		<levels>
+			<level>special</level>
+		</levels>
+		<groups>
+			<group>perf</group>
+		</groups>
+	</test>				
 	<!-- Lambda Benchmarks -->
 	<test>
 		<testCaseName>bumbleBench-DispatchBench-InnerClasses</testCaseName>


### PR DESCRIPTION
• Added Crypto benchmarks from BumbleBench: DistinctStringsEqualsBench, NewStringBufferWithCapacityBench, NewStringBuilderWithCapacityBench & SameStringsEqualsBench

Issue: https://github.com/AdoptOpenJDK/openjdk-tests/issues/1379

Signed-off-by: Piyush Gupta <piyush286@gmail.com>