### PR TITLE
Ignore -jfr and -static-libs filenames when testing upstream

### DIFF
--- a/buildenv/jenkins/upstream_openjdk_tests
+++ b/buildenv/jenkins/upstream_openjdk_tests
@@ -104,7 +104,7 @@ class ReleaseRetriever implements Serializable {
             if (!a.name.endsWith(".sign")) {
                 rels.each{ r ->
                    if (a.name.contains(r.OS) && a.name.contains(r.ARCH)) {
-                       if (!a.name.contains("debuginfo")) {
+                       if (!a.name.contains("debuginfo") && !a.name.contains("jfr") && !a.name.contains("static-libs")) {
                            if (a.name.contains("-jdk")) {
                                r.JDK_URL = a.browser_download_url
                            }


### PR DESCRIPTION
For OpenJDK Project Builds we produce JFR enabled builds for the 8u262 EA builds cycle in addition to the default build. This is to give people binaries with it enabled and compare it to the not enabled ones. For testing the system is only set up to get a triplet <JDK> <JRE> <TESTIMAGE> where the last is optional. For now focus the testing on the JFR disabled bits. Ignore those file names containing `jfr`. Example:
https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/tag/jdk8u262-b01

For OpenJDK 11u there is a new artefact, -static-libs, which are native libraries from the OpenJDK build but instead of being built shared (so's) have them built statically (.a). This is useful if somebody wanted to use OpenJDK 11u for building substrate vm. For testing purposes, those are not relevant in this context. Ignore them for now.