### PR TITLE
Enable ConcurrentScavenge tests for OpenJ9 AArch64 again

### DIFF
--- a/system/daaLoadTest/playlist.xml
+++ b/system/daaLoadTest/playlist.xml
@@ -113,8 +113,7 @@
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
-		<!-- concurrentScavenge is unsupported on aarch64; github.com/eclipse/openj9/issues/8762 -->
-		<platformRequirements>bits.64,^arch.arm,^arch.aarch64</platformRequirements>
+		<platformRequirements>bits.64,^arch.arm</platformRequirements>
 	</test>
 	
 	<test>
@@ -134,8 +133,7 @@
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
-		<!-- concurrentScavenge is unsupported on aarch64; github.com/eclipse/openj9/issues/8762 -->
-		<platformRequirements>bits.64,^arch.arm,^arch.aarch64</platformRequirements>
+		<platformRequirements>bits.64,^arch.arm</platformRequirements>
 	</test>
 	
 	<test>
@@ -155,8 +153,7 @@
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
-		<!-- concurrentScavenge is unsupported on aarch64; github.com/eclipse/openj9/issues/8762 -->
-		<platformRequirements>bits.64,^arch.arm,^arch.aarch64</platformRequirements>
+		<platformRequirements>bits.64,^arch.arm</platformRequirements>
 	</test>
 	
 	<test>
@@ -176,8 +173,7 @@
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
-		<!-- concurrentScavenge is unsupported on aarch64; github.com/eclipse/openj9/issues/8762 -->
-		<platformRequirements>bits.64,^arch.arm,^arch.aarch64</platformRequirements>
+		<platformRequirements>bits.64,^arch.arm</platformRequirements>
 	</test>
 	
 	<test>

--- a/system/lambdaLoadTest/playlist.xml
+++ b/system/lambdaLoadTest/playlist.xml
@@ -111,8 +111,7 @@
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
-		<!-- concurrentScavenge is unsupported on aarch64; github.com/eclipse/openj9/issues/8762 -->
-		<platformRequirements>bits.64,^arch.arm,^arch.aarch64,^spec.linux_ppc-64_le,^spec.linux_x86-64</platformRequirements>
+		<platformRequirements>bits.64,^arch.arm,^spec.linux_ppc-64_le,^spec.linux_x86-64</platformRequirements>
 	</test>
 	
 	<test>

--- a/system/mathLoadTest/playlist.xml
+++ b/system/mathLoadTest/playlist.xml
@@ -81,8 +81,7 @@
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
-		<!-- concurrentScavenge is unsupported on aarch64; github.com/eclipse/openj9/issues/8762 -->
-		<platformRequirements>bits.64,^arch.arm,^arch.aarch64</platformRequirements>
+		<platformRequirements>bits.64,^arch.arm</platformRequirements>
 	</test>
 	
 	<test>
@@ -102,8 +101,7 @@
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
-		<!-- concurrentScavenge is unsupported on aarch64; github.com/eclipse/openj9/issues/8762 -->
-		<platformRequirements>bits.64,^arch.arm,^arch.aarch64</platformRequirements>
+		<platformRequirements>bits.64,^arch.arm</platformRequirements>
 	</test>
 	
 	<test>
@@ -123,8 +121,7 @@
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
-		<!-- concurrentScavenge is unsupported on aarch64; github.com/eclipse/openj9/issues/8762 -->
-		<platformRequirements>bits.64,^arch.arm,^arch.aarch64</platformRequirements>
+		<platformRequirements>bits.64,^arch.arm</platformRequirements>
 	</test>
 	
 	<test>

--- a/system/mauveLoadTest/playlist.xml
+++ b/system/mauveLoadTest/playlist.xml
@@ -127,8 +127,7 @@
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
-		<!-- concurrentScavenge is unsupported on aarch64; github.com/eclipse/openj9/issues/8762 -->
-		<platformRequirements>bits.64,^arch.arm,^arch.aarch64</platformRequirements>
+		<platformRequirements>bits.64,^arch.arm</platformRequirements>
 		<disabled>AdoptOpenJDK/openjdk-systemtest/issues/75</disabled>
 	</test>
 	

--- a/system/otherLoadTest/playlist.xml
+++ b/system/otherLoadTest/playlist.xml
@@ -298,8 +298,7 @@
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
-		<!-- concurrentScavenge is unsupported on aarch64; github.com/eclipse/openj9/issues/8762 -->
-		<platformRequirements>bits.64,^arch.arm,^arch.aarch64</platformRequirements>
+		<platformRequirements>bits.64,^arch.arm</platformRequirements>
 	</test>
 	
 	<test>


### PR DESCRIPTION
This commit reverts the changes in #1675, to enable ConcurrentScavenge
tests for OpenJ9 AArch64 again.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>