### PR TITLE
Add x86 to generic-arch

### DIFF
--- a/openjdk/README.md
+++ b/openjdk/README.md
@@ -32,7 +32,7 @@ List items  are testnames followed by labels, all MUST BE commented
 as to why they are here and use a label:
 
 * generic-all   Problems on all platforms
-* generic-ARCH  Where ARCH is one of: x64, s390x, ppc64le, sparc, sparcv9, i586, etc.
+* generic-ARCH  Where ARCH is one of: x64, x86, s390x, ppc64le, sparc, sparcv9, i586, etc.
 * OSNAME-all    Where OSNAME is one of: solaris, linux, windows, macosx, aix
 * OSNAME-ARCH   Specific on to one OSNAME and ARCH, e.g. solaris-amd64
 * OSNAME-REV    Specific on to one OSNAME and REV, e.g. solaris-5.8


### PR DESCRIPTION
I found that there wasn't any documentation regarding excluding tests on 32bit machines. As a result, PR https://github.com/AdoptOpenJDK/openjdk-tests/pull/1724 was merged without having any effect on the excludes list. 

To avoid any non-standard combinations of excludes syntax (i.e.`OSNAME-x32`, `OSNAME-x86_32`), this commit clarifies how to add a 32-bit entry to the problem lists. 