### PR TITLE
Unexclude ProcessBuilder Basic test that has been fixed

### DIFF
--- a/openjdk/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/ProblemList_openjdk11-openj9.txt
@@ -38,8 +38,7 @@ java/lang/ClassLoader/RecursiveSystemLoader.java	https://github.com/eclipse/open
 java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	generic-all
 java/lang/Enum/ConstantDirectoryOptimalCapacity.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/ModuleLayer/BasicLayerTest.java	https://github.com/eclipse/openj9/issues/6462	generic-all
-java/lang/ProcessBuilder/Basic.java#id0		https://github.com/AdoptOpenJDK/openjdk-tests/issues/1397	aix-all,linux-aarch64
-#java/lang/ProcessBuilder/Basic.java#id0 is also excluded for the issue https://github.com/eclipse/openj9/issues/9032
+java/lang/ProcessBuilder/Basic.java#id0		https://github.com/eclipse/openj9/issues/9032	linux-aarch64
 java/lang/ProcessBuilder/Basic.java#id1		https://github.com/eclipse/openj9/issues/9032	linux-aarch64
 java/lang/ProcessBuilder/SkipTest.java https://github.com/eclipse/openj9/issues/4124 windows-all
 java/lang/StackTraceElement/PublicConstructor.java	https://github.com/eclipse/openj9/issues/6659	generic-all

--- a/openjdk/ProblemList_openjdk11.txt
+++ b/openjdk/ProblemList_openjdk11.txt
@@ -24,7 +24,6 @@
 
 java/lang/Class/GetPackageBootLoaderChildLayer.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
 java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	generic-all
-java/lang/ProcessBuilder/Basic.java#id0		https://github.com/AdoptOpenJDK/openjdk-tests/issues/1397	aix-all
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1773 windows-x86
 # java/lang/String/StringRepeat.java https://bugs.openjdk.java.net/browse/JDK-8221400
 java/lang/String/StringRepeat.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1272 windows-all

--- a/openjdk/ProblemList_openjdk15-openj9.txt
+++ b/openjdk/ProblemList_openjdk15-openj9.txt
@@ -38,7 +38,6 @@ java/lang/ClassLoader/RecursiveSystemLoader.java	https://github.com/eclipse/open
 java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	generic-all
 java/lang/Enum/ConstantDirectoryOptimalCapacity.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/ModuleLayer/BasicLayerTest.java	https://github.com/eclipse/openj9/issues/6462	generic-all
-java/lang/ProcessBuilder/Basic.java#id0		https://github.com/AdoptOpenJDK/openjdk-tests/issues/1397	aix-all
 java/lang/ProcessBuilder/SkipTest.java https://github.com/eclipse/openj9/issues/4124 windows-all
 java/lang/StackTraceElement/PublicConstructor.java	https://github.com/eclipse/openj9/issues/6659	generic-all
 java/lang/StackTraceElement/SerialTest.java	https://github.com/eclipse/openj9/issues/6659	generic-all

--- a/openjdk/ProblemList_openjdk15.txt
+++ b/openjdk/ProblemList_openjdk15.txt
@@ -25,7 +25,6 @@ java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java	https://github.com/Ad
 java/lang/String/nativeEncoding/StringPlatformChars.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	generic-all
 vm/JniInvocationTest.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	macosx-all
 java/lang/reflect/exeCallerAccessTest/CallerAccessTest.java https://github.com/AdoptOpenJDK/openjdk-build/issues/248 generic-all
-java/lang/ProcessBuilder/Basic.java#id0		https://github.com/AdoptOpenJDK/openjdk-tests/issues/1397	aix-all
 java/lang/System/LoggerFinder/modules/JDKLoggerForImageTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
 java/lang/System/LoggerFinder/modules/LoggerInImageTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
 java/lang/System/LoggerFinder/modules/NamedLoggerForImageTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all


### PR DESCRIPTION
The issue that caused this test to fail on AIX has been resolved.

For details, see: https://bugs.openjdk.java.net/browse/JDK-8239365
or https://github.com/AdoptOpenJDK/openjdk-tests/issues/1397

This has been introduced into jdk head prior to the jdk15 split, and
was backported to jdk11.

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>