### PR TITLE
Smart parallelization

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -108,52 +108,102 @@ def setupEnv() {
 def setupParallelEnv() {
 	stage('setupParallelEnv') {
 		timestamps{
-			setupEnv()
-
-			//Initialization for things in common between both multiple iterations and many subtests
-			//repeatAmount is the number of times the loops go through
 			def testSubDirs = []
-			int repeatAmount = ITERATIONS
+			int childJobNum = 1
+			def UPSTREAM_TEST_JOB_NAME = ""
+			def UPSTREAM_TEST_JOB_NUMBER = ""
 
-			//Setup for option-specific parameters
-			//If ITERATIONS is 1, then parallel is based on subfolders
-			if (repeatAmount == 1) {
+			if (params.PARALLEL == "Iteration") {
+				childJobNum = ITERATIONS
+				// limit childJobNum
+				if (childJobNum > 20) {
+					echo "Due to the limited machines, ITERATIONS can only be set up to 20. Current ITERATIONS is ${ITERATIONS}."
+					echo "Reset ITERATIONS to 20..." 
+					childJobNum = 20
+				}
+			} else if (params.PARALLEL == "Dynamic") {
+				int numOfMachines = getNumMachines()
+				sh "cd ./openjdk-tests/TKG; make genParallelList TEST=${TARGET} NUM_MACHINES=${numOfMachines}"
+
+				// get NUM_LIST from parallelList.mk. NUM_LIST can be different than numOfMachines
+				def parallelList = "openjdk-tests/TKG/parallelList.mk"
+				int NUM_LIST = -1
+				if (fileExists("${parallelList}")) {
+					echo "read parallelList.mk file: ${parallelList}"
+					def properties = readProperties file: "${parallelList}"
+					if (properties.NUM_LIST) {
+						NUM_LIST = properties.NUM_LIST.toInteger()
+					}
+				}
+				if ( NUM_LIST > 0) {
+					childJobNum = NUM_LIST
+					echo "Saving parallelList.mk file on jenkins..."
+					dir('openjdk-tests/TKG') {
+						archiveArtifacts artifacts: 'parallelList.mk', fingerprint: true, allowEmptyArchive: false
+					}
+
+					UPSTREAM_TEST_JOB_NAME = JOB_NAME
+					UPSTREAM_TEST_JOB_NUMBER = BUILD_NUMBER
+				} else {
+					assert false : "Build failed because cannot find NUM_LIST in parallelList.mk file."
+				}
+			} else if (params.PARALLEL == "Subdir") {
 				dir("$WORKSPACE/openjdk-tests/${env.BUILD_LIST}") {
 					testSubDirs = sh(returnStdout: true, script: "ls -d */").trim().tokenize()
 				}
 
-				// We currently only run special.system in parallel mode and some subfolders do not have any system test in special level
-				// In order to save machine resources, exclude the following system test subfolders in parallel mode
-				def excludes = ["jlm/", "modularity/", "sharedClasses/"]
-				echo "exclude the following system test subfolders: ${excludes}"
-				testSubDirs = testSubDirs - excludes
-				repeatAmount = testSubDirs.size()
-				echo "repeatAmount is ${repeatAmount}, testSubDirs is ${testSubDirs}, running test in parallel mode"
+				if (TARGET.contains('special.system')) {
+					// In special.system, some subfolders do not have any system test in special level
+					// In order to save machine resources, exclude the following system test subfolders in parallel mode
+					def excludes = ["jlm/", "modularity/", "sharedClasses/"]
+					echo "exclude the following system test subfolders: ${excludes}"
+					testSubDirs = testSubDirs - excludes
+				}
+				
+				childJobNum = testSubDirs.size()
+				if ( childJobNum > 20) {
+					assert false : "Build failed becuase childJobNum: ${childJobNum} > 20."
+				}
 			}
-
+			echo "[PARALLEL: ${params.PARALLEL}] childJobNum is ${childJobNum}, creating jobs and running them in parallel..."
 			parallel_tests = [:]
+			create_jobs = [:]
 
-			for (int i = 0; i < repeatAmount; i++) {
-				def buildListName = ""
+			for (int i = 0; i < childJobNum; i++) {
+				def buildListName = env.BUILD_LIST
 				def childTest = ""
-				if (ITERATIONS == 1) {
+				def childTarget = TARGET
+				if (params.PARALLEL == "Iteration") {
+					childTest = "iteration_${i}"
+					
+				} else if (params.PARALLEL == "Dynamic") {
+					childTest = "testList_${i}"
+					childTarget = "-f parallelList.mk ${childTest}"
+				} else if (params.PARALLEL == "Subdir") {
 					childTest = testSubDirs[i].trim().replace("/","");
 					buildListName = "${env.BUILD_LIST}/${childTest}"
 				}
-				else {
-					childTest = "test_iteration_${i}"
-					buildListName = env.BUILD_LIST
+
+				def TEST_JOB_NAME = "${JOB_NAME}_${childTest}"
+				create_jobs[childTest] = {
+					echo "create the job ${TEST_JOB_NAME}"
+					createJob( TEST_JOB_NAME, PLATFORM)
 				}
 
 				def childParams = []
 				// loop through all the params and change the parameters if needed
 				params.each { param ->
+					// set ITERATIONS, PARALLEL, and NUM_MACHINES to default value
 					if (param.key == "ITERATIONS") {
 						childParams << string(name: param.key, value: "1")
 					} else if (param.key == "BUILD_LIST") {
 						childParams << string(name: param.key, value: "${buildListName}")
-					} else if (param.key == "IS_PARALLEL") {
-						childParams << booleanParam(name: param.key, value: false)
+					} else if (param.key == "TARGET") {
+						childParams << string(name: param.key, value: "${childTarget}")
+					} else if (param.key == "PARALLEL") {
+						childParams << string(name: param.key, value: "None")
+					} else if (param.key == "NUM_MACHINES") {
+						childParams << string(name: param.key, value: "1")
 					} else {
 						def value = param.value.toString()
 						if (value == "true" || value == "false") {
@@ -163,19 +213,67 @@ def setupParallelEnv() {
 						}
 					}
 				}
+
+				childParams << string(name: 'UPSTREAM_TEST_JOB_NAME', value: UPSTREAM_TEST_JOB_NAME)
+				childParams << string(name: 'UPSTREAM_TEST_JOB_NUMBER', value: UPSTREAM_TEST_JOB_NUMBER)
+
 				//This parameter is needed because it enables many iterations of the same test (which all have same names)
 				//to have a unique variable in the array so that Jenkins will run it
 				childParams << string(name: 'RUNTIME_NAME', value: childTest)
-
-				def TEST_JOB_NAME = "${JOB_NAME}"
 
 				parallel_tests[childTest] = {
 					build job: TEST_JOB_NAME, parameters: childParams
 				}
 			}
+			parallel create_jobs
+
 			// return to top level pipeline file in order to exit node block before running tests in parallel
 		}
 	}
+}
+
+
+// Returns num
+// num = params.NUM_MACHINES. If it is not provided, the default value is 1
+// num cannot be greater than slave machines / 2
+def getNumMachines(){
+	int num = params.NUM_MACHINES ? params.NUM_MACHINES.toInteger() : 1
+	def slaves = nodesByLabel(LABEL).size()
+	int limit = slaves / 2
+	if (num > limit) {
+		echo "Number of slave machines is ${slaves}. Number of machines cannot be greater than ${slaves} / 2 (=${limit}). Set num to ${limit}"
+		num = limit
+	}
+	return num
+}
+
+def createJob( TEST_JOB_NAME, ARCH_OS ) {
+
+	def jobParams = [:]
+	jobParams.put('TEST_JOB_NAME', TEST_JOB_NAME)
+	jobParams.put('ARCH_OS_LIST', ARCH_OS)
+
+	//get level and group if TEST_JOB_NAME matches the format of Test_openjdk11_j9_extended.functional_ppc64_aix
+	//otherwise, use default level and group value in template
+	if (TEST_JOB_NAME.startsWith("Test_openjdk")) {
+		def level = ""
+		def group = ""
+		def tokens = TEST_JOB_NAME.split('_');
+		if (tokens.size() > 3 && tokens[3].contains(".")) {
+			level = tokens[3].split("\\.")[0]
+			group = tokens[3].split("\\.")[1]
+		}
+
+		if (level && group) {
+			jobParams.put('LEVELS', level)
+			jobParams.put('GROUPS', group)
+		}
+	}
+
+	def templatePath = 'openjdk-tests/buildenv/jenkins/testJobTemplate'
+
+	def create = jobDsl targets: templatePath, ignoreExisting: false, additionalParameters: jobParams
+	return create
 }
 
 def setup() {
@@ -322,6 +420,14 @@ def buildTest() {
 				}
 			}
 
+			if (params.UPSTREAM_TEST_JOB_NAME && params.UPSTREAM_TEST_JOB_NUMBER) {
+				try {
+					copyArtifacts fingerprintArtifacts: true, projectName: params.UPSTREAM_TEST_JOB_NAME, selector: specific(params.UPSTREAM_TEST_JOB_NUMBER), target: './openjdk-tests/TKG/'
+				} catch (Exception e) {
+					echo "Cannot run copyArtifacts from ${params.UPSTREAM_TEST_JOB_NAME} ${params.UPSTREAM_TEST_JOB_NUMBER}. Skipping copyArtifacts..."
+				}
+			}
+
 			try {
 				//get pre-staged jars from test.getDependency build before test compilation
 				copyArtifacts fingerprintArtifacts: true, projectName: "test.getDependency", selector: lastSuccessful(), target: 'openjdk-tests/TKG/lib'
@@ -369,7 +475,10 @@ def runTest( ) {
 			if (TARGET.contains('custom') && CUSTOM_TARGET!='') {
 				CUSTOM_OPTION = "${TARGET.toUpperCase()}_TARGET='${CUSTOM_TARGET}'"
 			}
-			RUNTEST_CMD = "./openjdk-tests _${params.TARGET} ${CUSTOM_OPTION}"
+			if (!TARGET.startsWith('-f')) {
+				TARGET="_${params.TARGET}"
+			}
+			RUNTEST_CMD = "./openjdk-tests ${TARGET} ${CUSTOM_OPTION}"
 			for (int i = 0; i < ITERATIONS; i++) {
 				echo "ITERATION: ${iterationCount}/${ITERATIONS}"
 				if (env.BUILD_LIST == 'openjdk') {
@@ -443,7 +552,7 @@ def post(output_name) {
 			}
 
 			boolean failIfNoResultsValue = true
-			if (params.IS_PARALLEL == true) {
+			if (params.PARALLEL && params.PARALLEL != "None") {
 				failIfNoResultsValue = false
 			}
 			step([$class: "TapPublisher", testResults: "**/*.tap", outputTapToConsole: false, failIfNoResults: failIfNoResultsValue])
@@ -501,12 +610,11 @@ def testBuild() {
 	timeout(time: TIME_LIMIT, unit: 'HOURS') {
 		try {
 			addJobDescription()
-
+			setup()
 			// prepare environment and compile test projects
-			if( params.IS_PARALLEL == true ){
+			if( params.PARALLEL && params.PARALLEL != "None" ) {
 				setupParallelEnv()
 			} else {
-				setup()
 				try {
 					//ToDo: temporary workaround for jck test parallel runs
 					// until build.xml is added into each subfolder
@@ -644,7 +752,7 @@ def addGrinderLink() {
 }
 
 def run_parallel_tests() {
-	if (params.IS_PARALLEL == true) {
+	if (params.PARALLEL && params.PARALLEL != "None") {
 		stage ("Parallel Tests") {
 			parallel parallel_tests
 		}

--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -29,6 +29,9 @@ if (!binding.hasVariable('JCK_GIT_REPO_PREFIX')) JCK_GIT_REPO_PREFIX = ""
 if (!binding.hasVariable('SSH_AGENT_CREDENTIAL')) SSH_AGENT_CREDENTIAL = ""
 if (!binding.hasVariable('KEEP_REPORTDIR')) KEEP_REPORTDIR = "true"
 if (!binding.hasVariable('AUTO_DETECT')) AUTO_DETECT = true
+if (!binding.hasVariable('TEST_JOB_NAME')) TEST_JOB_NAME = ""
+if (!binding.hasVariable('TARGET')) TARGET = ""
+if (!binding.hasVariable('BUILD_LIST')) BUILD_LIST = ""
 
 if (!binding.hasVariable('BUILDS_TO_KEEP')) {
 	BUILDS_TO_KEEP = 10
@@ -40,19 +43,21 @@ if (!binding.hasVariable('BUILDS_TO_KEEP')) {
 if (binding.hasVariable('LEVELS')) {
 	LEVELS = LEVELS.split(',')
 } else {
-	LEVELS = ['sanity','extended','special']
+	// 'sanity','extended','special'
+	LEVELS = ['sanity']
 }
 
 if (binding.hasVariable('JDK_VERSIONS')) {
 	JDK_VERSIONS = JDK_VERSIONS.split(',')
 } else {
-	JDK_VERSIONS = [8,11]
+	JDK_VERSIONS = [8]
 }
 
 if (binding.hasVariable('GROUPS')) {
 	GROUPS = GROUPS.split(',')
 } else {
-	GROUPS = ['functional','system','openjdk', 'perf', 'external']
+	// 'functional','system','openjdk', 'perf', 'external', 'jck'
+	GROUPS = ['functional']
 }
 
 
@@ -102,9 +107,15 @@ ARCH_OS_LIST.each { ARCH_OS ->
 	JDK_VERSIONS.each { JDK_VERSION ->
 		LEVELS.each { LEVEL ->
 			GROUPS.each { GROUP ->
-				def TEST_JOB_NAME = "Test_openjdk${JDK_VERSION}_${JDK_IMPL_SN}_${LEVEL}.${GROUP}_${ARCH_OS}${SUFFIX}"
-
-				def BUILD_LIST = GROUP
+				if (!TEST_JOB_NAME) {
+					TEST_JOB_NAME = "Test_openjdk${JDK_VERSION}_${JDK_IMPL_SN}_${LEVEL}.${GROUP}_${ARCH_OS}${SUFFIX}"
+				}
+				if (!TARGET) {
+					TARGET = "${LEVEL}.${GROUP}"
+				}
+				if (!BUILD_LIST) {
+					BUILD_LIST = GROUP
+				}
 
 				// for jck builds, we need to pass in EXTRA_OPTIONS
 				def EXTRA_OPTIONS = "";
@@ -136,7 +147,7 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							stringParam('JDK_IMPL', JDK_IMPL, "JDK implementation, e.g. hotspot, openj9, sap")
 							stringParam('PLATFORM', "${ARCH_OS}", "Platform to be tested")
 							stringParam('BUILD_LIST', BUILD_LIST, "Specific test directory to compile, set blank for all projects to be compiled")
-							stringParam('TARGET', "${LEVEL}.${GROUP}", "Test TARGET to execute")
+							stringParam('TARGET', "${TARGET}", "Test TARGET to execute")
 							stringParam('CUSTOM_TARGET', "", "Only used when the custom target is specified in TARGET , e.g. jdk_custom, langtools_custom, etc., CUSTOM_TARGET=path to the test class to execute")
 							choiceParam('SDK_RESOURCE', ['upstream', 'nightly', 'customized', 'releases'], "Where to get sdk?")
 							stringParam('CUSTOMIZED_SDK_URL', "", "Customized SDK url, need to set when SDK_RESOURCE=customized")
@@ -156,7 +167,8 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							stringParam('ARTIFACTORY_REPO', ARTIFACTORY_REPO, "Optional. It should be used with ARTIFACTORY_SERVER")
 							stringParam('ARTIFACTORY_ROOT_DIR', ARTIFACTORY_ROOT_DIR, "Optional. It should be used with ARTIFACTORY_SERVER and ARTIFACTORY_REPO. Default is to set root dir to be the same as the current Jenkins domain")
 							booleanParam('PERSONAL_BUILD', false, "Is this a personal build?")
-							booleanParam('IS_PARALLEL', false, "Should tests run in parallel?")
+							choiceParam('PARALLEL', ['None', 'Dynamic', 'Subdir', 'Iteration'], "Optional. Parallel mode")
+							stringParam('NUM_MACHINES', "1", "Optional. Number of machines to run in parallel. Default value is 1. Need to be used with PARALLEL=Dynamic")
 							stringParam('USER_CREDENTIALS_ID', "", "Optional. User credential ID")
 							stringParam('VENDOR_TEST_REPOS', "", "Optional. Addtional test repos")
 							stringParam('VENDOR_TEST_BRANCHES', "", "Optional. Addtional test branches")
@@ -171,6 +183,8 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							stringParam('TKG_REPO', TKG_REPO, "TestKitGen git repo. Please use ssh for zos.")
 							stringParam('TKG_BRANCH', "master", "TKG branch")
 							stringParam('TKG_SHA', "", "TKG sha")
+							stringParam('UPSTREAM_TEST_JOB_NAME', "", "Auto-populated. Upstream test job name. It will be used together with PARALLEL=Dynamic")
+							stringParam('UPSTREAM_TEST_JOB_NUMBER', "", "Auto-populated. Upstream test job number. It will be used together with PARALLEL=Dynamic")
 						}
 						cpsScm {
 							scm {


### PR DESCRIPTION
- Generate and trigger child test jobs based on PARALLEL value
- PARALLEL value can be the following:
   - Subdir (i.e., this is for external, perf, special.system test builds)
   - Dynamic
      - set number of child jobs (childJobNum). childJobNum =
params.NUM_MACHINES. If it is not provided, the default value is 1.
childJobNum cannot be greater than slave machines / 2
      - call TKG with NUM_MACHINES=childJobNum. It will generate
parallelList.mk dynamically
      - get NUM_LIST from parallelList.mk. Set childJobNum = NUM_LIST
   - Iteration (simply repeat based on ITERATIONS param. Max is 20)
   - None (no parallel)
- template is updated to create test jobs accordingly

Issue: #1563

Signed-off-by: lanxia <lan_xia@ca.ibm.com>