### PR TITLE
OpenJ9 AArch64: Enable 2 java/net/httpclient tests back again

### DIFF
--- a/openjdk/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/ProblemList_openjdk11-openj9.txt
@@ -157,7 +157,6 @@ java/net/MulticastSocket/Promiscuous.java https://github.com/AdoptOpenJDK/openjd
 java/net/MulticastSocket/SetLoopbackMode.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699 linux-s390x
 java/net/MulticastSocket/Test.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699 linux-s390x
 java/net/Socket/asyncClose/AsyncClose.java	https://github.com/eclipse/openj9/issues/4560    generic-all
-java/net/httpclient/http2/HpackHuffmanDriver.java	https://github.com/eclipse/openj9/issues/9041	linux-aarch64
 java/net/httpclient/websocket/BlowupOutputQueue.java https://github.com/eclipse/openj9/issues/4298 macosx-all
 java/net/httpclient/websocket/PendingBinaryPingClose.java https://github.com/eclipse/openj9/issues/4298 macosx-all
 java/net/httpclient/websocket/PendingBinaryPongClose.java https://github.com/eclipse/openj9/issues/4298 macosx-all
@@ -167,7 +166,6 @@ java/net/httpclient/websocket/PendingPongBinaryClose.java https://github.com/ecl
 java/net/httpclient/websocket/PendingPongTextClose.java https://github.com/eclipse/openj9/issues/4298 macosx-all
 java/net/httpclient/websocket/PendingTextPingClose.java https://github.com/eclipse/openj9/issues/4298 macosx-all
 java/net/httpclient/websocket/PendingTextPongClose.java https://github.com/eclipse/openj9/issues/4298 macosx-all
-java/net/httpclient/websocket/ReaderDriver.java	https://github.com/eclipse/openj9/issues/9083	linux-aarch64
 # java/net/ipv6tests/B6521014.java on macosx-all issue	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1524
 # java/net/ipv6tests/B6521014.java on macosx-all issue https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1085
 java/net/ipv6tests/B6521014.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1105 linux-all,macosx-all


### PR DESCRIPTION
This commit enables the following two tests, which used to fail with
timeouts:

- java/net/httpclient/http2/HpackHuffmanDriver.java (eclipse/openj9#9041)
- java/net/httpclient/websocket/ReaderDriver.java.ReaderDriver (eclipse/openj9#9083)

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>