### PR TITLE
Default numOfMachines to 1 when only 1 slave exists

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -243,6 +243,10 @@ def setupParallelEnv() {
 def getNumMachines(){
 	int num = params.NUM_MACHINES ? params.NUM_MACHINES.toInteger() : 1
 	def slaves = nodesByLabel(LABEL).size()
+	if (slaves == 1) {
+		echo "Only 1 slave machine available. Set num to 1"
+		return slaves
+	}
 	int limit = slaves / 2
 	if (num > limit) {
 		echo "Number of slave machines is ${slaves}. Number of machines cannot be greater than ${slaves} / 2 (=${limit}). Set num to ${limit}"


### PR DESCRIPTION
Currently if only 1 slave exists, the integer
division will limit to 0 slaves and the build
will fail.

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>