### PR TITLE
AArch64: Enable SC_Softmx_JitAot_Linux test back again

### DIFF
--- a/system/sharedClasses/playlist.xml
+++ b/system/sharedClasses/playlist.xml
@@ -105,7 +105,6 @@
 	</test>
 	
 	<!-- Exclude the following test on Linux ppc64le & s390x. Reason: AdoptOpenJDK/openjdk-systemtest/issues/79 -->
-	<!-- Exclude the following test on Linux aarch64. Reason: eclipse/openj9/issues/8966 -->
 	<test>
 		<testCaseName>SC_Softmx_JitAot</testCaseName>
 		<variations>
@@ -143,7 +142,7 @@
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
-		<platformRequirements>os.linux,^arch.ppc,^arch.390,^arch.aarch64</platformRequirements>
+		<platformRequirements>os.linux,^arch.ppc,^arch.390</platformRequirements>
 	</test>
 	
 	<test>


### PR DESCRIPTION
This commit enables SC_Softmx_JitAot_Linux test for AArch64 back again,
reverting the change in #1717.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>