### PR TITLE
Exclude tests

### DIFF
--- a/openjdk/ProblemList_openjdk8.txt
+++ b/openjdk/ProblemList_openjdk8.txt
@@ -288,13 +288,15 @@ com/sun/jdi/EvalInterfaceStatic.sh  https://github.com/AdoptOpenJDK/openjdk-test
 com/sun/jdi/GetLocalVariables3Test.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
 com/sun/jdi/GetLocalVariables4Test.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
 com/sun/jdi/JdbLockTest.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
-com/sun/jdi/JdbMethodExitTest.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
+com/sun/jdi/JdbMethodExitTest.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all, linux-s390x
+# com/sun/jdi/JdbMethodExitTest.sh on s390x JBS https://bugs.openjdk.java.net/browse/JDK-8201652
 com/sun/jdi/JdbMissStep.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
 com/sun/jdi/JdbVarargsTest.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
 com/sun/jdi/MixedSuspendTest.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
 com/sun/jdi/NotAField.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
 com/sun/jdi/NullLocalVariable.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
-com/sun/jdi/Redefine-g.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
+com/sun/jdi/Redefine-g.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all, linux-s390x
+# com/sun/jdi/Redefine-g.sh on s390x JBS https://bugs.openjdk.java.net/browse/JDK-8201652
 com/sun/jdi/RedefineAbstractClass.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
 com/sun/jdi/RedefineAddPrivateMethod.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
 com/sun/jdi/RedefineAnnotation.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all

--- a/openjdk/ProblemList_openjdk8.txt
+++ b/openjdk/ProblemList_openjdk8.txt
@@ -274,43 +274,43 @@ com/sun/tools/attach/StartManagementAgent.java	https://github.com/AdoptOpenJDK/o
 # jdk_jdi
 
 com/sun/jdi/RedefineCrossEvent.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/227	macosx-all
-com/sun/jdi/EvalArraysAsList.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1718 aix-all, windows-x64, windows-x32
-# com/sun/jdi/EvalArraysAsList.sh on windows_x64 and windows_x32 issue https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711
-com/sun/jdi/ArrayLengthDumpTest.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-x64, windows-x32
-com/sun/jdi/BreakpointWithFullGC.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-x64, windows-x32
-com/sun/jdi/CatchAllTest.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-x64, windows-x32
-com/sun/jdi/CatchCaughtTest.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-x64, windows-x32
-com/sun/jdi/CatchPatternTest.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-x64, windows-x32
-com/sun/jdi/CommandCommentDelimiter.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-x64, windows-x32
-com/sun/jdi/DeoptimizeWalk.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-x64, windows-x32
-com/sun/jdi/EvalArgs.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-x64, windows-x32
-com/sun/jdi/EvalInterfaceStatic.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-x64, windows-x32
-com/sun/jdi/GetLocalVariables3Test.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-x64, windows-x32
-com/sun/jdi/GetLocalVariables4Test.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-x64, windows-x32
-com/sun/jdi/JdbLockTest.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-x64, windows-x32
-com/sun/jdi/JdbMethodExitTest.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-x64, windows-x32
-com/sun/jdi/JdbMissStep.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-x64, windows-x32
-com/sun/jdi/JdbVarargsTest.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-x64, windows-x32
-com/sun/jdi/MixedSuspendTest.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-x64, windows-x32
-com/sun/jdi/NotAField.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-x64, windows-x32
-com/sun/jdi/NullLocalVariable.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-x64, windows-x32
-com/sun/jdi/Redefine-g.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-x64, windows-x32
-com/sun/jdi/RedefineAbstractClass.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-x64, windows-x32
-com/sun/jdi/RedefineAddPrivateMethod.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-x64, windows-x32
-com/sun/jdi/RedefineAnnotation.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-x64, windows-x32
-com/sun/jdi/RedefineChangeClassOrder.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-x64, windows-x32
-com/sun/jdi/RedefineClasses.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-x64, windows-x32
-com/sun/jdi/RedefineClearBreakpoint.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-x64, windows-x32
-com/sun/jdi/RedefineException.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-x64, windows-x32
-com/sun/jdi/RedefineFinal.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-x64, windows-x32
-com/sun/jdi/RedefineImplementor.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-x64, windows-x32
-com/sun/jdi/RedefineIntConstantToLong.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-x64, windows-x32
-com/sun/jdi/RedefineMulti.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-x64, windows-x32
-com/sun/jdi/RedefinePop.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-x64, windows-x32
-com/sun/jdi/RedefineStep.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-x64, windows-x32
-com/sun/jdi/RedefineTTYLineNumber.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-x64, windows-x32
-com/sun/jdi/StringConvertTest.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-x64, windows-x32
-com/sun/jdi/WatchFramePop.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-x64, windows-x32
+com/sun/jdi/EvalArraysAsList.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1718 aix-all, windows-all
+# com/sun/jdi/EvalArraysAsList.sh on windows issue https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711
+com/sun/jdi/ArrayLengthDumpTest.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
+com/sun/jdi/BreakpointWithFullGC.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
+com/sun/jdi/CatchAllTest.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
+com/sun/jdi/CatchCaughtTest.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
+com/sun/jdi/CatchPatternTest.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
+com/sun/jdi/CommandCommentDelimiter.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
+com/sun/jdi/DeoptimizeWalk.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
+com/sun/jdi/EvalArgs.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
+com/sun/jdi/EvalInterfaceStatic.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
+com/sun/jdi/GetLocalVariables3Test.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
+com/sun/jdi/GetLocalVariables4Test.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
+com/sun/jdi/JdbLockTest.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
+com/sun/jdi/JdbMethodExitTest.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
+com/sun/jdi/JdbMissStep.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
+com/sun/jdi/JdbVarargsTest.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
+com/sun/jdi/MixedSuspendTest.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
+com/sun/jdi/NotAField.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
+com/sun/jdi/NullLocalVariable.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
+com/sun/jdi/Redefine-g.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
+com/sun/jdi/RedefineAbstractClass.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
+com/sun/jdi/RedefineAddPrivateMethod.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
+com/sun/jdi/RedefineAnnotation.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
+com/sun/jdi/RedefineChangeClassOrder.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
+com/sun/jdi/RedefineClasses.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
+com/sun/jdi/RedefineClearBreakpoint.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
+com/sun/jdi/RedefineException.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
+com/sun/jdi/RedefineFinal.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
+com/sun/jdi/RedefineImplementor.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
+com/sun/jdi/RedefineIntConstantToLong.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
+com/sun/jdi/RedefineMulti.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
+com/sun/jdi/RedefinePop.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
+com/sun/jdi/RedefineStep.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
+com/sun/jdi/RedefineTTYLineNumber.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
+com/sun/jdi/StringConvertTest.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
+com/sun/jdi/WatchFramePop.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
 
 ############################################################################
 


### PR DESCRIPTION
* Follow up to https://github.com/AdoptOpenJDK/openjdk-tests/pull/1719 and https://github.com/AdoptOpenJDK/openjdk-tests/pull/1724 which did not successfully exclude the tests on x32
* Escalates the exclusion of EvalArraysAsList.sh to all windows machines
* Further excludes two shell tests on s390x suffering from the same issue

Signed-off-by: Morgan Davies <morgan.davies@ibm.com>