### PR TITLE
Rename Renaissance Tests

### DIFF
--- a/perf/renaissance/playlist.xml
+++ b/perf/renaissance/playlist.xml
@@ -15,7 +15,7 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:noNamespaceSchemaLocation="../../TKG/playlist.xsd">
 	<test>
-		<testCaseName>akka-uct</testCaseName>
+		<testCaseName>renaissance-akka-uct</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)renaissance-mit.jar$(Q) --json $(Q)$(REPORTDIR)$(D)akka-uct.json$(Q) akka-uct; \
 		$(TEST_STATUS)</command>
 		<levels>
@@ -26,7 +26,7 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>als</testCaseName>
+		<testCaseName>renaissance-als</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)renaissance-mit.jar$(Q) --json $(Q)$(REPORTDIR)$(D)als.json$(Q) als; \
 		$(TEST_STATUS)</command>
 		<levels>
@@ -37,7 +37,7 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>chi-square</testCaseName>
+		<testCaseName>renaissance-chi-square</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)renaissance-mit.jar$(Q) --json $(Q)$(REPORTDIR)$(D)chi-square.json$(Q) chi-square; \
 		$(TEST_STATUS)</command>
 		<levels>
@@ -48,7 +48,7 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>db-shootout</testCaseName>
+		<testCaseName>renaissance-db-shootout</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)renaissance-mit.jar$(Q) --json $(Q)$(REPORTDIR)$(D)db-shootout.json$(Q) db-shootout; \
 		$(TEST_STATUS)</command>
 		<!-- Issue https://github.com/renaissance-benchmarks/renaissance/issues/210 -->
@@ -61,7 +61,7 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>dec-tree</testCaseName>
+		<testCaseName>renaissance-dec-tree</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)renaissance-mit.jar$(Q) --json $(Q)$(REPORTDIR)$(D)dec-tree.json$(Q) dec-tree; \
 		$(TEST_STATUS)</command>
 		<levels>
@@ -72,20 +72,19 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>finagle-chirper</testCaseName>
+		<testCaseName>renaissance-finagle-chirper</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)renaissance-mit.jar$(Q) --json $(Q)$(REPORTDIR)$(D)finagle-chirper.json$(Q) finagle-chirper; \
-		$(TEST_STATUS)</command>
-		<!-- Issue https://github.com/renaissance-benchmarks/renaissance/issues/211 -->
-		<platformRequirements>^os.win</platformRequirements> 		
+		$(TEST_STATUS)</command>			
 		<levels>
 			<level>extended</level>
 		</levels>
 		<groups>
 			<group>perf</group>
 		</groups>
+		<disabled>https://github.com/renaissance-benchmarks/renaissance/issues/231</disabled>
 	</test>
 	<test>
-		<testCaseName>finagle-http</testCaseName>
+		<testCaseName>renaissance-finagle-http</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)renaissance-mit.jar$(Q) --json $(Q)$(REPORTDIR)$(D)finagle-http.json$(Q) finagle-http; \
 		$(TEST_STATUS)</command>
 		<levels>
@@ -96,7 +95,7 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>fj-kmeans</testCaseName>
+		<testCaseName>renaissance-fj-kmeans</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)renaissance-mit.jar$(Q) --json $(Q)$(REPORTDIR)$(D)fj-kmeans.json$(Q) fj-kmeans; \
 		$(TEST_STATUS)</command>
 		<levels>
@@ -107,7 +106,7 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>future-genetic</testCaseName>
+		<testCaseName>renaissance-future-genetic</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)renaissance-mit.jar$(Q) --json $(Q)$(REPORTDIR)$(D)future-genetic.json$(Q) future-genetic; \
 		$(TEST_STATUS)</command>
 		<levels>
@@ -118,7 +117,7 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>gauss-mix</testCaseName>
+		<testCaseName>renaissance-gauss-mix</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)renaissance-mit.jar$(Q) --json $(Q)$(REPORTDIR)$(D)gauss-mix.json$(Q) gauss-mix; \
 		$(TEST_STATUS)</command>
 		<levels>
@@ -129,7 +128,7 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>log-regression</testCaseName>
+		<testCaseName>renaissance-log-regression</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)renaissance-mit.jar$(Q) --json $(Q)$(REPORTDIR)$(D)log-regression.json$(Q) log-regression; \
 		$(TEST_STATUS)</command>
 		<levels>
@@ -140,7 +139,7 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>mnemonics</testCaseName>
+		<testCaseName>renaissance-mnemonics</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)renaissance-mit.jar$(Q) --json $(Q)$(REPORTDIR)$(D)mnemonics.json$(Q) mnemonics; \
 		$(TEST_STATUS)</command>
 		<levels>
@@ -151,7 +150,7 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>movie-lens</testCaseName>
+		<testCaseName>renaissance-movie-lens</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)renaissance-mit.jar$(Q) --json $(Q)$(REPORTDIR)$(D)movie-lens.json$(Q) movie-lens; \
 		$(TEST_STATUS)</command>
 		<levels>
@@ -162,7 +161,7 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>naive-bayes</testCaseName>
+		<testCaseName>renaissance-naive-bayes</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)renaissance-mit.jar$(Q) --json $(Q)$(REPORTDIR)$(D)naive-bayes.json$(Q) naive-bayes; \
 		$(TEST_STATUS)</command>
 		<levels>
@@ -173,7 +172,7 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>par-mnemonics</testCaseName>
+		<testCaseName>renaissance-par-mnemonics</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)renaissance-mit.jar$(Q) --json $(Q)$(REPORTDIR)$(D)par-mnemonics.json$(Q) par-mnemonics; \
 		$(TEST_STATUS)</command>
 		<levels>
@@ -184,7 +183,7 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>philosophers</testCaseName>
+		<testCaseName>renaissance-philosophers</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)renaissance-mit.jar$(Q) --json $(Q)$(REPORTDIR)$(D)philosophers.json$(Q) philosophers; \
 		$(TEST_STATUS)</command>
 		<levels>
@@ -195,7 +194,7 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>scala-kmeans</testCaseName>
+		<testCaseName>renaissance-scala-kmeans</testCaseName>
 		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)renaissance-mit.jar$(Q) --json $(Q)$(REPORTDIR)$(D)scala-kmeans.json$(Q) scala-kmeans; \
 		$(TEST_STATUS)</command>
 		<levels>


### PR DESCRIPTION
• Renamed Renaissance tests according to TRSS parser convention so that the results of these tests can be parsed and viewed on TRSS
• Disabled renaissance-finagle-chirper for now since it fails

Issue: https://github.com/AdoptOpenJDK/openjdk-tests/issues/1770

Signed-off-by: Piyush Gupta <piyush286@gmail.com>