### PR TITLE
Get pre-staged jars from test.getDependency build for compiling TKG

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -125,8 +125,16 @@ def setupParallelEnv() {
 				int numOfMachines = getNumMachines()
 				String PARALLEL_OPTIONS = "TEST=${TARGET} NUM_MACHINES=${numOfMachines}"
 				if (params.TRSS_URL) {
-					PARALLEL_OPTIONS += " TRSS_URL=${params.TRSS_URL}" 
+					PARALLEL_OPTIONS += " TRSS_URL=${params.TRSS_URL}"
 				}
+
+				try {
+					//get pre-staged jars from test.getDependency build
+					copyArtifacts fingerprintArtifacts: true, projectName: "test.getDependency", selector: lastSuccessful(), target: 'openjdk-tests/TKG/lib'
+				} catch (Exception e) {
+					echo 'Cannot run copyArtifacts from test.getDependency. Skipping copyArtifacts...'
+				}
+
 				sh "cd ./openjdk-tests/TKG; make genParallelList ${PARALLEL_OPTIONS}"
 
 				// get NUM_LIST from parallelList.mk. NUM_LIST can be different than numOfMachines


### PR DESCRIPTION
In serial builds, copyArtifacts from `test.getDependency` happens in build stage. Currently, parallel build (parent build) does not have copyArtifacts from `test.getDependency`, it gets jars directly using URLs. To make this more stable, add copyArtifacts from `test.getDependency` in parallel parent build.

Related: runtimes/infrastructure/issues/3831

Signed-off-by: lanxia <lan_xia@ca.ibm.com>