### PR TITLE
Fix reference repo path for initial scm checkout

### DIFF
--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -137,7 +137,14 @@ if (PLATFORM_MAP.containsKey(params.PLATFORM)) {
                 cleanWs()
                 sh "git clone -b ${SCM_GIT_BRANCH} ${SCM_GIT_REPO} openjdk-tests"
             } else {
-                checkout scm
+                def gitConfig = scm.getUserRemoteConfigs().get(0)
+                checkout scm: [$class: 'GitSCM',
+                    branches: [[name: "${scm.branches[0].name}"]],
+                    extensions: [
+                        [$class: 'CloneOption', reference: "${HOME}/openjdk_cache"],
+                        [$class: 'RelativeTargetDirectory', relativeTargetDir: 'openjdk-tests']],
+                    userRemoteConfigs: [[url: "${gitConfig.getUrl()}"]]
+                ]
             }
             jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
             jenkinsfile.testBuild()

--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -201,7 +201,6 @@ ARCH_OS_LIST.each { ARCH_OS ->
 										cleanBeforeCheckout()
 										pruneStaleBranch()
 										cloneOptions {
-											reference('$HOME/openjdk_cache')
 											timeout(60)
 										}
 									}


### PR DESCRIPTION
It is currently set in the job config and propagated down
to the build during checkout scm. The problem is the
'$HOME' variable is not getting resolved so the clone
is looking for exactly that. Moving it out of the
job config (template) and into the pipeline will allow
it to be resolved properly. It is also not needed on the
job config because we use a lightweight checkout.

Fixes #1789

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>