### PR TITLE
Add  .Z to the list of filters for SDK package

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -231,7 +231,7 @@ def setup() {
 					step([$class: 'CopyArtifact',
 						fingerprintArtifacts: true,
 						flatten: true,
-						filter: "**/*.tar.gz,**/*.tgz,**/*.zip,**/*.jar",
+						filter: "**/*.tar.gz,**/*.tgz,**/*.zip,**/*.jar,**/*.Z",
 						projectName: "${params.UPSTREAM_JOB_NAME}",
 						selector: [$class: 'SpecificBuildSelector', buildNumber: "${params.UPSTREAM_JOB_NUMBER}"]])
 				}


### PR DESCRIPTION
This will allow `pax.Z`(zos), `tar.Z` (aix) form of SDK zip files to be processed. 

Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>