### PR TITLE
Enable the Attach API for openjdk jobs on z/OS

### DIFF
--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -38,6 +38,9 @@ ifeq ($(CYGWIN),1)
 		| cut -d "=" -f 2-` / 1024 / 1024 \
 		)
 endif
+ifeq ($(OS),OS/390)
+	EXTRA_OPTIONS += -Dcom.ibm.tools.attach.enable=yes
+endif
 # Upstream OpenJDK, roughly, sets concurrency based on the
 # following: min(NPROCS/2, MEM_IN_GB/2).
 MEM := $(shell expr $(MEMORY_SIZE) / 2048)


### PR DESCRIPTION
With the Attach API disabled by default on z/OS, some tests will
just fail. Enabling the API allows Attachments, and enables the tests
to pass.

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>