### PR TITLE
Fix external quarkus-quickstarts test

### DIFF
--- a/external/common_functions.sh
+++ b/external/common_functions.sh
@@ -336,7 +336,7 @@ function set_test_info() {
         script="test.sh"
         test_results="testResults"
         tag_version="1.3.2.Final"
-        environment_variable="DOCKERIMAGE_TAG=\"1.3.2.Final\""
+        environment_variable="MODE=\"java\""
         debian_packages="git wget maven"
         debianslim_packages="${debian_packages}"
         ubuntu_packages="${debian_packages}"

--- a/external/quarkus_quickstarts/dockerfile/test.sh
+++ b/external/quarkus_quickstarts/dockerfile/test.sh
@@ -41,7 +41,13 @@ export MAVEN_OPTS="-Xmx1g"
 cd /quarkus-quickstarts
 pwd
 echo "Compile and run quarkus_quickstarts tests"
-mvn -pl !:hibernate-orm-quickstart,!:hibernate-orm-panache-quickstart clean install 
+mvn -pl !:hibernate-orm-quickstart,!:hibernate-orm-panache-quickstart,\
+!:hibernate-search-elasticsearch-quickstart,!:mqtt-quickstart,\
+!:quartz-quickstart,!:security-jdbc-quickstart,!:security-keycloak-authorization-quickstart,\
+!:security-openid-connect-web-authentication-quickstart,\
+!:security-openid-connect-multi-tenancy-quickstart,!:spring-data-jpa-quickstart,\
+!:vertx-quickstart,!:context-propagation-quickstart,!:getting-started-reactive-rest,\
+!:kafka-quickstart,!:neo4j-quickstart clean install
 test_exit_code=$?
 echo "Build quarkus_quickstarts completed"
 

--- a/external/quarkus_quickstarts/playlist.xml
+++ b/external/quarkus_quickstarts/playlist.xml
@@ -28,7 +28,7 @@
 	</test>
 	<test>
 		<testCaseName>quarkus_quickstarts_test</testCaseName>
-		<command>$(TEST_ROOT)$(D)external$(D)external.sh --run --tag ${DOCKERIMAGE_TAG} --version ${JDK_VERSION} --impl ${JDK_IMPL} --dir quarkus_quickstarts --reportdst $(REPORTDIR) --docker_args "$(EXTRA_DOCKER_ARGS)"; \
+		<command>$(TEST_ROOT)$(D)external$(D)external.sh --run --tag ${DOCKERIMAGE_TAG} --version ${JDK_VERSION} --impl ${JDK_IMPL} --dir quarkus_quickstarts --reportdst $(REPORTDIR) --docker_args "-v /var/run/docker.sock:/var/run/docker.sock $(EXTRA_DOCKER_ARGS)"; \
 		$(TEST_STATUS); \
 		$(TEST_ROOT)$(D)external$(D)external.sh --clean --tag ${DOCKERIMAGE_TAG} --version ${JDK_VERSION} --impl ${JDK_IMPL} --dir quarkus_quickstarts 
 		</command>


### PR DESCRIPTION
- added docker volumes to run tests
- excluded tests only designed for local run or requiring specific docker image

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>