### PR TITLE
Re-exclude tests on z-linux

### DIFF
--- a/openjdk/ProblemList_openjdk8.txt
+++ b/openjdk/ProblemList_openjdk8.txt
@@ -289,14 +289,14 @@ com/sun/jdi/EvalInterfaceStatic.sh  https://github.com/AdoptOpenJDK/openjdk-test
 com/sun/jdi/GetLocalVariables3Test.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
 com/sun/jdi/GetLocalVariables4Test.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
 com/sun/jdi/JdbLockTest.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
-com/sun/jdi/JdbMethodExitTest.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all, linux-s390x
+com/sun/jdi/JdbMethodExitTest.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all, s390x-linux
 # com/sun/jdi/JdbMethodExitTest.sh on s390x JBS https://bugs.openjdk.java.net/browse/JDK-8201652
 com/sun/jdi/JdbMissStep.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
 com/sun/jdi/JdbVarargsTest.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
 com/sun/jdi/MixedSuspendTest.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
 com/sun/jdi/NotAField.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
 com/sun/jdi/NullLocalVariable.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
-com/sun/jdi/Redefine-g.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all, linux-s390x
+com/sun/jdi/Redefine-g.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all, s390x-linux
 # com/sun/jdi/Redefine-g.sh on s390x JBS https://bugs.openjdk.java.net/browse/JDK-8201652
 com/sun/jdi/RedefineAbstractClass.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
 com/sun/jdi/RedefineAddPrivateMethod.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all

--- a/openjdk/ProblemList_openjdk8.txt
+++ b/openjdk/ProblemList_openjdk8.txt
@@ -275,7 +275,7 @@ com/sun/tools/attach/StartManagementAgent.java	https://github.com/AdoptOpenJDK/o
 # jdk_jdi
 
 com/sun/jdi/RedefineCrossEvent.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/227	macosx-all
-com/sun/jdi/EvalArraysAsList.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1718 aix-all, windows-all
+com/sun/jdi/EvalArraysAsList.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1718   aix-all, windows-all
 # com/sun/jdi/EvalArraysAsList.sh on windows issue https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711
 com/sun/jdi/ArrayLengthDumpTest.sh  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all
 com/sun/jdi/BreakpointWithFullGC.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1711 windows-all


### PR DESCRIPTION
* linux-s390x does not appear to work for exclusions on z-linux. Trying with s390x-linux instead