### PR TITLE
Add option to jdk_lang_j9 for JITServer

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -217,7 +217,7 @@
 	<test>
 		<testCaseName>jdk_lang_j9</testCaseName>
 		<variations>
-			<variation>-Xdump:system:none -Xdump:heap:none -Xdump:system:events=gpf+abort+traceassert+corruptcache</variation>
+			<variation>-Xdump:system:none -Xdump:heap:none -Xdump:system:events=gpf+abort+traceassert+corruptcache -XX:-JITServerTechPreviewMessage</variation>
 		</variations>   
 		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
 	$(JTREG_BASIC_OPTIONS) $(JDK_NATIVE_OPTIONS) -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \


### PR DESCRIPTION
`InheritIO.sh` used by `jdk_lang_j9` expects` stderr.txt` to contain only `exit value: 0`. However with JITServer, `stderr.txt` now contains an extra technology preview warning message from JITServer. Add `-XX:doNotShowJITServerWarningMessage` to `jdk_lang_j9` to disable the message.

Related to eclipse/openj9#9169

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>