### PR TITLE
Update getJtreg task logic

### DIFF
--- a/openjdk/build.xml
+++ b/openjdk/build.xml
@@ -29,37 +29,38 @@
 		<mkdir dir="${DEST}"/>
 		<if>
 			<not>
-				<available file="jtreg-4.2.0-tip.tar.gz" />
+				<available file="jtreg-4.2.0-tip.tar" />
 			</not>
 			<then>
-                                <if> <available file="custom_jtreg.tar.gz"/>
-                                        <then>
-                                                <echo message="Using custom_jtreg.tar.gz"/>
-                                                <copy file="custom_jtreg.tar.gz" tofile="jtreg-4.2.0-tip.tar.gz"/>
-                                        </then>
-                                        <else>
-                                                <echo message="Getting Jtreg from https://ci.adoptopenjdk.net/job/jtreg/lastSuccessfulBuild/artifact/jtreg-4.2.0-tip.tar.gz"/>
-                                                <exec executable="curl" failonerror="true">
-                                                        <arg line="--retry 5 -OLJSks https://ci.adoptopenjdk.net/job/jtreg/lastSuccessfulBuild/artifact/jtreg-4.2.0-tip.tar.gz" />
-                                                </exec>
-                                        </else>
-                                </if>
-			    	<exec executable="gzip" failonerror="true">
-			    		<arg line="-d jtreg-4.2.0-tip.tar.gz" />
-			    	</exec>
-                	    	<if> <contains string="${SPEC}" substring="zos" />
-                              		<then>
-                                		<exec executable="tar" failonerror="true">
-                                        		<arg line="xfo jtreg-4.2.0-tip.tar -C ${DEST}" />
-                                		</exec>
-                              		</then>
-     			      		<else>
-			    			<exec executable="tar" failonerror="true">
-			      				<arg line="xf jtreg-4.2.0-tip.tar -C ${DEST}" />
-			    		</exec>
-                              		</else>
-                            	</if>
+				<if> <available file="custom_jtreg.tar.gz"/>
+					<then>
+						<echo message="Using custom_jtreg.tar.gz"/>
+							<copy file="custom_jtreg.tar.gz" tofile="jtreg-4.2.0-tip.tar.gz"/>
+					</then>
+				<else>
+					<echo message="Getting Jtreg from https://ci.adoptopenjdk.net/job/jtreg/lastSuccessfulBuild/artifact/jtreg-4.2.0-tip.tar.gz"/>
+					<exec executable="curl" failonerror="true">
+						<arg line="--retry 5 -OLJSks https://ci.adoptopenjdk.net/job/jtreg/lastSuccessfulBuild/artifact/jtreg-4.2.0-tip.tar.gz" />
+					</exec>
+				</else>
+				</if>
+				<exec executable="gzip" failonerror="true">
+					<arg line="-d jtreg-4.2.0-tip.tar.gz" />
+				</exec>
 			</then>
+		</if>
+		<if>
+			<contains string="${SPEC}" substring="zos" />
+			<then>
+				<exec executable="tar" failonerror="true">
+					<arg line="xfo jtreg-4.2.0-tip.tar -C ${DEST}" />
+				</exec>
+			</then>
+		<else>
+			<exec executable="tar" failonerror="true">
+				<arg line="xf jtreg-4.2.0-tip.tar -C ${DEST}" />
+			</exec>
+		</else>
 		</if>
 	</target>
 


### PR DESCRIPTION
Check file jtreg-4.2.0-tip.tar instead of jtreg-4.2.0-tip.tar.gz
as there is requirement not to require GNU tar options when
downloading jtreg. jtreg-4.2.0-tip.tar.gz file has been decompressed as
jtreg-4.2.0-tip.tar

Move untar task outside of check file exist function as the task should be done for each build step (make compile).


Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>