### PR TITLE
OpenJ9 AArch64: Enable 4 tests back again

### DIFF
--- a/openjdk/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/ProblemList_openjdk11-openj9.txt
@@ -117,7 +117,6 @@ java/lang/reflect/Nestmates/TestReflectionAPI.java	https://github.com/AdoptOpenJ
 java/lang/reflect/Proxy/ProxyForMethodHandle.java	https://github.com/eclipse/openj9/issues/7741	generic-all
 java/lang/reflect/Proxy/ProxyLayerTest.java	https://github.com/eclipse/openj9/issues/7775	generic-all
 java/lang/reflect/PublicMethods/PublicMethodsTest.java	https://github.com/eclipse/openj9/issues/7897	generic-all
-java/lang/reflect/callerCache/ReflectionCallerCacheTest.java	https://github.com/eclipse/openj9/issues/9260	linux-aarch64
 jdk/modules/etc/DefaultModules.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
 jdk/modules/incubator/ImageModules.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
 
@@ -252,16 +251,13 @@ java/rmi/server/UnicastServerRef/serialFilter/FilterUSRTest.java	https://github.
 java/util/Arrays/TimSortStackSize2.java	https://github.com/eclipse/openj9/issues/7086	generic-all
 java/util/Arrays/largeMemory/ParallelPrefix.java https://github.com/eclipse/openj9/issues/4100 linux-ppc64le
 java/util/BitSet/stream/BitSetStreamTest.java https://github.com/eclipse/openj9/issues/4720 linux-all
-java/util/WeakHashMap/GCDuringIteration.java	https://github.com/eclipse/openj9/issues/9043	linux-aarch64
 java/util/Spliterator/SpliteratorCollisions.java	https://github.com/eclipse/openj9/issues/7090	generic-all
-java/util/concurrent/ArrayBlockingQueue/WhiteBox.java	https://github.com/eclipse/openj9/issues/9044	linux-aarch64
 java/util/concurrent/atomic/VMSupportsCS8.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/util/concurrent/forkjoin/FJExceptionTableLeak.java	https://github.com/eclipse/openj9/issues/3209	generic-all
 java/util/concurrent/locks/Lock/TimedAcquireLeak.java	https://github.com/eclipse/openj9/issues/7125	macosx-all,linux-all,aix-all
 java/util/concurrent/TimeUnit/Basic.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1665 windows-all
 java/util/logging/CheckZombieLockTest.java	https://bugs.openjdk.java.net/browse/JDK-8148972	macosx-all,linux-all,windows-x64
 #java/util/logging/CheckZombieLockTest.java on windows https://github.com/eclipse/openj9/issues/9186
-java/util/logging/LogManager/Configuration/ParentLoggerWithHandlerGC.java	https://github.com/eclipse/openj9/issues/8897	linux-aarch64
 java/util/logging/LogManager/TestLoggerNames.java https://github.com/eclipse/openj9/issues/4561 generic-all
 java/util/logging/TestLoggerWeakRefLeak.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/util/stream/boottest/java.base/java/util/stream/NodeTest.java https://github.com/eclipse/openj9/issues/4129 macosx-all


### PR DESCRIPTION
This commit enables the 4 tests below for AArch64:

- java/lang/reflect/callerCache/ReflectionCallerCacheTest.java
- java/util/logging/LogManager/Configuration/ParentLoggerWithHandlerGC.java
- java/util/WeakHashMap/GCDuringIteration.java
- java/util/concurrent/ArrayBlockingQueue/WhiteBox.java

These tests were excluded by #1715 and #1739.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>