### PR TITLE
Add Liberty Throughput Framework & Other Enhancements

### DIFF
--- a/perf/liberty/README.md
+++ b/perf/liberty/README.md
@@ -1,0 +1,25 @@
+
+<!--
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+[1]https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+-->
+
+# Liberty Benchmarks
+
+**TARGET** | Description |
+-- | -- | 
+liberty-dt7-startup | Benchmark to measure startup time and footprint of server running Liberty with DayTrader7 | 
+liberty-dt7-throughput | Benchmark to measure throughput of server running Open Liberty with DayTrader7, connected to Apache Derby database, by driving load with Apache JMeter |
+
+### How to use the Liberty Framework?
+
+Please see `usage()` function in various scripts: `sufp_benchmark.sh`, `throughput_benchmark.sh`, and `configure_liberty.sh`.
+

--- a/perf/liberty/build.xml
+++ b/perf/liberty/build.xml
@@ -22,124 +22,26 @@
 	<property name="DEST" value="${BUILD_ROOT}/perf/liberty" />
 
 	<!--Properties for this particular build-->
-	<property name="src" location="." />
+	<property name="SRC" location="." />
 	<property environment="env" />
 	
-	<property name="BM_BIN_DIR" value="${env.PERF_ROOT}/libertyBinaries" />
-	
-	<property name="BM_BINARIES_URL" value="https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/2019-04-19_0642/openliberty-19.0.0.4.zip" />
-	<property name="BM_VERSION" value="openliberty-19.0.0.4" />
-	<basename property="BM_BINARIES_ZIP" file="${BM_BINARIES_URL}"/>
-	
-	<property name="LIBERTY_APP_URL" value="https://github.com/WASdev/sample.daytrader7/releases/download/v1.2/daytrader-ee7.ear" />
-	<basename property="LIBERTY_APP" file="${LIBERTY_APP_URL}"/>
-
-	<property name="DERBY_BINARIES_URL" value="http://archive.apache.org/dist/db/derby/db-derby-10.10.1.1/db-derby-10.10.1.1-lib.zip" />
-	<property name="DERBY_PACKAGE" value="db-derby-10.10.1.1-lib" />
-	<basename property="DERBY_BINARIES_ZIP" file="${DERBY_BINARIES_URL}"/>
+	<property name="BM_VERSION" value="openliberty-19.0.0.4" />	
 	
 	<target name="init">
 		<mkdir dir="${DEST}" />
-		<mkdir dir="${BM_BIN_DIR}" />
-		<echo message="BM_BINARIES_ZIP=${BM_BINARIES_ZIP}" />
 	</target>
-
-	<target name="getBinaries" depends="init">
-		<var name="curl_command" value=""/>
-		<if>
-			<available file="${DEST}/libertyBinaries/${BM_VERSION}" />
-			<then>
-				<echo message="${DEST}/libertyBinaries/${BM_VERSION} exists." />
-			</then>
-			<else>
-				<echo message="${DEST}/libertyBinaries/${BM_VERSION} doesn't exist." />
-				<if>
-					<available file="${BM_BIN_DIR}/${BM_BINARIES_ZIP}" type="file" />
-					<then>
-						<echo message="${BM_BIN_DIR}/${BM_BINARIES_ZIP} exists. Hence, not downloading it." />
-						<unzip src="${BM_BIN_DIR}/${BM_BINARIES_ZIP}" dest="${DEST}/libertyBinaries" />
-					</then>
-					<else>
-						<echo message="${BM_BIN_DIR}/${BM_BINARIES_ZIP} doesn't exist. Hence, downloading it." />						
-						<var name="curl_command" value="-OLks ${BM_BINARIES_URL}"/>
-						<echo message="curl ${curl_command}" />
-						<exec executable="curl" failonerror="true">
-							<arg line="${curl_command}" />
-						</exec>
-						<unzip src="${BM_BINARIES_ZIP}" dest="${DEST}/libertyBinaries" />										
-					</else>
-				</if>
-				<echo message="Moving ${DEST}/libertyBinaries/wlp to ${DEST}/libertyBinaries/${BM_VERSION}" />
-				<move file="${DEST}/libertyBinaries/wlp" tofile="${DEST}/libertyBinaries/${BM_VERSION}"/>
-			</else>
-		</if>
-		<if>
-			<available file="${DEST}/libertyBinaries/${BM_VERSION}/usr/shared/apps/webcontainer/${LIBERTY_APP}" type="file" />
-			<then>
-				<echo message="${DEST}/libertyBinaries/${BM_VERSION}/usr/shared/apps/webcontainer/${LIBERTY_APP} exists. Hence, not downloading it." />
-			</then>
-			<else>
-				<echo message="${DEST}/libertyBinaries/${BM_VERSION}/usr/shared/apps/webcontainer/${LIBERTY_APP} doesn't exist. Hence, downloading it." />						
-				<var name="curl_command" value="-OLks ${LIBERTY_APP_URL}"/>
-				<echo message="curl ${curl_command}" />
-				<exec executable="curl" failonerror="true">
-					<arg line="${curl_command}" />
-				</exec>
-				<copy file="${LIBERTY_APP}" todir="${DEST}/libertyBinaries/${BM_VERSION}/usr/shared/apps/webcontainer/"/>
-			</else>
-		</if>
-		<if>
-			<available file="${DEST}/libertyBinaries/${BM_VERSION}/usr/shared/resources/derby/derby.jar" type="file" />
-			<then>
-				<echo message="${DEST}/libertyBinaries/${BM_VERSION}/usr/shared/resources/derby/derby.jar exists. Hence, not downloading it." />
-			</then>
-			<else>
-				<echo message="${DEST}/libertyBinaries/${BM_VERSION}/usr/shared/resources/derby/derby.jar doesn't exist. Hence, downloading it." />						
-				<var name="curl_command" value="-OLks ${DERBY_BINARIES_URL}"/>
-				<echo message="curl ${curl_command}" />
-				<exec executable="curl" failonerror="true">
-					<arg line="${curl_command}" />
-				</exec>
-				<unzip src="${DERBY_BINARIES_ZIP}" dest="." />
-				<copy file="${DERBY_PACKAGE}/lib/derby.jar" todir="${DEST}/libertyBinaries/${BM_VERSION}/usr/shared/resources/derby/"/>
-				<delete file="${DERBY_BINARIES_ZIP}"/>
-				<delete dir="${DERBY_PACKAGE}"/>
-			</else>
-		</if>
-	</target>	
-	<target name="dist" depends="getBinaries" description="generate the distribution">
+	<target name="configure" depends="init" description="Configure Liberty">
 		<copy todir="${DEST}">
-			<fileset dir="${src}"/>
+			<fileset dir="${SRC}"/>
 		</copy>
 		<chmod file="${DEST}/**" perm="a+x" maxparallel="10"/>
+		<exec executable="bash">
+			<env key="DEST" value="${DEST}"/>
+			<env key="LIBERTY_DEP_CACHE_LOCATION" value="${env.PERF_ROOT}"/>
+		    <arg value="${DEST}/scripts/bin/configure_liberty.sh"/>
+		</exec>							
 	</target>
-	<target name="configure" depends="dist" description="configure Liberty">
-		<if>
-			<available file="${DEST}/libertyBinaries/${BM_VERSION}/usr/shared/resources/data/tradedb7/service.properties" type="file" />
-			<then>
-				<echo message="${DEST}/libertyBinaries/${BM_VERSION}/usr/shared/resources/data/tradedb7/service.properties exists. Not configuring database." />
-			</then>
-			<else>
-				<echo message="${DEST}/libertyBinaries/${BM_VERSION}/usr/shared/resources/data/tradedb7/service.properties doesn't exist. Configuring database." />						
-				<exec executable="bash">
-					<env key="DB_SETUP" value="1"/>
-				    <arg value="${DEST}/configs/benchmark.sh"/>
-				    <arg value="${DEST}"/>
-				</exec>
-			</else>
-		</if>
-	</target>
-	<target name="archive" depends="configure" description="clean up">
-		<delete file="${BM_BIN_DIR}/${BM_VERSION}.zip"/>
-		<move file="${DEST}/libertyBinaries/${BM_VERSION}" tofile="${DEST}/libertyBinaries/wlp"/>
-		<zip destfile="${BM_BIN_DIR}/${BM_VERSION}.zip" basedir="${DEST}/libertyBinaries"/>
-		<move file="${DEST}/libertyBinaries/wlp" tofile="${DEST}/libertyBinaries/${BM_VERSION}"/>
-	</target>
-	<target name="clean" depends="archive" description="clean up">
-		<delete dir="${BM_BINARIES_ZIP}" />
-	</target>
-
 	<target name="build">
-		<antcall target="clean" inheritall="true" />
+		<antcall target="configure" inheritall="true" />
 	</target>
 </project>

--- a/perf/liberty/configs/dt7_sufp.sh
+++ b/perf/liberty/configs/dt7_sufp.sh
@@ -31,21 +31,13 @@ echo "JDK=${JDK}"
 export JDK_DIR="${TEST_JDK_HOME}/.."
 echo "JDK_DIR=${JDK_DIR}"
 
-######### Generated Script #########
-
-if [ -z "${DB_SETUP}" ]; then
-	#TODO: Need to do some cleanup and restructure some files for adding other configs
-	echo ""
-	echo "********** START OF NEW TESTCI BENCHMARK JOB **********"
-	echo "Benchmark Name: LibertyStartupDT Benchmark Variant: 17dev-4way-0-256-qs"
-	echo "Benchmark Product: ${JDK}"
-	echo ""
-fi
-
 #TODO: Need to tune these options. Keeping them simple for now 
 export JDK_OPTIONS="-Xmx256m"
 export COLD="0"
 export WARMUP="0"
+export RESULTS_MACHINE="$(hostname)"
+export ROOT_RESULTS_DIR="$(pwd)"
+export RESULTS_DIR="libertyResults-cleaned"
 export NO_SETUP="false"
 export SETUP_ONLY="false"
 export WARM="1"

--- a/perf/liberty/configs/dt7_throughput.sh
+++ b/perf/liberty/configs/dt7_throughput.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+echo "***** Running Benchmark Script *****"
+
+echo "Current Dir: $(pwd)"
+
+#TODO: Remove these once the use of STAF has been eliminated from all the benchmark scripts
+export PATH=/usr/local/staf/bin:$PATH
+export LD_LIBRARY_PATH=/usr/local/staf/lib:$LD_LIBRARY_PATH
+
+
+echo "JDK_VERSION=${JDK_VERSION}"
+
+export JDK="j2sdk-image"
+echo "JDK=${JDK}"
+
+export JDK_DIR="${TEST_JDK_HOME}/.."
+echo "JDK_DIR=${JDK_DIR}"
+
+#TODO: Need to tune these options. Keeping them simple for now 
+export JDK_OPTIONS="-Xms1024m -Xmx1024m"
+export MEASURES="1"
+export WARMUPS="0"
+export SINGLE_CLIENT_WARMUP="0"
+export MEASURE_TIME="30"
+export WARMUP_TIME="30"
+export RESULTS_MACHINE="$(hostname)"
+export ROOT_RESULTS_DIR="$(pwd)"
+export RESULTS_DIR="libertyResults-cleaned"
+
+export NET_PROTOCOL="LOCAL"
+echo "dt7_throughput.sh NET_PROTOCOL=${NET_PROTOCOL}"
+export CLIENT="$(hostname)"
+export DB_MACHINE="$(hostname)"
+export LIBERTY_HOST="$(hostname)"
+
+export CLIENT_WORK_DIR="${1}/liberty-client"
+export DB_SERVER_WORKDIR="${CLIENT_WORK_DIR}"
+export DATABASE="derby"
+export DB2_HOME="/home/db2inst1/"
+export DB_NAME="tradedb7"
+export DB_PORT="50000"
+export DB_USR_NAME="db2inst1"
+export SERVER_NAME="DayTrader7-$JDK"
+export SECOND_CLIENT=""
+export THIRD_CLIENT=""
+export PROFILING_TOOL=""
+export PROFILING_JAVA_OPTION=""
+export LIBERTY_PORT="9080"
+export LARGE_THREAD_POOL="true"
+export JMETER_LOC="${1}/JMeter/apache-jmeter-3.3/bin/jmeter"
+export JMETER_INSTANCES=""
+export SERVER_XML=""
+export THROUGHPUT_DRIVER="jmeter"
+export CORE_THREADS="40"
+export MAX_THREADS="50"
+export SCENARIO="DayTrader7"
+export HEALTH_CENTRE=""
+export PRIMITIVE=""
+export CLEAN_RUN="true"
+export SETUP_ONLY="false"
+export NO_SETUP="false"
+export LAUNCH_SCRIPT="server"
+export LIBERTY_BINARIES_DIR="$1/libertyBinaries"
+export LIBERTY_VERSION="openliberty-19.0.0.4"
+export GCMV_ENABLED="false"
+
+#TODO: Need to soft-code these configs. Need to add various affinity tools in the perf pre-reqs ()
+export AFFINITY=""
+
+bash ${1}/scripts/bin/throughput_benchmark.sh 

--- a/perf/liberty/playlist.xml
+++ b/perf/liberty/playlist.xml
@@ -15,14 +15,28 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:noNamespaceSchemaLocation="../../TKG/playlist.xsd">
 	<test>
-		<testCaseName>OpenLibertyStartupDT7</testCaseName>
-		<command>bash $(TEST_RESROOT)/../../../openjdk-tests/perf/liberty/configs/benchmark.sh $(TEST_RESROOT); \
+		<testCaseName>liberty-dt7-startup</testCaseName>
+		<command>bash $(Q)$(TEST_RESROOT)$(D)configs$(D)dt7_sufp.sh$(Q) $(TEST_RESROOT); \
 		${TEST_STATUS}
 		</command>
 		<!-- scripts are only tested on linux -->
 		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
 		<levels>
-			<level>extended</level>
+			<level>special</level>
+		</levels>
+		<groups>
+			<group>perf</group>
+		</groups>
+	</test>
+	<test>
+		<testCaseName>liberty-dt7-throughput</testCaseName>
+		<command>bash $(Q)$(TEST_RESROOT)$(D)configs$(D)dt7_throughput.sh$(Q) $(TEST_RESROOT); \
+		${TEST_STATUS}
+		</command>
+		<!-- scripts are only tested on linux -->
+		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
+		<levels>
+			<level>special</level>
 		</levels>
 		<groups>
 			<group>perf</group>

--- a/perf/liberty/scripts/bin/configure_liberty.sh
+++ b/perf/liberty/scripts/bin/configure_liberty.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+
+################################################################################
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Print out the help information if all mandatory environment variables are not set
+usage()
+{
+	echo "
+Usage:
+
+To customize the use of this script use the following environment variables:
+
+DEST							- Location of Liberty Test Material
+LIBERTY_DEP_CACHE_LOCATION		- Cache with Liberty Dependencies
+
+"
+}
+
+
+# Environment variables setup. Terminate script if a mandatory env variable is not set
+checkAndSetEnvVars()
+{
+	printf '%s\n' "
+.--------------------------
+| Environment Setup
+"
+
+    if [ -z "${DEST}" ]; then
+        echo "DEST not set. Defaulting to current directory"
+        DEST="."
+    fi
+    if [ -z "${LIBERTY_DEP_CACHE_LOCATION}" ]; then
+        echo "LIBERTY_DEP_CACHE_LOCATION not set. Defaulting to current directory"
+        LIBERTY_DEP_CACHE_LOCATION="."
+    fi
+   
+	echo "DEST=${DEST}"
+	echo "LIBERTY_DEP_CACHE_LOCATION=${LIBERTY_DEP_CACHE_LOCATION}"	
+}
+
+echoAndRunCmd()
+{
+	echo "$1"
+	$1
+}
+
+populateDatabase()
+{
+	printf '%s\n' "
+.--------------------------
+| Populate Database
+"
+	
+	DB_FILE="${DEST}/libertyBinaries/${BM_VERSION}/usr/shared/resources/data/tradedb7/service.properties"
+	if [ -e "${DB_FILE}" ]; then
+		echo "${DB_FILE} exists. Not configuring database."
+	else
+		echo "${DB_FILE} doesn't exist. Configuring database."
+		export DB_SETUP="1"
+		bash ${DEST}/configs/dt7_throughput.sh ${DEST}
+		unset DB_SETUP
+	fi
+}
+
+JMETER_DEPENDENCIES_URL=(
+	"https://github.com/maciejzaleski/JMeter-WebSocketSampler/releases/download/version-1.0.2/JMeterWebSocketSampler-1.0.2-SNAPSHOT.jar"
+    "https://repo1.maven.org/maven2/org/eclipse/jetty/websocket/websocket-server/9.1.1.v20140108/websocket-server-9.1.1.v20140108.jar"
+    "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-io/9.1.1.v20140108/jetty-io-9.1.1.v20140108.jar"
+    "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-util/9.1.1.v20140108/jetty-util-9.1.1.v20140108.jar"
+    "https://repo1.maven.org/maven2/org/eclipse/jetty/websocket/websocket-api/9.1.1.v20140108/websocket-api-9.1.1.v20140108.jar"
+    "https://repo1.maven.org/maven2/org/eclipse/jetty/websocket/websocket-client/9.1.1.v20140108/websocket-client-9.1.1.v20140108.jar"
+    "https://repo1.maven.org/maven2/org/eclipse/jetty/websocket/websocket-common/9.1.1.v20140108/websocket-common-9.1.1.v20140108.jar"
+)
+
+downloadJmeterDependencies()
+{
+	printf '%s\n' "
+.--------------------------
+| Downloading JMeter dependencies
+"
+
+ 	echoAndRunCmd "cd ${JMETER_LOCATION}/lib/ext"
+ 	
+	for i in "${JMETER_DEPENDENCIES_URL[@]}"; do
+
+		DEP_NAME=${i}
+		CURL_CMD="curl -OLks ${DEP_NAME}"
+		
+		echoAndRunCmd "${CURL_CMD}"
+
+    done
+
+}
+
+unsetVars()
+{	
+	unset APP_URL APP_ARCHIVE EXTRACT_ORIGINAL_NAME EXTRACT_NEW_NAME APP_DEST
+}
+
+downloadDepencies()
+{	
+	printf '%s\n' "
+.--------------------------
+| Downloading Dependencies ${EXTRACT_NEW_NAME}
+"
+   
+	echo "APP_URL=${APP_URL}"
+	echo "APP_ARCHIVE=${APP_ARCHIVE}"
+	echo "EXTRACT_ORIGINAL_NAME=${EXTRACT_ORIGINAL_NAME}"	
+	echo "EXTRACT_NEW_NAME=${EXTRACT_NEW_NAME}"
+	echo "APP_DEST=${APP_DEST}"
+	
+	echoAndRunCmd "mkdir -p ${APP_DEST}"
+	
+	echoAndRunCmd "cd ${LIBERTY_DEP_CACHE_LOCATION}"
+	
+	if [ -e "${APP_DEST}/${EXTRACT_NEW_NAME}" ]; then
+		echo "${APP_DEST}/${EXTRACT_NEW_NAME} exists in Dest. Hence, not downloading it."
+	else		
+		echo "${APP_DEST}/${EXTRACT_NEW_NAME} doesn't exist in Dest."	
+		
+		if [ -e "${APP_ARCHIVE}" ]; then
+			echo "${LIBERTY_DEP_CACHE_LOCATION}/${APP_ARCHIVE} exists in Cache. Hence, not downloading it."
+		else
+			echo "${LIBERTY_DEP_CACHE_LOCATION}/${APP_ARCHIVE} doesn't exist in Cache. Hence, downloading it."
+			CURL_CMD="curl -OLk ${APP_URL}" 
+	
+			echoAndRunCmd "${CURL_CMD}"		
+		fi
+		
+		if [ "${APP_ARCHIVE}" != "${EXTRACT_NEW_NAME}" ]; then
+			echo "${APP_ARCHIVE} requires extraction."
+			echoAndRunCmd "unzip -oq ${APP_ARCHIVE} -d ${APP_DEST}"
+			
+			if [ "${EXTRACT_NEW_NAME}" != "${EXTRACT_ORIGINAL_NAME}" ]; then
+				echo "EXTRACT_NEW_NAME (${EXTRACT_NEW_NAME}) is not equal to EXTRACT_ORIGINAL_NAME (${EXTRACT_ORIGINAL_NAME}). Hence, need to rename the directory."
+				echoAndRunCmd "mv ${APP_DEST}/${EXTRACT_ORIGINAL_NAME} ${APP_DEST}/${EXTRACT_NEW_NAME}"
+			else
+				echo "EXTRACT_NEW_NAME is equal to EXTRACT_ORIGINAL_NAME (${EXTRACT_ORIGINAL_NAME}). Hence, no need to rename directory."	
+			fi
+		
+		else
+			echo "${APP_ARCHIVE} doesn't require extraction."
+			echoAndRunCmd "cp ${APP_ARCHIVE} ${APP_DEST}"
+		fi
+	fi 	
+}
+
+OS=$(uname)
+echo "OS=${OS}"
+ARCH=$(uname -m)
+echo "ARCH=${ARCH}"
+
+if [ "${OS}" = "Linux" ] && [ "${ARCH}" = "x86_64" ]; then
+	echo "Configuring Liberty since OS=${OS} and ARCH=${ARCH}, which is the only platform tested so far."
+else
+	echo "Exiting without configuring Liberty since OS=${OS} and ARCH=${ARCH}. Linux x86_64 is the only platform tested so far."
+	exit	
+fi
+	
+checkAndSetEnvVars
+
+echoAndRunCmd "mkdir -p ${DEST} ${LIBERTY_DEP_CACHE_LOCATION}"
+
+
+##########################
+
+unsetVars
+APP_URL="https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/2019-04-19_0642/openliberty-19.0.0.4.zip"
+APP_ARCHIVE="$(basename ${APP_URL})"
+EXTRACT_ORIGINAL_NAME="wlp"
+EXTRACT_NEW_NAME="openliberty-19.0.0.4"
+APP_DEST="${DEST}/libertyBinaries"
+downloadDepencies
+
+BM_VERSION=${EXTRACT_NEW_NAME}
+
+##########################
+
+unsetVars
+APP_URL="https://github.com/WASdev/sample.daytrader7/releases/download/v1.2/daytrader-ee7.ear"
+APP_ARCHIVE="$(basename ${APP_URL})"
+EXTRACT_ORIGINAL_NAME=${APP_ARCHIVE}
+EXTRACT_NEW_NAME=${EXTRACT_ORIGINAL_NAME}
+APP_DEST="${DEST}/libertyBinaries/${BM_VERSION}/usr/shared/apps/webcontainer"
+downloadDepencies
+
+##########################
+
+unsetVars
+APP_URL="http://archive.apache.org/dist/db/derby/db-derby-10.10.1.1/db-derby-10.10.1.1-lib.zip"
+APP_ARCHIVE="$(basename ${APP_URL})"
+EXTRACT_ORIGINAL_NAME="db-derby-10.10.1.1-lib"
+EXTRACT_NEW_NAME=${EXTRACT_ORIGINAL_NAME}
+APP_DEST="${DEST}"
+downloadDepencies
+
+DERBY_FILE_LOCATION="${DEST}/libertyBinaries/${BM_VERSION}/usr/shared/resources/derby/"
+echoAndRunCmd "mkdir -p ${DERBY_FILE_LOCATION}"
+echoAndRunCmd "cp ${APP_DEST}/${EXTRACT_NEW_NAME}/lib/derby.jar ${DERBY_FILE_LOCATION}"
+
+##########################
+
+unsetVars
+APP_URL="https://github.com/WASdev/sample.daytrader7/archive/v1.2.zip"
+APP_ARCHIVE="$(basename ${APP_URL})"
+EXTRACT_ORIGINAL_NAME="sample.daytrader7-1.2"
+EXTRACT_NEW_NAME=${EXTRACT_ORIGINAL_NAME}
+APP_DEST="${DEST}"
+downloadDepencies
+
+JMX_FILE_LOCATION="${DEST}/scripts/resource/client_scripts"
+echoAndRunCmd "mkdir -p ${JMX_FILE_LOCATION}"
+echoAndRunCmd "cp ${APP_DEST}/${EXTRACT_NEW_NAME}/jmeter_files/daytrader7.jmx ${JMX_FILE_LOCATION}"
+
+##########################
+
+unsetVars
+APP_URL="https://archive.apache.org/dist/jmeter/binaries/apache-jmeter-3.3.zip"
+APP_ARCHIVE="$(basename ${APP_URL})"
+EXTRACT_ORIGINAL_NAME="apache-jmeter-3.3" 
+EXTRACT_NEW_NAME=${EXTRACT_ORIGINAL_NAME}
+APP_DEST="${DEST}/JMeter"
+downloadDepencies
+
+JMETER_LOCATION="${APP_DEST}/${EXTRACT_NEW_NAME}"
+downloadJmeterDependencies
+
+##########################
+
+populateDatabase
+
+##########################
+
+

--- a/perf/liberty/scripts/bin/database_utils.sh
+++ b/perf/liberty/scripts/bin/database_utils.sh
@@ -14,10 +14,6 @@
 # limitations under the License.
 ################################################################################
 
-#TODO: verify that all alternative ssh commands work if using them instead of staf
-# Identifies that this script is for Liberty Benchmark
-# Note: Backslashes need to be escaped so it looks properly formatted when actually printed
-
 # Import the common utilities needed to run this benchmark
 . "$(dirname $0)"/common_utils.sh
 

--- a/perf/liberty/scripts/bin/throughput_benchmark.sh
+++ b/perf/liberty/scripts/bin/throughput_benchmark.sh
@@ -1,0 +1,1820 @@
+#!/usr/bin/env bash
+
+################################################################################
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+## Print out the help information if all mandatory environment variables are not set
+usage()
+{
+echo "
+Usage:
+
+To customize the use of this script use the following environment variables:
+
+VERBOSE_MODE        - Prints all commands before they are executed.
+
+NO_SETUP            - Liberty server creation is skipped if set to true.
+                      If false, a new server will be created and the corresponding customized server.xml
+                      and customized bootstrap.properties (if exists) files will overwrite the server's default.
+
+SETUP_ONLY          - Only Liberty server creation and replacement of Liberty server default server.xml and bootstrap.properties (if available) is done.
+
+JDK                 - Name of JDK build to use
+
+JDK_DIR             - absolute path to directory where JDK builds are located.\n
+                      Ex: if the path to a JDK's bin directory is /tmp/all_jdks/jdk8/sdk/bin\n
+                      Then JDK=jdk8 and JDK_DIR=/tmp/all_jdks
+
+JDK_OPTIONS         - JVM command line options
+
+PROFILING_TOOL      - Profiling Tool to Use (Example: 'jprof tprof', 'perf stat')
+
+LIBERTY_HOST        - Hostname for Liberty host machine
+
+LIBERTY_VERSION     - Liberty application's root directory
+
+LIBERTY_PORT        - Listening port on Liberty host machine
+
+LAUNCH_SCRIPT       - Liberty script that can create, start, stop a server
+
+SERVER_NAME         - The given name will be used to identify the Liberty server.
+
+SERVER_XML          - XML File
+
+AFFINITY            - CPU pinning command prefixed on the Liberty server start command.
+
+LARGE_THREAD_POOL   - Sets specified CORE_THREADS, MAX_THREADS, keepAlive=60s, STEAL_POLICY,
+                      rejectedWorkPolicy=CALLER_RUNS
+
+CORE_THREADS        - Starting number of core threads in the pool used by server
+
+MAX_THREADS         - Max number of threads in the pool used by server
+
+STEAL_POLICY        - Steal policy defaults to LOCAL if not set
+
+SCENARIO            - Supported scenarios: AcmeAir, TradeApp, TradeAppDerby, Primitive,
+                      DayTrader, DayTrader7, DayTraderJDBC, DayTrader7JDBC, DayTraderCrypto, DayTraderRU,
+                      DayTraderSSL, DayTrader7SSL, JMS 
+
+APP_VERSION
+                    - The specific DayTrader 3 application version used for all scenarios
+                      involving this particular benchmark. (Default: daytrader3.0.10.1-ee6-src)
+
+CLEAN_RUN           - adds the --clean option suffix when starting the Liberty server
+
+GCMV_ENABLED        - The GCMV tool will run
+
+RESULTS_MACHINE     - Hostname for results storage machine
+
+RESULTS_DIR         - Name of directory on Liberty host where results are temporarily stored
+
+ROOT_RESULTS_DIR    - Absolute path of Liberty results directory on remote storage machine
+
+CLIENT              - Hostname for client machine
+
+CLIENT_WORK_DIR     - Directory on client machine used to store the client script
+
+THROUGHPUT_DRIVER   - Client side throughput driver
+
+MEASURES            - number of measure runs client will perform
+
+WARMUPS             - number of warmup runs client will perform
+
+SINGLE_CLIENT_WARMUP
+                    - number of warmup runs with 1 simulated client
+
+MEASURE_TIME        - number of seconds each measure run will last
+
+WARMUP_TIME         - number of seconds each warmup run will last
+
+DB_MACHINE          - Hostname for database achine
+
+DB2_HOME            - Home directory for db2 user (ex. /home/db2inst1/)
+
+DB_NAME             - Name of database (ex. day30r)
+
+DB_PORT             - Listening port for database (ex. 50000)
+
+DB_USR_NAME         - Database login username
+
+DB_PASSWORD         - Database login password (Defaults to DB_USR_NAME)
+
+DB_SERVER_WORKDIR   - Work directory for database (Defaults to /java/perffarm/liberty)
+
+JMETER_LOC			- Location of Load Driver: JMeter (/java/perffarm/JMeter/apache-jmeter-2.12/bin/jmeter)
+
+Specific to the DayTraderSSL & DayTrader7SSL Scenarios:
+
+CIPHER_SUITE        - Configured in Liberty server.xml
+
+KEY_TYPE            - Configured in Liberty server.xml
+
+KEY_LENGTH          - Configured in Liberty server.xml
+
+SSL_PASSWORD        - Keypass value for Java keytool (Default: Liberty)
+                      Also configured in JMeter system.properties file
+
+PROTOCOL            - Configured in Liberty server.xml and JMeter jmeter.properties
+
+SSL_SESSION_REUSE   - Configured in JMeter jmeter.properties
+
+JMETER_INSTANCES    - Number of JMeter clients. Defaults to 1
+
+HOST_MACHINE_USER   - HOST Machine username to be used for ssh logins ( for STAF it will be automatically set to User that STAF runs on as dummy var)
+
+DB_MACHINE_USER     - DB Machine username to be used for ssh logins ( for STAF it will be automatically set to User that STAF runs on as dummy var)
+
+CLIENT_MACHINE_USER - Client Machine username to be used for ssh logins ( for STAF it will be automatically set to User that STAF runs on as dummy var)
+
+NET_PROTOCOL        - Intermachine communication protocol decider variable
+                      User may declaire variable as STAF, SSH or LOCAL else, exit
+                      If LOCAL is specified when more than one machines used, use STAF instead
+                      If not specificed, STAF is used as default
+
+
+Specific to the Primitive Scenario:
+
+PRIMITIVE           - The primitive servlet type
+"
+}
+
+#######################################################################################
+#	THROUGHPUT UTILS - Helper methods that are throughput specific
+#######################################################################################
+
+SSH_CMD=""
+STAF_CMD=""
+LOCAL_CMD=""
+
+function runNetProtocolCmd()
+{
+    case ${NET_PROTOCOL} in
+        "STAF")
+            echoAndRunCmd "${STAF_CMD}" "${1}" 
+        ;; 
+        "SSH") 
+            echo "${SSH_CMD}"
+            echoAndRunCmd "${SSH_CMD}" "${1}"
+        ;;
+        "LOCAL")
+            echoAndRunCmd "${LOCAL_CMD}" "${1}"
+        ;;
+esac
+}
+##
+## Environment variables setup. Terminate script if a mandatory env variable is not set
+checkAndSetThroughputEnvVars()
+{
+    printf '%s\n' "
+.--------------------------
+| Throughput Environment Setup
+"
+    if [ -z "$NET_PROTOCOL" ]; then
+        echo "NET_PROTOCOL not set"
+        if [ "${DB_MACHINE}" == "${CLIENT}" ] && [ "${LIBERTY_HOST}" == "${CLIENT}" ]; then
+            echo "NET_PROTOCOL set to LOCAL as all 3 machines are same"
+            export NET_PROTOCOL="LOCAL"
+        else
+            echo "NET_PROTOCOL set to STAF"
+            export NET_PROTOCOL="STAF"
+        fi
+    elif [ $NET_PROTOCOL == "LOCAL" ] && [ "${DB_MACHINE}" != "${CLIENT}" ] && [ "${LIBERTY_HOST}" != "${CLIENT}" ]; then
+        echo "DB Machine:" ${DB_MACHINE} "Client Machine:"${CLIENT} "Liberty Host Machine:"${LIBERTY_HOST}
+        echo "All 3 machines must be same for Local run. Setting NET_PROTOCOL to STAF"
+        export NET_PROTOCOL="STAF"
+    fi
+    echo "NET_PROTOCOL=${NET_PROTOCOL}"
+    
+    if [ -z "${CLIENT_MACHINE_USER}" ]; then
+        echo "CLIENT MACHNINE_USER not set, setting it to jbench"
+        #Using jbecnh for tempoary measure as Client Credential is not given in current state
+        export CLIENT_MACHINE_USER="jbench"
+    fi
+    if [ -z "${DB_MACHINE_USER}" ]; then
+        echo "DB MACHNINE_USER not set, setting it to jbench"
+        #Using jbecnh for tempoary measure as Client Credential is not given in current state
+        export DB_MACHINE_USER="jbench"
+    fi
+    if [ -z "${HOST_MACHINE_USER}" ]; then
+        echo "HOST MACHNINE_USER not set, setting it to current user : `whoami`"
+        export HOST_MACHINE_USER=`whoami`
+    fi
+    if [ ${NET_PROTOCOL} != "STAF" ] && [ "${PLATFORM}" = "CYGWIN" ]; then
+        echo "Net protocol is not STAF, Setting Windows path of Benchmark & work dir to appropriate unix path"
+        BENCHMARK_ORIGINAL_DIR=${BENCHMARK_DIR}
+        echo ${BENCHMARK_ORIGINAL_DIR}
+        BENCHMARK_DIR=`cygpath -u ${BENCHMARK_DIR}`
+        CLIENT_WORK_DIR=`cygpath -u ${CLIENT_WORK_DIR}`
+    fi
+    
+    if [ -z "$GCMV_ENABLED" ]; then
+        echo "GCMV_ENABLED not set. Defaulting to true"
+        GCMV_ENABLED="true"
+        
+    fi
+
+    if [ -z "$MEASURES" ]; then
+        echo "MEASURES not set"
+        usage
+        exit
+    fi
+
+    if [ -z "$WARMUPS" ]; then
+        echo "WARMUPS not set"
+        usage
+        exit
+    fi
+    
+    if [ -z "$SINGLE_CLIENT_WARMUP" ]; then
+        echo "SINGLE_CLIENT_WARMUP not set. Defaulting to 1"
+        export SINGLE_CLIENT_WARMUP=1
+    fi
+
+    if [ -z "$MEASURE_TIME" ]; then
+        echo "MEASURE_TIME not set"
+        usage
+        exit
+    fi
+
+    if [ -z "$WARMUP_TIME" ]; then
+        echo "WARMUP_TIME not set"
+        usage
+        exit
+    fi
+
+    if [ -z "$CLIENT" ]; then
+        echo "CLIENT not set"
+        usage
+        exit
+    fi
+
+    if [ -z "$CLIENT_WORK_DIR" ]; then
+        echo "CLIENT_WORK_DIR not set"
+        usage
+        exit
+    fi
+
+	if [ -z "$JMETER_LOC" ]; then
+        echo "Optional JMETER_LOC not set. Setting to '/java/perffarm/JMeter/apache-jmeter-2.12/bin/jmeter'"
+        JMETER_LOC="/java/perffarm/JMeter/apache-jmeter-2.12/bin/jmeter"
+    fi
+    
+    if [ -z "$DB_MACHINE" ]; then
+        echo "DB_MACHINE not set"
+        usage
+        exit
+    fi
+
+    if [ -z "$DB2_HOME" ]; then
+        echo "DB2_HOME not set"
+        usage
+        exit
+    fi
+
+    if [ -z "$DB_NAME" ]; then
+        echo "DB_NAME not set"
+        usage
+        exit
+    fi
+    
+    if [ -z "$DB_PORT" ]; then
+        echo "DB_PORT not set"
+        usage
+        exit
+    fi
+
+    if [ -z "$DB_USR_NAME" ]; then
+        echo "DB_USR_NAME not set"
+        usage
+        exit
+    fi
+
+    if [ -z "$DB_PASSWORD" ]; then
+        echo "Optional DB_PASSWORD not set. Setting to match DB_USR_NAME"
+        DB_PASSWORD=${DB_USR_NAME}
+    fi
+
+    if [ -z "$THROUGHPUT_DRIVER" ]; then
+        echo "Optional THROUGHPUT_DRIVER not set. Setting to IWL"
+        THROUGHPUT_DRIVER="IWL"
+    fi
+
+    if [ -z "$LIBERTY_PORT" ]; then
+        echo "LIBERTY_PORT not set"
+        usage
+        exit
+    fi
+
+    if [ -z "$LARGE_THREAD_POOL" ]; then
+        echo "Optional LARGE_THREAD_POOL not set. Setting to 'false'"
+        LARGE_THREAD_POOL="false"
+    fi
+
+    if [ -z "$CLEAN_RUN" ]; then
+        echo "Optional CLEAN_RUN not set. Setting to 'true'"
+        CLEAN_RUN="true"
+    fi
+
+    if [ -z "$SSL_PASSWORD" ]; then
+        echo "SSL_PASSWORD not set. Defaulting to 'Liberty'"
+        export SSL_PASSWORD="Liberty"
+    fi
+
+    if [ -z "$DB_SERVER_WORKDIR" ]; then
+        echo "Optional DB_SERVER_WORKDIR not set. Setting to '/java/perffarm/liberty/'"
+        DB_SERVER_WORKDIR="/java/perffarm/liberty"
+    fi
+
+    RESULTS="results.xml"
+    CLIENT_CPU_RESULTS="client_CPU_results.xml"
+    SERVER_CPU_RESULTS="server_CPU_results.xml"
+    DB_CPU_RESULTS="db_CPU_results.xml"
+}
+
+##
+## Scenario dependent environment variable setup
+scenarioSpecificEnvSetup()
+{
+    printf '%s\n' "
+.--------------------------
+| Scenario Specific Environment Setup
+"
+    case ${SCENARIO} in
+        DayTraderSSL|DayTrader7SSL)
+            #check scenario SSL specific env vars
+            if [ -z "$CIPHER_SUITE" ]; then
+                echo "CIPHER_SUITE must be defined for SSL runs"
+                echo "Some supported ones are : TLS_RSA_WITH_AES_128_CBC_SHA256"
+                exit
+            fi
+            if [ -z "$KEY_TYPE" ]; then
+                echo "KEY_TYPE must be defined for SSL runs. e.g RSA"
+                exit
+            fi
+            if [ -z "$KEY_LENGTH" ]; then
+                echo "KEY_LENGTH must be defined for SSL runs"
+                exit
+            fi
+            if [ -z "$PROTOCOL" ]; then
+                echo "PROTOCOL must be defined for SSL runs"
+                exit
+            fi
+            if [ -z "$SSL_SESSION_REUSE" ]; then
+                echo "SSL_SESSION_REUSE must be defined for SSL runs"
+                exit
+            fi
+            if [ -z "$JMETER_INSTANCES" ]; then
+                echo "JMETER_INSTANCES is not defined. Defaulting to 1"
+                export JMETER_INSTANCES=1
+            fi
+            if [ "$CIPHER_SUITE" = "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256" ]; then
+                if [ "$KEY_TYPE" = "RSA" ]; then
+                    export KEY_TYPE="ECDSA"
+                fi
+                if [ "$KEY_LENGTH" = "2048" ]; then
+                    export KEY_LENGTH="256"
+                fi
+            fi
+
+            # generate SSL keys and copy them to client
+            if [ "$PLATFORM" = "CYGWIN" ]; then
+                local tmpSERVER_DIR=$WIN_SERVER_DIR
+            else
+                local tmpSERVER_DIR=$SERVER_DIR
+            fi
+            
+            if [ ! -e $tmpSERVER_DIR/resources/security ]; then
+                mkdir -p $tmpSERVER_DIR/resources/security
+            fi
+            echo "server dir is $tmpSERVER_DIR"
+            echo "Creating Key file"
+            echo "${JAVA_HOME}/bin/keytool -genkey -alias RSA_2048 -keyalg RSA -keysize 2048 -dname CN=example -keystore ${tmpSERVER_DIR}/resources/security/key.jks -storepass Liberty -keypass ${SSL_PASSWORD}"
+            ${JAVA_HOME}/bin/keytool -genkey -alias RSA_2048 -keyalg RSA -keysize 2048 -dname CN=example -keystore ${tmpSERVER_DIR}/resources/security/key.jks -storepass Liberty -keypass ${SSL_PASSWORD}
+
+            echo "${JAVA_HOME}/bin/keytool -genkey -alias RSA_3072 -keyalg RSA -keysize 3072 -dname CN=example -keystore ${tmpSERVER_DIR}/resources/security/key.jks -storepass Liberty -keypass ${SSL_PASSWORD}"
+            ${JAVA_HOME}/bin/keytool -genkey -alias RSA_3072 -keyalg RSA -keysize 3072 -dname CN=example -keystore ${tmpSERVER_DIR}/resources/security/key.jks -storepass Liberty -keypass ${SSL_PASSWORD}
+
+            echo "${JAVA_HOME}/bin/keytool -genkey -alias ECDSA_256 -sigalg SHA256withECDSA -keyalg EC -keysize 256 -dname CN=example -keystore ${tmpSERVER_DIR}/resources/security/key.jks -storepass Liberty -keypass ${SSL_PASSWORD}"
+            ${JAVA_HOME}/bin/keytool -genkey -alias ECDSA_256 -sigalg SHA256withECDSA -keyalg EC -keysize 256 -dname CN=example -keystore ${tmpSERVER_DIR}/resources/security/key.jks -storepass Liberty -keypass ${SSL_PASSWORD}  
+            
+            STAF_CMD="STAF local fs copy file ${tmpSERVER_DIR}/resources/security/key.jks tomachine ${CLIENT} todirectory ${CLIENT_WORK_DIR}"
+            SSH_CMD="scp ${tmpSERVER_DIR}/resources/security/key.jks ${CLIENT_MACHINE_USER}@${CLIENT}:${CLIENT_WORK_DIR}"
+            LOCAL_CMD="cp ${tmpSERVER_DIR}/resources/security/key.jks ${CLIENT_WORK_DIR}"
+            runNetProtocolCmd 
+            ;;
+        AcmeAir)
+            if [ -z "$MONGODB_DIR" ]; then
+                echo "MONGODB_DIR is not defined. Defaulting to /java/perffarm/nodejs/mongo3"
+                export MONGODB_DIR=/java/perffarm/nodejs/mongo3
+            fi
+            export ACMEAIR_CLIENT_WORK_DIR=${CLIENT_WORK_DIR}/AcmeAir
+            ;;       
+        Primitive)
+            if [ -z "${PRIMITIVE}" ]; then
+                echo "Primitive type not set - required for the Primitive scenario."
+                exit
+            fi
+            ;;
+        *)
+            ;;
+    esac
+}
+
+##
+## Set client script environment variables and transfer the client scripts to the client
+clientScriptSetup()
+{
+    printf '%s\n' "
+.--------------------------
+| Client Throughput Script Setup
+"
+  # set the path where client scripts are stored on host
+  if [ -z "${CLIENT_SCRIPT_DIR}" ]; then
+    case ${PLATFORM} in
+      # Because staf runs under windows not cygwin, need to convert paths on windows
+      CYGWIN)
+        if [ ${NET_PROTOCOL} == "STAF" ]; then
+            local CLIENT_SCRIPT_PATH=$(cygpath -m "${BENCHMARK_DIR}/resource/client_scripts")
+        else 
+            local CLIENT_SCRIPT_PATH=$(cygpath -u "${BENCHMARK_DIR}/resource/client_scripts")
+        fi
+        PATH_SEP=";"
+        ;;
+
+      *)
+        local CLIENT_SCRIPT_PATH="${BENCHMARK_DIR}/resource/client_scripts"
+        PATH_SEP=":"
+        ;;
+    esac
+  else
+    local CLIENT_SCRIPT_PATH=${CLIENT_SCRIPT_DIR}
+    PATH_SEP=":"
+  fi
+
+  echoAndRunCmd "mkdir -p ${CLIENT_WORK_DIR}"
+
+  echo "CLIENT_SCRIPT_PATH=${CLIENT_SCRIPT_PATH}"
+  echo "CLIENT_WORK_DIR=${CLIENT_WORK_DIR}"
+  echo "PATH_SEP=${PATH_SEP}"
+
+  # transfer client scripts
+  STAF_CMD="STAF local FS COPY DIRECTORY ${CLIENT_SCRIPT_PATH} TOMACHINE ${CLIENT} TODIRECTORY ${CLIENT_WORK_DIR} RECURSE"
+  SSH_CMD="scp -r ${CLIENT_SCRIPT_PATH}/* ${CLIENT_MACHINE_USER}@${CLIENT}:${CLIENT_WORK_DIR}"
+  LOCAL_CMD="cp -r ${CLIENT_SCRIPT_PATH}/* ${CLIENT_WORK_DIR}"
+  runNetProtocolCmd -alwaysEcho
+  STAF_CMD="STAF ${CLIENT} PROCESS START SHELL COMMAND chmod -R 755 ${CLIENT_WORK_DIR}"
+  SSH_CMD="ssh ${CLIENT_MACHINE_USER}@${CLIENT} sudo chmod -R 755 ${CLIENT_WORK_DIR}"
+  LOCAL_CMD="sudo chmod -R 755 ${CLIENT_WORK_DIR}"
+  runNetProtocolCmd -alwaysEcho
+  
+  # check for successful transfer
+  if [ "`echo $? | grep Done`" = "0" ]; then
+    echo "!!! ERROR !!! Couldn\'t copy client scripts across."
+    exit
+  fi
+}
+
+# Configure the Liberty server's server.xml and optionally bootstrap.properties depending on scenario
+# TODO: Once verified, not all scenarios set SERVER_XML_TMP?
+scenarioSpecificServerSetup() {
+    printf '%s\n' "
+.--------------------------
+| Scenario Specific Liberty Server Setup
+"
+    if [[ "${SCENARIO}" = DayTrader* ]]; then
+
+        # set the default scenario specific server.xml script the Liberty server will use
+        case ${SCENARIO} in
+            DayTraderCrypto)
+                export CLIENT_SERVERXML="dt3cryptoserver.xml"
+                ;;
+
+            DayTraderSSL)
+                export CLIENT_SERVERXML="ssl_dt3server.xml"
+                ;;
+
+            DayTrader7|DayTrader7JDBC)
+                export CLIENT_SERVERXML="dt7server.xml"
+                echo "CLIENT_SERVERXML=dt7server.xml"
+                ;;
+
+            DayTrader7SSL)
+                export CLIENT_SERVERXML="ssl_dt7server.xml"
+                echo "CLIENT_SERVERXML=ssl_dt7server.xml"
+                ;;
+            *)
+                export CLIENT_SERVERXML="dt3server.xml"
+                ;;
+        esac
+
+		if [ "${DATABASE}" = "derby" ]; then
+		
+			echo "DATABASE=${DATABASE}"
+			export CLIENT_SERVERXML="sufpdt7server.xml"
+		
+		fi
+	
+        # use default scenario specific server.xml if not given
+        if [ -z "${SERVER_XML}" ]; then
+            echo "Using ${CLIENT_SERVERXML} for Server xml"
+        else
+            echo "Server XML defined in job. Using ${SERVER_XML} instead of ${CLIENT_SERVERXML}"
+            export CLIENT_SERVERXML="${SERVER_XML}"
+        fi
+        
+        # replace server's default created server.xml with our custom one, along with adding bootstrap.properties
+        echoAndRunCmd "cp ${BENCHMARK_DIR}/resource/${CLIENT_SERVERXML} ${SERVER_DIR}/server.xml"
+        echoAndRunCmd "cp ${BENCHMARK_DIR}/resource/db2bootstrap.properties ${SERVER_DIR}/bootstrap.properties"
+
+        # replace the placeholders in server.xml
+        echo "Setting the following values in server.xml:"
+
+        if [[ ! "${SCENARIO}" = DayTrader7 ]]; then
+            echo "APP_VERSION=${APP_VERSION}"
+        fi
+
+        echo "DB_NAME=${DB_NAME}"
+        echo "DB_MACHINE=${DB_MACHINE}"
+        echo "DB_PORT=${DB_PORT}"
+        echo "DB_USR_NAME=${DB_USR_NAME}"
+        echo "DB_PASSWORD"
+        
+        if [ "$PLATFORM" = "OS/390" ]; then
+            ${BENCHMARK_DIR}/bin/encode.sh ${SERVER_DIR}/server.xml
+        fi
+        
+        local SERVER_XML_TMP=`sed "s/DB_NAME_HERE/${DB_NAME}/g" ${SERVER_DIR}/server.xml | sed "s/DB_MACHINE_HERE/${DB_MACHINE}/g" | sed "s/DB_PORT_HERE/${DB_PORT}/g" | sed "s/DB_USR_HERE/${DB_USR_NAME}/g" | sed "s/DB_PASSWORD_HERE/${DB_PASSWORD}/g"`
+
+        # replace DayTrader3 App version
+        if [[ ! "${SCENARIO}" = DayTrader7* ]]; then
+            SERVER_XML_TMP=`echo "${SERVER_XML_TMP}" | sed "s/APP_VERSION_HERE/${APP_VERSION}/g"`
+        fi
+
+        # replace large thread pool placeholders in server.xml
+        if [ "${LARGE_THREAD_POOL}" = "true" ]; then
+            echo "Running with large thread pool, coreThreads=${CORE_THREADS}, maxThreads=${MAX_THREADS}, stealPolicy=${STEAL_POLICY}"
+            local LARGE_THREAD_POOL_LINE="<executor name=\"LargeThreadPool\" id=\"default\" coreThreads=\"${CORE_THREADS}\" maxThreads=\"${MAX_THREADS}\" keepAlive=\"60s\" stealPolicy=\"${STEAL_POLICY}\" rejectedWorkPolicy=\"CALLER_RUNS\" />"
+            SERVER_XML_TMP=`echo "${SERVER_XML_TMP}" | sed "s%</server>%${LARGE_THREAD_POOL_LINE}\n</server>%"`
+        fi
+
+        ###############
+        #CHECK IF CORRECTLY REPLACED PLACEHOLDERS IN SERVER.XML
+        ###############
+
+        if [ ! -z "${SERVER_XML_TMP}" ]; then
+            echo ${SERVER_XML_TMP} | tee ${SERVER_DIR}/server.xml
+        else
+            echo "Could not match required placeholders in server.xml. File before sed replace:"
+            cat  ${SERVER_DIR}/server.xml
+            exit 1
+        fi
+        
+        if [ "$PLATFORM" = "OS/390" ]; then
+            ${BENCHMARK_DIR}/bin/encode.sh -toascii ${SERVER_DIR}/server.xml
+        fi
+
+        ###############
+        #REPLACE CRYPTO PLACEHOLDERS
+        ###############
+        
+        if [ "$SCENARIO" = "DayTraderSSL" ] || [ "$SCENARIO" = "DayTrader7SSL" ]; then
+            local newXML=`cat ${SERVER_DIR}/server.xml | \
+            sed "s/TARGET_PROTOCOL/${PROTOCOL}/g" | \
+            sed "s/TARGET_CIPHER_SUITE/${CIPHER_SUITE}/g" | \
+            sed "s/TARGET_KEY_ALIAS/${KEY_TYPE}_${KEY_LENGTH}/g"`
+            echo "$newXML" | tee ${SERVER_DIR}/server.xml	
+            
+            # jmeter_ssl.properties is used in the client run.sh script
+            cat ${BENCHMARK_DIR}/resource/template_jmeter.properties | \
+            sed "s/TARGET_PROTOCOL/${PROTOCOL}/g" | \
+            sed "s/SSL_SESSION_REUSE/${SSL_SESSION_REUSE}/g" >  ${BENCHMARK_DIR}/resource/client_scripts/jmeter_ssl.properties
+            
+            cat ${BENCHMARK_DIR}/resource/template_system.properties | \
+            sed "s%KEYSTORE_LOC_HERE%${CLIENT_WORK_DIR}/key.jks%g" | \
+            sed "s/PASSWORD_HERE/${SSL_PASSWORD}/g" >  ${BENCHMARK_DIR}/tmp/system.properties
+            
+        ###############
+        #SEND JMETER SYSTEM PROP TO CLIENT MACHINE
+        ###############
+            #TODO: Looks like these 2 lines could be shared with DayTrader (no ssl). Leaving it for now. Need to test before doing so.
+            local JMETER_BIN_DIR=`echo $JMETER_LOC|sed 's%/jmeter%%g'`
+            STAF_CMD="STAF local fs copy file ${BENCHMARK_DIR}/tmp/system.properties tomachine ${CLIENT} todirectory ${JMETER_BIN_DIR}"
+            SSH_CMD="scp ${BENCHMARK_DIR}/tmp/system.properties ${CLIENT_MACHINE_USER}@${CLIENT}:${JMETER_BIN_DIR}"
+            LOCAL_CMD="cp ${BENCHMARK_DIR}/tmp/system.properties ${JMETER_BIN_DIR}"
+            runNetProtocolCmd
+
+        else
+            if [ $THROUGHPUT_DRIVER = "jmeter" ]; then
+                local JMETER_BIN_DIR=`echo $JMETER_LOC|sed 's%/jmeter%%g'`
+                cp ${BENCHMARK_DIR}/resource/template_nosslsystem.properties ${BENCHMARK_DIR}/tmp/system.properties
+                STAF_CMD="staf local fs copy file ${BENCHMARK_DIR}/tmp/system.properties tomachine ${CLIENT} todirectory ${JMETER_BIN_DIR}"
+                SSH_CMD="scp ${BENCHMARK_DIR}/tmp/system.properties ${CLIENT_MACHINE_USER}@${CLIENT}:${JMETER_BIN_DIR}"
+                LOCAL_CMD="cp ${BENCHMARK_DIR}/tmp/system.properties ${JMETER_BIN_DIR}"
+                runNetProtocolCmd
+            fi
+        fi
+    elif [ "${SCENARIO}" = "TradeApp" ]; then
+
+        ###############
+        #REPLACE DEFAULT SERVER.XML AND BOOTSTRAP.PROPERTIES WITH CUSTOM FILES
+        ###############
+
+        # make db2 server xml - overwrite always to ensure correct values
+        export CLIENT_SERVERXML="db2server.xml"
+        if [ -z "${SERVER_XML}" ]; then
+            echo "Using ${CLIENT_SERVERXML} for Server xml"
+        else
+            echo "Server XML defined in job. Using ${SERVER_XML} instead of ${CLIENT_SERVERXML}"
+            export CLIENT_SERVERXML = "${SERVER_XML}"
+        fi
+        
+        
+        echoAndRunCmd "cp ${BENCHMARK_DIR}/resource/${CLIENT_SERVERXML} ${SERVER_DIR}/server.xml"
+        echoAndRunCmd "cp ${BENCHMARK_DIR}/resource/db2bootstrap.properties ${SERVER_DIR}/bootstrap.properties"
+        
+        if [ "$PLATFORM" = "OS/390" ]; then
+            ${BENCHMARK_DIR}/bin/encode.sh ${SERVER_DIR}/server.xml
+        fi
+        
+        ###############
+        #REPLACE DATABASE INFO IN SERVER.XML
+        ###############
+
+        # replace the relevant details
+        echo "Setting the following values in server.xml:"
+        echo "DB_NAME=${DB_NAME}"
+        echo "DB_MACHINE=${DB_MACHINE}"
+        echo "DB_PORT=${DB_PORT}"
+        echo "DB_USR_NAME=${DB_USR_NAME}"
+        echo "DB_PASSWORD"
+        local SERVER_XML_TMP=`sed "s/DB_NAME_HERE/${DB_NAME}/g" ${SERVER_DIR}/server.xml | sed "s/DB_MACHINE_HERE/${DB_MACHINE}/g" | sed "s/DB_PORT_HERE/${DB_PORT}/g" | sed "s/DB_USR_HERE/${DB_USR_NAME}/g" | sed "s/DB_PASSWORD_HERE/${DB_PASSWORD}/g"`
+
+        # if we are running java 80 we want to use the newer DB2 jars as the old ones get sun io errors.
+        if [ `echo "${JDK}" | grep -E "p.{4}80"` ]; then
+            SERVER_XML_TMP=`echo "${SERVER_XML_TMP}" | sed "s%\\\${shared.resource.dir}/db2%\\\${shared.resource.dir}/db2new%"`
+        fi
+
+        ###############
+        #REPLACE LARGE THREAD POOL INFO IN SERVER.XML
+        ###############
+
+        if [ "${LARGE_THREAD_POOL}" = "true" ]; then
+            echo "Running with large thread pool, coreThreads=${CORE_THREADS}, maxThreads=${MAX_THREADS}, stealPolicy=${STEAL_POLICY}"
+            local LARGE_THREAD_POOL_LINE="<executor name=\"LargeThreadPool\" id=\"default\" coreThreads=\"${CORE_THREADS}\" maxThreads=\"${MAX_THREADS}\" keepAlive=\"60s\" stealPolicy=\"${STEAL_POLICY}\" rejectedWorkPolicy=\"CALLER_RUNS\" />"
+            SERVER_XML_TMP=`echo "${SERVER_XML_TMP}" | sed "s%</server>%${LARGE_THREAD_POOL_LINE}\n</server>%"`
+        fi
+
+        ###############
+        #CHECK IF CORRECTLY REPLACED PLACEHOLDERS IN SERVER.XML
+        ###############
+
+        if [ ! -z "${SERVER_XML_TMP}" ]; then
+            echo ${SERVER_XML_TMP} | tee ${SERVER_DIR}/server.xml
+        else
+            echo "Could not match required placeholders in server.xml. File before sed replace:"
+            cat  ${SERVER_DIR}/server.xml
+            exit
+        fi
+        
+        if [ "$PLATFORM" = "OS/390" ]; then
+            ${BENCHMARK_DIR}/bin/encode.sh -toascii ${SERVER_DIR}/server.xml
+        fi
+        
+    elif [ "${SCENARIO}" = "TradeAppDerby" ]; then
+
+        ###############
+        #REPLACE DEFAULT SERVER.XML AND BOOTSTRAP.PROPERTIES WITH CUSTOM FILES
+        ###############
+
+        # nothing to replace in the server.xml template for TradeAppDerby scenario
+        export CLIENT_SERVERXML="derbyServer.xml"
+        if [ -z "${SERVER_XML}" ]; then
+            echo "Using ${CLIENT_SERVERXML} for Server xml"
+        else
+            echo "Server XML defined in job. Using ${SERVER_XML} instead of ${CLIENT_SERVERXML}"
+            export CLIENT_SERVERXML = "${SERVER_XML}"
+        fi
+        
+        
+        echoAndRunCmd "cp ${BENCHMARK_DIR}/resource/${CLIENT_SERVERXML} ${SERVER_DIR}/server.xml"
+        echoAndRunCmd "cp ${BENCHMARK_DIR}/resource/derbyBootstrap.properties ${SERVER_DIR}/bootstrap.properties"
+        
+        
+        if [ "$PLATFORM" = "OS/390" ]; then
+            ${BENCHMARK_DIR}/bin/encode.sh ${SERVER_DIR}/server.xml
+        fi
+
+        ###############
+        #REPLACE LARGE THREAD POOL INFO IN SERVER.XML
+        ###############
+
+        if [ "${LARGE_THREAD_POOL}" = "true" ]; then
+            echo "Running with large thread pool, coreThreads=${CORE_THREADS}, maxThreads=${MAX_THREADS}, stealPolicy=${STEAL_POLICY}"
+            local LARGE_THREAD_POOL_LINE="<executor name=\"LargeThreadPool\" id=\"default\" coreThreads=\"${CORE_THREADS}\" maxThreads=\"${MAX_THREADS}\" keepAlive=\"60s\" stealPolicy=\"${STEAL_POLICY}\" rejectedWorkPolicy=\"CALLER_RUNS\" />"
+            local SERVER_XML_TMP=`sed "s%</server>%${LARGE_THREAD_POOL_LINE}\n</server>%" ${SERVER_DIR}/server.xml`
+        fi
+
+        ###############
+        #CHECK IF CORRECTLY REPLACED PLACEHOLDERS IN SERVER.XML
+        ###############
+
+        if [ ! -z "${SERVER_XML_TMP}" ]; then
+            echo ${SERVER_XML_TMP} | tee ${SERVER_DIR}/server.xml
+        else
+            echo "Could not match required placeholders in server.xml. File before sed replace:"
+            cat  ${SERVER_DIR}/server.xml
+            exit
+        fi
+
+
+        if [ "$PLATFORM" = "OS/390" ]; then
+            ${BENCHMARK_DIR}/bin/encode.sh -toascii ${SERVER_DIR}/server.xml
+        fi
+        
+    elif [ "${SCENARIO}" = "Primitive" ]; then
+
+        ###############
+        #REPLACE DEFAULT SERVER.XML AND BOOTSTRAP.PROPERTIES WITH CUSTOM FILES
+        ###############
+
+        # nothing to replace in the server.xml template for Primitive scenario
+        export CLIENT_SERVERXML="primativeServer.xml"
+        if [ -z "${SERVER_XML}" ]; then
+            echo "Using ${CLIENT_SERVERXML} for Server xml"
+        else
+            echo "Server XML defined in job. Using ${SERVER_XML} instead of ${CLIENT_SERVERXML}"
+            export CLIENT_SERVERXML="${SERVER_XML}"
+        fi
+        
+        
+        echoAndRunCmd "cp ${BENCHMARK_DIR}/resource/${CLIENT_SERVERXML} ${SERVER_DIR}/server.xml"
+        echoAndRunCmd "cp ${BENCHMARK_DIR}/resource/primitiveBootstrap.properties  ${SERVER_DIR}/bootstrap.properties"
+        
+        if [ "$PLATFORM" = "OS/390" ]; then
+            ${BENCHMARK_DIR}/bin/encode.sh ${SERVER_DIR}/server.xml
+        fi
+        
+        ###############
+        #REPLACE LARGE THREAD POOL INFO IN SERVER.XML
+        ###############
+
+        if [ "${LARGE_THREAD_POOL}" = "true" ]; then
+            echo "Running with large thread pool, coreThreads=${CORE_THREADS}, maxThreads=${MAX_THREADS}, stealPolicy=${STEAL_POLICY}"
+            local LARGE_THREAD_POOL_LINE="<executor name=\"LargeThreadPool\" id=\"default\" coreThreads=\"${CORE_THREADS}\" maxThreads=\"${MAX_THREADS}\" keepAlive=\"60s\" stealPolicy=\"${STEAL_POLICY}\" rejectedWorkPolicy=\"CALLER_RUNS\" />"
+            local SERVER_XML_TMP=`sed "s%</server>%${LARGE_THREAD_POOL_LINE}\n</server>%" ${SERVER_DIR}/server.xml`
+        fi
+
+        ###############
+        #CHECK IF CORRECTLY REPLACED PLACEHOLDERS IN SERVER.XML
+        ###############
+
+        if [ ! -z "${SERVER_XML_TMP}" ]; then
+            echo ${SERVER_XML_TMP} | tee ${SERVER_DIR}/server.xml
+        else
+            echo "Could not match required placeholders in server.xml. File before sed replace:"
+            cat  ${SERVER_DIR}/server.xml
+            exit
+        fi
+        if [ "$PLATFORM" = "OS/390" ]; then
+            ${BENCHMARK_DIR}/bin/encode.sh -toascii ${SERVER_DIR}/server.xml
+        fi
+
+    elif [ "${SCENARIO}" = "JMS" ]; then
+
+        ###############
+        #REPLACE DEFAULT SERVER.XML AND BOOTSTRAP.PROPERTIES WITH CUSTOM FILES
+        ###############
+
+        # nothing to replace in the server.xml template for JMS scenario
+        export CLIENT_SERVERXML="jmsServer.xml"
+        if [ -z "${SERVER_XML}" ]; then
+            echo "Using ${CLIENT_SERVERXML} for Server xml"
+        else
+            echo "Server XML defined in job. Using ${SERVER_XML} instead of ${CLIENT_SERVERXML}"
+            export CLIENT_SERVERXML="${SERVER_XML}"
+        fi
+        
+        echoAndRunCmd "cp ${BENCHMARK_DIR}/resource/${CLIENT_SERVERXML} ${SERVER_DIR}/server.xml"
+        # not actually used for anything, for now
+        echoAndRunCmd "cp ${BENCHMARK_DIR}/resource/jmsBootstrap.properties  ${SERVER_DIR}/bootstrap.properties"
+
+        ###############
+        #ADD JMS APP TO SERVER'S DROPINS DIR
+        ###############
+
+        # Copy JMS app into dropins folder
+        echoAndRunCmd "mkdir ${SERVER_DIR}/dropins"
+        echoAndRunCmd "cp ${BENCHMARK_DIR}/resource/JMSApp.war ${SERVER_DIR}/dropins/JMSApp.war"
+
+    elif [ "${SCENARIO}" = "AcmeAir" ]; then
+
+        ###############
+        #REPLACE DEFAULT SERVER.XML AND BOOTSTRAP.PROPERTIES WITH CUSTOM FILES
+        ###############
+
+        export CLIENT_SERVERXML="acmeair_server.xml"
+        if [ -z "${SERVER_XML}" ]; then
+            echo "Using ${CLIENT_SERVERXML} for Server xml"
+        else
+            echo "Server XML defined in job. Using ${SERVER_XML} instead of ${CLIENT_SERVERXML}"
+            export CLIENT_SERVERXML="${SERVER_XML}"
+        fi
+        
+        echoAndRunCmd "cp ${BENCHMARK_DIR}/resource/${CLIENT_SERVERXML} ${SERVER_DIR}/server.xml"
+        
+        echoAndRunCmd "cp ${BENCHMARK_DIR}/resource/acmeairBootstrap.properties  ${SERVER_DIR}/bootstrap.properties"
+        
+        ###############
+        #REPLACE DATABASE INFO IN SERVER.XML
+        ###############
+
+        local SERVER_XML_TMP=`sed "s%MONGO_SERVER_HERE%$DB_MACHINE%" ${SERVER_DIR}/server.xml`
+
+        ###############
+        #CHECK IF CORRECTLY REPLACED PLACEHOLDERS IN SERVER.XML
+        ###############
+
+        if [ ! -z "${SERVER_XML_TMP}" ]; then
+            echo ${SERVER_XML_TMP} | tee ${SERVER_DIR}/server.xml
+        else
+            echo "Could not match required placeholders in server.xml. File before sed replace:"
+            cat  ${SERVER_DIR}/server.xml
+            exit
+        fi
+
+        ###############
+        #START MONGODB
+        ###############
+
+        # TODO: Once verified, use staf instead?
+        ssh $DB_MACHINE ${ACMEAIR_CLIENT_WORK_DIR}/mongodb.sh start ${MONGODB_DIR}
+    fi	
+}
+##
+## Set the variables to be exported for client thorughput script, database restoration script
+## This is required when NET_PROTOCOL is set to LOCAL
+localSpecificEnvSetup() 
+{
+    printf '%s\n' "
+.--------------------------
+| exporting Local Specific Environment variables
+"   
+    export NET_PROTOCOL=${NET_PROTOCOL}; 
+    export PROFILING_TOOL=${PROFILING_TOOL}; 
+    export LIBERTY_SERVERDIR=${SERVER_DIR};
+    export THROUGHPUT_DRIVER=${THROUGHPUT_DRIVER}; 
+    export SERVER_PID=${SERVER_PID};
+    export MEASURES=${MEASURES}; 
+    export WARMUPS=${WARMUPS};
+    export SINGLE_CLIENT_WARMUPS=${SINGLE_CLIENT_WARMUP}; 
+    export MEASURE_TIME=${MEASURE_TIME}; 
+    export WARMUP_TIME=${WARMUP_TIME};
+    export DB_HOST=${DB_MACHINE}; 
+    export DB2_HOME=${DB2_HOME}; 
+    export DB_NAME=${DB_NAME}; 
+    export WAS_HOST=${LIBERTY_HOST}; 
+    export WAS_PORT=${LIBERTY_PORT}; 
+    export CLIENT=${CLIENT}; 
+    export DB_SERVER_WORKDIR=${DB_SERVER_WORKDIR}; 
+    export SERVER_WORKDIR=${BENCHMARK_DIR}/tmp; 
+    export PRIMITIVE=${PRIMITIVE}; 
+    export SCENARIO=${SCENARIO}; 
+    export NUM_CPUS=${NUM_CPUS}; 
+    export JMETER_LOC=${JMETER_LOC}; 
+    export JMETER_INSTANCES=${JMETER_INSTANCES}; 
+    export SR=${SSL_SESSION_REUSE}; 
+    export CLIENT_MACHINE_USER=${CLIENT_MACHINE_USER}; 
+    export HOST_MACHINE_USER=${HOST_MACHINE_USER}; 
+    export DB_MACHINE_USER=${DB_MACHINE_USER}; 
+    export CLIENT_WORK_DIR=${CLIENT_WORK_DIR};
+}
+##
+## Set the options relating to large thread pool based on scenario given
+largeThreadPoolSetup()
+{
+    printf '%s\n' "
+.--------------------------
+| Large Thread Pool Setup
+"
+    case ${SCENARIO} in
+        TradeApp)
+            if [ -z "${CORE_THREADS}" ]; then
+                echo "Optional CORE_THREADS not set. Setting to '40'"
+                CORE_THREADS="40"
+            fi
+            if [ -z "${MAX_THREADS}" ]; then
+                echo "Optional MAX_THREADS not set. Setting to '50'"
+                MAX_THREADS="50"
+            fi
+            if [ -z "${STEAL_POLICY}" ]; then
+                echo "Optional STEAL_POLICY not set. Setting to 'LOCAL'"
+                STEAL_POLICY="LOCAL"
+            fi
+            ;;
+
+        DayTraderSSL|DayTrader7SSL)
+            if [ -z "${CORE_THREADS}" ]; then
+                echo "Optional CORE_THREADS not set. Setting to '40'"
+                CORE_THREADS="40"
+            fi
+            if [ -z "${MAX_THREADS}" ]; then
+                echo "Optional MAX_THREADS not set. Setting to '50'"
+                MAX_THREADS="50"
+            fi
+            if [ -z "${STEAL_POLICY}" ]; then
+                echo "Optional STEAL_POLICY not set. Setting to 'LOCAL'"
+                STEAL_POLICY="LOCAL"
+            fi
+            ;;
+
+        DayTrader|DayTraderJDBC|DayTrader7|DayTrader7JDBC)
+            if [ -z "${CORE_THREADS}" ]; then
+                echo "Optional CORE_THREADS not set. Setting to '40'"
+                CORE_THREADS="40"
+            fi
+            if [ -z "${MAX_THREADS}" ]; then
+                echo "Optional MAX_THREADS not set. Setting to '50'"
+                MAX_THREADS="50"
+            fi
+            if [ -z "${STEAL_POLICY}" ]; then
+                echo "Optional STEAL_POLICY not set. Setting to 'LOCAL'"
+                STEAL_POLICY="LOCAL"
+            fi
+            ;;
+            
+        DayTraderRU)
+            if [ -z "${CORE_THREADS}" ]; then
+                echo "Optional CORE_THREADS not set. Setting to '40'"
+                CORE_THREADS="40"
+            fi
+            if [ -z "${MAX_THREADS}" ]; then
+                echo "Optional MAX_THREADS not set. Setting to '50'"
+                MAX_THREADS="50"
+            fi
+            if [ -z "${STEAL_POLICY}" ]; then
+                echo "Optional STEAL_POLICY not set. Setting to 'LOCAL'"
+                STEAL_POLICY="LOCAL"
+            fi
+            ;;
+
+        DayTraderCrypto)
+            if [ -z "${CORE_THREADS}" ]; then
+                echo "Optional CORE_THREADS not set. Setting to '40'"
+                CORE_THREADS="40"
+            fi
+            if [ -z "${MAX_THREADS}" ]; then
+                echo "Optional MAX_THREADS not set. Setting to '50'"
+                MAX_THREADS="50"
+            fi
+            if [ -z "${STEAL_POLICY}" ]; then
+                echo "Optional STEAL_POLICY not set. Setting to 'LOCAL'"
+                STEAL_POLICY="LOCAL"
+            fi
+            ;;
+
+        TradeAppDerby)
+            if [ -z "${CORE_THREADS}" ]; then
+                echo "Optional CORE_THREADS not set. Setting to '40'"
+                CORE_THREADS="40"
+            fi
+            if [ -z "${MAX_THREADS}" ]; then
+                echo "Optional MAX_THREADS not set. Setting to '50'"
+                MAX_THREADS="50"
+            fi
+            if [ -z "${STEAL_POLICY}" ]; then
+                echo "Optional STEAL_POLICY not set. Setting to 'LOCAL'"
+                STEAL_POLICY="LOCAL"
+            fi
+            ;;
+
+        Primitive)
+            if [ -z "${CORE_THREADS}" ]; then
+                echo "Optional CORE_THREADS not set. Setting to '10'"
+                CORE_THREADS="10"
+            fi
+            if [ -z "${MAX_THREADS}" ]; then
+                echo "Optional MAX_THREADS not set. Setting to '15'"
+                MAX_THREADS="15"
+            fi
+            if [ -z "${STEAL_POLICY}" ]; then
+                echo "Optional STEAL_POLICY not set. Setting to 'LOCAL'"
+                STEAL_POLICY="LOCAL"
+            fi
+            ;;
+
+        JMS)
+            # Nothing specific to do
+            ;;
+
+        *)
+            # ?? Shouldn't get here
+            ;;
+    esac
+    echo "CORE_THREADS=${CORE_THREADS}"
+    echo "MAX_THREADS=${MAX_THREADS}"
+    echo "STEAL_POLICY=${STEAL_POLICY}"
+}
+
+##
+## Start the client script on the client machine. This will initiate client process (ex. start jmeter testing)
+# TODO: Once verified why client needs tprof set
+runClientScript()
+{
+    printf '%s\n' "
+.--------------------------
+| Running Client Throughput Script
+"
+  if [ "$SCENARIO" = "DayTraderSSL" ] || [ "$SCENARIO" = "DayTrader7SSL" ]; then
+    STAF_CMD="STAF ${CLIENT} PROCESS START SHELL COMMAND sh ${CLIENT_WORK_DIR}/client_throughput_start.sh ENV DB_MACHINE_USER=${DB_MACHINE_USER} ENV HOST_MACHINE_USER=${HOST_MACHINE_USER} ENV CLIENT_MACHINE_USER=${CLIENT_MACHINE_USER} ENV NET_PROTOCOL=${NET_PROTOCOL} ENV PROFILING_TOOL=${PROFILING_TOOL} ENV LIBERTY_SERVERDIR=${SERVER_DIR} ENV THROUGHPUT_DRIVER=${THROUGHPUT_DRIVER} ENV SERVER_PID=${SERVER_PID} ENV MEASURES=${MEASURES} ENV WARMUPS=${WARMUPS} ENV SINGLE_CLIENT_WARMUPS=${SINGLE_CLIENT_WARMUP} ENV MEASURE_TIME=${MEASURE_TIME} ENV WARMUP_TIME=${WARMUP_TIME} ENV DB_HOST=${DB_MACHINE} ENV DB2_HOME=${DB2_HOME} ENV DB_NAME=${DB_NAME} ENV WAS_HOST=${LIBERTY_HOST} ENV WAS_PORT=${LIBERTY_PORT} ENV CLIENT=${CLIENT} ENV CLIENT_WORK_DIR=${CLIENT_WORK_DIR} ENV DB_SERVER_WORKDIR=${DB_SERVER_WORKDIR} ENV SERVER_WORKDIR=${BENCHMARK_DIR}/tmp ENV PRIMITIVE=${PRIMITIVE} ENV SCENARIO=${SCENARIO} ENV NUM_CPUS=${NUM_CPUS} ENV JMETER_LOC=${JMETER_LOC} ENV JMETER_INSTANCES=${JMETER_INSTANCES} ENV SR=${SSL_SESSION_REUSE} WORKDIR ${CLIENT_WORK_DIR} STDERRTOSTDOUT RETURNSTDOUT WAIT ${MAX_CLIENT_WAIT}"
+    SSH_CMD="ssh ${CLIENT_MACHINE_USER}@${CLIENT} sh -c \"export DB_MACHINE_USER=${DB_MACHINE_USER}; export HOST_MACHINE_USER=${HOST_MACHINE_USER}; export CLIENT_MACHINE_USER=${CLIENT_MACHINE_USER}; export NET_PROTOCOL=${NET_PROTOCOL}; export PROFILING_TOOL=${PROFILING_TOOL}; export LIBERTY_SERVERDIR=${SERVER_DIR}; export THROUGHPUT_DRIVER=${THROUGHPUT_DRIVER}; export SERVER_PID=${SERVER_PID}; export MEASURES=${MEASURES}; export WARMUPS=${WARMUPS}; export SINGLE_CLIENT_WARMUPS=${SINGLE_CLIENT_WARMUP}; export MEASURE_TIME=${MEASURE_TIME}; export WARMUP_TIME=${WARMUP_TIME}; export DB_HOST=${DB_MACHINE}; export DB2_HOME=${DB2_HOME}; export DB_NAME=${DB_NAME}; export WAS_HOST=${LIBERTY_HOST}; export WAS_PORT=${LIBERTY_PORT}; export CLIENT=${CLIENT}; export CLIENT_WORK_DIR=${CLIENT_WORK_DIR} export DB_SERVER_WORKDIR=${DB_SERVER_WORKDIR}; export SERVER_WORKDIR=${BENCHMARK_DIR}/tmp; export PRIMITIVE=${PRIMITIVE}; export SCENARIO=${SCENARIO}; export NUM_CPUS=${NUM_CPUS}; export JMETER_LOC=${JMETER_LOC}; export JMETER_INSTANCES=${JMETER_INSTANCES}; export SR=${SSL_SESSION_REUSE}; timeout ${MAX_CLIENT_WAIT} ${CLIENT_WORK_DIR}/client_throughput_start.sh \" 2>&1 & wait"
+    LOCAL_CMD="${CLIENT_WORK_DIR}/client_throughput_start.sh 2>&1"
+    runNetProtocolCmd -alwaysEcho    
+  elif [ "$SCENARIO" = "AcmeAir" ]; then
+    
+    # Load the database with customers 
+    STAF_CMD="STAF ${DB_MACHINE} PROCESS START SHELL COMMAND sh ${ACMEAIR_CLIENT_WORK_DIR}/loaddb.sh ${LIBERTY_HOST} ${LIBERTY_PORT} true STDERRTOSTDOUT RETURNSTDOUT WAIT"
+	SSH_CMD="ssh ${DB_MACHINE_USER}@${DB_MACHINE} ${ACMEAIR_CLIENT_WORK_DIR}/loaddb.sh ${LIBERTY_HOST} ${LIBERTY_PORT} true 2>&1 & wait"
+    LOCAL_CMD="${ACMEAIR_CLIENT_WORK_DIR}/loaddb.sh ${LIBERTY_HOST} ${LIBERTY_PORT} true 2>&1"
+    runNetProtocolCmd -alwaysEcho
+
+    STAF_CMD="STAF ${CLIENT} PROCESS START SHELL COMMAND rm ${ACMEAIR_CLIENT_WORK_DIR}/jmeter.log STDERRTOSTDOUT RETURNSTDOUT WAIT" 
+    SSH_CMD="ssh ${CLIENT_MACHINE_USER}@${CLIENT} rm ${ACMEAIR_CLIENT_WORK_DIR}/jmeter.log 2>&1 & wait"
+    LOCAL_CMD="rm ${ACMEAIR_CLIENT_WORK_DIR}/jmeter.log 2>&1"
+    runNetProtocolCmd -alwaysEcho
+
+    STAF_CMD="STAF ${CLIENT} PROCESS START SHELL COMMAND ${JMETER_LOC} -Jdrivers=10 -Jhost=${LIBERTY_HOST} -Jport=${LIBERTY_PORT} -n -t ${ACMEAIR_CLIENT_WORK_DIR}/AcmeAir_java.jmx -p ${ACMEAIR_CLIENT_WORK_DIR}/acmeair.properties -l ${ACMEAIR_CLIENT_WORK_DIR}/jmeter.log > jmeter.out 2>&1 STDERRTOSTDOUT RETURNSTDOUT WAIT"
+    SSH_CMD="ssh ${CLIENT_MACHINE_USER}@${CLIENT} ${JMETER_LOC} -Jdrivers=10 -Jhost=${LIBERTY_HOST} -Jport=${LIBERTY_PORT} -n -t ${ACMEAIR_CLIENT_WORK_DIR}/AcmeAir_java.jmx -p ${ACMEAIR_CLIENT_WORK_DIR}/acmeair.properties -l ${ACMEAIR_CLIENT_WORK_DIR}/jmeter.log > jmeter.out 2>&1 & wait"
+    LOCAL_CMD="/java/perffarm/Jmeter/bin/jmeter -Jdrivers=10 -Jhost=${LIBERTY_HOST} -Jport=${LIBERTY_PORT} -n -t ${ACMEAIR_CLIENT_WORK_DIR}/AcmeAir_java.jmx -p ${ACMEAIR_CLIENT_WORK_DIR}/acmeair.properties -l ${ACMEAIR_CLIENT_WORK_DIR}/jmeter.log > jmeter.out 2>&1"
+	runNetProtocolCmd -alwaysEcho
+    
+    STAF_CMD="STAF ${CLIENT} FS COPY FILE ${ACMEAIR_CLIENT_WORK_DIR}/jmeter.log TOMACHINE ${LIBERTY_HOST} TODIRECTORY ${BENCHMARK_DIR}/tmp"
+    SSH_CMD="scp ${CLIENT_MACHINE_USER}@${CLIENT}:${ACMEAIR_CLIENT_WORK_DIR}/jmeter.log ${HOST_MACHINE_USER}@${LIBERTY_HOST}:${BENCHMARK_DIR}/tmp"
+    LOCAL_CMD="cp ${ACMEAIR_CLIENT_WORK_DIR}/jmeter.log ${BENCHMARK_DIR}/tmp"
+    runNetProtocolCmd -alwaysEcho
+  else
+    STAF_CMD="STAF ${CLIENT} PROCESS START SHELL COMMAND bash ${CLIENT_WORK_DIR}/client_throughput_start.sh ENV DB_MACHINE_USER=${DB_MACHINE_USER} ENV HOST_MACHINE_USER=${HOST_MACHINE_USER} ENV CLIENT_MACHINE_USER=${CLIENT_MACHINE_USER} ENV NET_PROTOCOL=${NET_PROTOCOL} ENV JMETER_LOC=${JMETER_LOC} ENV LIBERTY_SERVERDIR=${SERVER_DIR} ENV PROFILING_TOOL=${PROFILING_TOOL} ENV THROUGHPUT_DRIVER=${THROUGHPUT_DRIVER} ENV SCENARIO=${SCENARIO} ENV SERVER_PID=${SERVER_PID} ENV MEASURES=${MEASURES} ENV WARMUPS=${WARMUPS} ENV SINGLE_CLIENT_WARMUPS=${SINGLE_CLIENT_WARMUP} ENV MEASURE_TIME=${MEASURE_TIME} ENV WARMUP_TIME=${WARMUP_TIME} ENV DB_HOST=${DB_MACHINE} ENV DB2_HOME=${DB2_HOME} ENV DB_NAME=${DB_NAME} ENV WAS_HOST=${LIBERTY_HOST} ENV WAS_PORT=${LIBERTY_PORT} ENV CLIENT=${CLIENT} ENV CLIENT_WORK_DIR=${CLIENT_WORK_DIR} ENV DB_SERVER_WORKDIR=${DB_SERVER_WORKDIR} ENV SERVER_WORKDIR=${BENCHMARK_DIR}/tmp ENV PRIMITIVE=${PRIMITIVE} ENV NUM_CPUS=${NUM_CPUS} WORKDIR ${CLIENT_WORK_DIR} STDERRTOSTDOUT RETURNSTDOUT WAIT ${MAX_CLIENT_WAIT}"
+    SSH_CMD="ssh ${CLIENT_MACHINE_USER}@${CLIENT} bash -c \"export DB_MACHINE_USER=${DB_MACHINE_USER}; export HOST_MACHINE_USER=${HOST_MACHINE_USER}; export CLIENT_MACHINE_USER=${CLIENT_MACHINE_USER}; export NET_PROTOCOL=${NET_PROTOCOL}; export JMETER_LOC=${JMETER_LOC}; export LIBERTY_SERVERDIR=${SERVER_DIR}; export PROFILING_TOOL=${PROFILING_TOOL}; export THROUGHPUT_DRIVER=${THROUGHPUT_DRIVER} ; export SCENARIO=${SCENARIO}; export SERVER_PID=${SERVER_PID}; export MEASURES=${MEASURES}; export WARMUPS=${WARMUPS}; export SINGLE_CLIENT_WARMUPS=${SINGLE_CLIENT_WARMUP}; export MEASURE_TIME=${MEASURE_TIME}; export WARMUP_TIME=${WARMUP_TIME}; export DB_HOST=${DB_MACHINE}; export DB2_HOME=${DB2_HOME}; export DB_NAME=${DB_NAME}; export WAS_HOST=${LIBERTY_HOST}; export WAS_PORT=${LIBERTY_PORT}; export CLIENT=${CLIENT}; export CLIENT_WORK_DIR=${CLIENT_WORK_DIR} export DB_SERVER_WORKDIR=${DB_SERVER_WORKDIR}; export SERVER_WORKDIR=${BENCHMARK_DIR}/tmp; export PRIMITIVE=${PRIMITIVE}; export NUM_CPUS=${NUM_CPUS}; timeout ${MAX_CLIENT_WAIT} ${CLIENT_WORK_DIR}/client_throughput_start.sh \" 2>&1 & wait"
+    LOCAL_CMD="timeout ${MAX_CLIENT_WAIT} ${CLIENT_WORK_DIR}/client_throughput_start.sh 2>&1"
+    runNetProtocolCmd -alwaysEcho
+  fi
+}
+
+## Start the database process on the database machine and restore the original database used for testing
+runDatabaseRestoreScript()
+{
+    printf '%s\n' "
+.--------------------------
+| Restoring Database
+"
+    STAF_CMD="STAF ${CLIENT} PROCESS START SHELL COMMAND sh ${CLIENT_WORK_DIR}/database_start_and_restore.sh ENV NET_PROTOCOL=${NET_PROTOCOL} ENV DB_HOST=${DB_MACHINE} ENV DB2_HOME=${DB2_HOME} ENV DB_NAME=${DB_NAME} ENV DB_SERVER_WORKDIR=${DB_SERVER_WORKDIR} STDERRTOSTDOUT RETURNSTDOUT WAIT ${MAX_CLIENT_WAIT}"
+    SSH_CMD="ssh ${CLIENT_MACHINE_USER}@${CLIENT} sh -c \"export MACHINE_USER=root; export NET_PROTOCOL=${NET_PROTOCOL}; export DB_HOST=${DB_MACHINE}; export DB2_HOME=${DB2_HOME}; export DB_NAME=${DB_NAME}; export DB_SERVER_WORKDIR=${DB_SERVER_WORKDIR}; timeout ${MAX_CLIENT_WAIT} ${CLIENT_WORK_DIR}/database_start_and_restore.sh\" 2>&1 & wait"
+    LOCAL_CMD="timeout ${MAX_CLIENT_WAIT} ${CLIENT_WORK_DIR}/database_start_and_restore.sh 2>&1"
+    runNetProtocolCmd -alwaysEcho
+}
+
+##
+## Use the resulting files from client and database to produce throughput results
+parseResults()
+{
+    printf '%s\n' "
+.--------------------------
+| Parsing Throughput Results from Client and Database
+"
+  # parse the data
+  #	Store the parsed results in a file, which we can then test to see if the throughput parsing worked.
+
+  # Patch code to match previous codework when SSH & LOCAL pathway is used for windows
+  if [ "${NET_PROTOCOL}" != "STAF" ] && [ "${PLATOFRM}" = "CYGWIN" ]; then
+    BENCHMARK_DIR=${BENCHMARK_ORIGINAL_DIR}
+  fi
+
+  # For windows need to convert the Java path to a cygwin path (could do other way around, they just need to match)
+  local UNIX_PATH
+  case ${PLATFORM} in
+    CYGWIN)
+      UNIX_PATH=$(cygpath -m "${BENCHMARK_DIR}")
+      ;;
+    *)
+      UNIX_PATH="${BENCHMARK_DIR}"
+      ;;
+  esac
+  
+  if [ "$PLATFORM" = "OS/390" ]; then
+    ${BENCHMARK_DIR}/bin/encode.sh -toascii ${BENCHMARK_DIR}/tmp/${SERVER_CPU_RESULTS} ${BENCHMARK_DIR}/tmp/${CLIENT_CPU_RESULTS} ${BENCHMARK_DIR}/tmp/${DB_CPU_RESULTS} ${BENCHMARK_DIR}/tmp/${RESULTS}
+  fi
+
+  #TODO: maybe for jenkins this is not needed. What is the raw format?
+  #how jenkins is storing it, maybe write own parser
+  
+  local PARSE_CMD
+  case $SCENARIO in
+    TradeApp)
+      PARSE_CMD="${JAVA_HOME}/bin/java -cp ${UNIX_PATH}/resource/parser/liberty_parser.jar${PATH_SEP}${UNIX_PATH}/resource/parser/combined_parser.jar com.ibm.libertyperf.parsers.TradeLiteParser ${UNIX_PATH}/tmp/${RESULTS} ${UNIX_PATH}/tmp/${CLIENT_CPU_RESULTS} ${UNIX_PATH}/tmp/${SERVER_CPU_RESULTS} ${UNIX_PATH}/tmp/${DB_CPU_RESULTS}"
+      ;;
+    DayTrader|DayTrader7|DayTraderJDBC|DayTrader7JDBC|DayTraderRU)
+      PARSE_CMD="${JAVA_HOME}/bin/java -cp ${UNIX_PATH}/resource/parser/liberty_parser.jar${PATH_SEP}${UNIX_PATH}/resource/parser/combined_parser.jar com.ibm.libertyperf.parsers.TradeLiteParser ${BENCHMARK_DIR}/tmp/${RESULTS} ${BENCHMARK_DIR}/tmp/${CLIENT_CPU_RESULTS} ${BENCHMARK_DIR}/tmp/${SERVER_CPU_RESULTS} ${BENCHMARK_DIR}/tmp/${DB_CPU_RESULTS}"
+      ;;
+    DayTraderSSL|DayTrader7SSL)
+      PARSE_CMD="${JAVA_HOME}/bin/java -cp ${UNIX_PATH}/resource/parser/liberty_parser.jar${PATH_SEP}${UNIX_PATH}/resource/parser/combined_parser.jar com.ibm.libertyperf.parsers.TradeLiteParser ${dt_ssl_result_files} ${UNIX_PATH}/tmp/${CLIENT_CPU_RESULTS} ${UNIX_PATH}/tmp/${SERVER_CPU_RESULTS} ${UNIX_PATH}/tmp/${DB_CPU_RESULTS}"
+      ;;
+    DayTraderCrypto)
+      PARSE_CMD="${JAVA_HOME}/bin/java -cp ${UNIX_PATH}/resource/parser/liberty_parser.jar${PATH_SEP}${UNIX_PATH}/resource/parser/combined_parser.jar com.ibm.libertyperf.parsers.TradeLiteParser ${UNIX_PATH}/tmp/${RESULTS} ${UNIX_PATH}/tmp/${CLIENT_CPU_RESULTS} ${UNIX_PATH}/tmp/${SERVER_CPU_RESULTS} ${UNIX_PATH}/tmp/${DB_CPU_RESULTS}"
+      ;;
+    TradeAppDerby|Primitive|JMS)
+      PARSE_CMD="${JAVA_HOME}/bin/java -cp ${UNIX_PATH}/resource/parser/liberty_parser.jar${PATH_SEP}${UNIX_PATH}/resource/parser/combined_parser.jar com.ibm.libertyperf.parsers.TradeLiteParser ${UNIX_PATH}/tmp/${RESULTS} ${UNIX_PATH}/tmp/${CLIENT_CPU_RESULTS} ${UNIX_PATH}/tmp/${SERVER_CPU_RESULTS}"
+      ;;
+    AcmeAir)
+      local ACMEAIRTP=`cat ${BENCHMARK_DIR}/tmp/jmeter.log|awk -f resource/acmeair_score.awk`
+      if [ "${ACMEAIRTP%.*}" -gt 0 ]; then
+        echo "Run Successful"
+      fi
+      echo "Throughput: ${ACMEAIRTP}"
+      PARSE_CMD="echo 'metric type=\"throughput\" '"
+      ;;
+  esac
+	   
+
+if [ -e "${UNIX_PATH}/resource/parser" ]; then
+	echo "${PARSE_CMD}"
+	# We do it like this, because otherwise the parse program also tries to parse "> parsedResuls.xml"
+	echo "$(${PARSE_CMD})" > ${BENCHMARK_DIR}/tmp/parsedResults.xml
+	if [ "${PLATFORM}" = "OS/390" ]; then
+	  ${BENCHMARK_DIR}/bin/encode.sh ${RESULTS} results_bkup.txt
+	  chmod u+x perSecondResults.sh.ebcdic
+	  #PER_SECOND_CMD="perSecondResults.sh ${RESULTS}"
+	  #echo "$(${PER_SECOND_CMD})"
+	fi
+	
+	###############
+	#CHECK PARSED RESULTS
+	###############
+	
+	# Check that the results contain throughput data
+	local RESULTS_CHECK=`grep -c 'metric type="throughput"' ${BENCHMARK_DIR}/tmp/parsedResults.xml`
+	if [ "${RESULTS_CHECK}" = "0" ]; then
+	  echo "Throughput results missing. Please check server logs for signs of an error."
+	  echo "Storing logs directory"
+	  echoAndRunCmd "cat ${SERVER_DIR}/logs/console.log"
+	  storeFiles -d ${SERVER_DIR}/logs
+	else
+	  cat ${BENCHMARK_DIR}/tmp/parsedResults.xml
+	fi
+ 
+ else
+ 	echo "Printing all results files since there are no parsers binaries."
+	echoAndRunCmd "cat ${BENCHMARK_DIR}/tmp/${RESULTS}"
+	echoAndRunCmd "cat ${BENCHMARK_DIR}/tmp/${CLIENT_CPU_RESULTS}"
+	echoAndRunCmd "cat ${BENCHMARK_DIR}/tmp/${SERVER_CPU_RESULTS}"
+	echoAndRunCmd "cat ${BENCHMARK_DIR}/tmp/${DB_CPU_RESULTS}"
+ fi
+
+}
+
+
+##
+## Print scenario specific stats calculated from RESULTS
+calculateScenarioSpecificStats()
+{
+    printf '%s\n' "
+.--------------------------
+| Calculating Scenario Specific Statistics
+"
+  echo "Scenario is ${SCENARIO}"
+  if [[ "${SCENARIO}" = DayTrader* ]]; then
+    local results
+    echo "WARNING: The times quoted below do NOT include the 60 second 1 client warmup"
+    if [ "$THROUGHPUT_DRIVER" = "iwl" ]; then	
+      results=`cat ${BENCHMARK_DIR}/tmp/${RESULTS} |grep "clients 50/50"|awk {'print $28}'`
+    else
+      results=`cat ${BENCHMARK_DIR}/tmp/results_bkup.txt |grep "summary +"|awk {'print $7'}|sed 's%/s%%g'`
+    fi
+
+    ###############
+    #CALCULATE AND PRINT MAX THROUGHPUT AND TIME TAKEN TO REACH
+    ###############
+
+    local i=0
+    local max=0
+    for result in $results
+    do
+        i=`echo $i+1|bc`
+        if [[ ${result%.*} -ge $max ]]; then
+            max=${result%.*}
+            #TODO: why are we multiplying by 6? The answer will be found when looking at the client run.sh script
+            local maxtime=`echo "$i*6"|bc`
+        fi	
+
+    done
+    local totalrun=`echo "$i*6"|bc`
+    #Percentage=`echo "(${maxtime}/${totalrun})*100"|bc`
+    #TODO: can be made more efficient. If target gets to 0.9 but its on the 0.5 iteration, then will have to happen 4 more times. But we can eliminate these repeat calculations.
+    echo "Max throughput of ${max} reached in ${maxtime} seconds total run=${totalrun}" #${Percentage}%"
+    
+    ###############
+    #CALCULATE AND PRINT THROUGHPUT TARGETS AND TIME TAKEN TO REACH
+    ###############
+    
+    for target in 0.5 0.6 0.7 0.8 0.9 0.95 0.98
+    do
+        local targetnumber=`echo "${target}*${max}"|bc`
+        i=0
+        for result in $results
+        do
+        i=`echo $i+1|bc`
+            if [[ ${result%.*} -ge ${targetnumber%.*} ]]; then
+                local timetarget=`echo "$i*6"|bc`
+                local targetPerc=`echo "$target*100"|bc`
+                echo "Target of ${targetPerc%.*}% - ${targetnumber%.*} - was reached in ${timetarget} seconds"
+                break
+            fi
+
+        done
+    done
+
+    local currentTime
+    if [[ "${SCENARIO}" = "DayTraderRU" ]]; then
+      local pages=$results
+      for limit in 60 120 300 600 1200
+      do
+          i=0
+          for page in $pages
+          do
+          i=`echo $i+1|bc`
+          currentTime=`echo "$i*6"|bc`
+              if [[ ${currentTime%.*} -ge ${limit%.*} ]]; then
+                  echo "Pages transfered at ${limit} seconds was ${page}"
+                  break
+              fi
+    
+          done
+      done
+      for target in 300000 600000 1000000 5000000 10000000
+      do
+          i=0
+          for page in $pages
+          do
+          i=`echo $i+1|bc`
+          currentTime=`echo "$i*6"|bc`
+              if [[ ${page%.*} -ge ${target%.*} ]]; then
+                  echo "Target of ${target} pages reached in ${currentTime}"
+                  break
+              fi
+          done
+      done
+    else
+      echo "This is not a rampup run. Page stats not easily determinable"
+    fi
+    local output=""
+    for result in $results
+        do		
+        if [[ "$output" = "" ]]; then			#check to see if we're on the first iteration - if so, then don't add a comma
+          output=${result%.*}
+        else
+          output="${output},${result%.*}"
+        fi
+        done
+    echo "CSV: ${output}"
+
+  else
+    echo "Nothing to do"
+  fi
+}
+
+##
+## Delete the results generated from this benchmark run on the client machine
+removeResultsFromClient()
+{
+    printf '%s\n' "
+.--------------------------
+| Remove Result Files from Client and Database
+"
+  # Remove these results files from the machines they came from
+  echo "Removing old data"
+  # delete the client results set
+
+  STAF_CMD="STAF ${CLIENT} PROCESS START SHELL COMMAND rm PARMS \"-f ${CLIENT_WORK_DIR}/${RESULTS}\" STDERRTOSTDOUT RETURNSTDOUT WAIT"
+  SSH_CMD="ssh ${CLIENT_MACHINE_USER}@${CLIENT} rm -f ${CLIENT_WORK_DIR}/${RESULTS} 2>&1 & wait"
+  LOCAL_CMD="rm -f ${CLIENT_WORK_DIR}/${RESULTS} 2>&1"
+  runNetProtocolCmd -alwaysEcho
+  # server data moved, was created in this dir so no copy left elsewhere to clean up
+  if [ "$SCENARIO" = "DayTraderSSL" ] || [ "$SCENARIO" = "DayTrader7SSL" ]; then
+        for clientIterator in 1 2 3
+        do
+          STAF_CMD="STAF ${CLIENT} PROCESS START SHELL COMMAND rm PARMS \" -f ${CLIENT_WORK_DIR}/client${clientIterator}.txt\" STDERRTOSTDOUT RETURNSTDOUT WAIT"
+          SSH_CMD="ssh ${CLIENT_MACHINE_USER}@${CLIENT} rm -f ${CLIENT_WORK_DIR}/client${clientIterator}.txt"
+          LOCAL_CMD="rm -f ${CLIENT_WORK_DIR}/client${clientIterator}.txt"
+          runNetProtocolCmd -alwaysEcho
+        done
+  fi
+  # delete the client CPU data
+  STAF_CMD="STAF ${CLIENT} PROCESS START SHELL COMMAND rm PARMS \"-f ${CLIENT_WORK_DIR}/${CLIENT_CPU_RESULTS}\" STDERRTOSTDOUT RETURNSTDOUT WAIT"
+  SSH_CMD="ssh ${CLIENT_MACHINE_USER}@${CLIENT} rm -f ${CLIENT_WORK_DIR}/${CLIENT_CPU_RESULTS} 2>&1 & wait"
+  LOCAL_CMD="rm -f ${CLIENT_WORK_DIR}/${CLIENT_CPU_RESULTS} 2>&1"
+  runNetProtocolCmd -alwaysEcho
+  ###############
+  #REMOVE CPU RESULTS DATA FROM DB MACHINE
+  ###############
+
+  for i in TradeApp  DayTrader DayTrader7 DayTraderJDBC DayTrader7JDBC DayTraderCrypto DayTraderHC DayTraderRU DayTraderSSL DayTrader7SSL
+  do
+    if [ "${SCENARIO}" = "${i}" ]; then
+      # delete the db host CPU data
+      STAF_CMD="STAF ${DB_MACHINE} PROCESS START SHELL COMMAND rm PARMS \"-f ${DB_SERVER_WORKDIR}/${DB_CPU_RESULTS}\" STDERRTOSTDOUT RETURNSTDOUT WAIT"
+      SSH_CMD="ssh ${DB_MACHINE_USER}@${DB_MACHINE} rm -f ${DB_SERVER_WORKDIR}/${DB_CPU_RESULTS} 2>&1 & wait"
+      LOLAL_CMD="rm -f ${DB_SERVER_WORKDIR}/db_CPU_results.xml 2>&1"
+      runNetProtocolCmd -alwaysEcho
+      break
+    fi
+  done
+}
+
+
+##
+## All files that will be stored are added to FILES_TO_STORE
+includeFilesToStore()
+{
+    printf '%s\n' "
+.--------------------------
+| Adding Client and Database Result Files to Store
+"
+  # include raw data
+  FILES_TO_STORE="${FILES_TO_STORE} ${SERVER_DIR}/logs/${LOG_FILE} ${BENCHMARK_DIR}/tmp/${RESULTS} ${BENCHMARK_DIR}/tmp/${CLIENT_CPU_RESULTS} ${BENCHMARK_DIR}/tmp/${SERVER_CPU_RESULTS} ${SERVER_DIR}/logs/messages*.log ${SERVER_DIR}/verbosejit*.txt* ${BENCHMARK_DIR}/tmp/results_bkup.txt ${BENCHMARK_DIR}/tmp/gcmvData.txt parsedResults.xml ${SERVER_DIR}/verbosegc*.xml*"
+  if [ "$SCENARIO" = "DayTraderSSL" ] || [ "$SCENARIO" = "DayTrader7SSL" ]; then
+      FILES_TO_STORE="${FILES_TO_STORE} ${dt_ssl_result_files}"
+  fi
+
+  case ${SCENARIO} in
+        TradeApp|DayTrader|DayTrader7|DayTraderJDBC|DayTrader7JDBC|DayTraderCrypto|DayTraderHC|DayTraderRU|DayTraderSSL|DayTrader7SSL)
+      FILES_TO_STORE="${FILES_TO_STORE} ${BENCHMARK_DIR}/tmp/${DB_CPU_RESULTS}"
+      ;;
+
+    AcmeAir)
+      FILES_TO_STORE="$FILES_TO_STORE ${BENCHMARK_DIR}/tmp/jmeter.log"
+      ;;
+    
+    *)
+      ;;
+  esac
+
+  # include trace files
+  if [[ "${PROFILING_TOOL}" = jprof* ]]; then
+    pushd ${BENCHMARK_DIR}/tmp
+    local TPROF_BACKUP_FILE=jprof_`date +%d%m%y-%H:%M:%S`.zip
+    echo "zip $TPROF_BACKUP_FILE swtrace* *a2n* tprof* a2n.err *${SERVER_PID}* *log-* *post.msg*"
+    zip $TPROF_BACKUP_FILE swtrace* *a2n* tprof* a2n.err *${SERVER_PID}* *log-* *post.msg*
+    echo "Zipped up TPROF files in ${TPROF_BACKUP_FILE}"
+    export FILES_TO_STORE="${FILES_TO_STORE} ${BENCHMARK_DIR}/tmp/${TPROF_BACKUP_FILE}"
+    popd
+  elif [[ "${PROFILING_TOOL}" = perf* ]]; then
+	pushd ${BENCHMARK_DIR}/tmp
+	echo "Adding perf files to the list of files to archive"
+	
+	export FILES_TO_STORE="${FILES_TO_STORE} ${BENCHMARK_DIR}/tmp/perf.data ${BENCHMARK_DIR}/tmp/perf_stat.txt /tmp/perf-${SERVER_PID}.map ${BENCHMARK_DIR}/tmp/perf_debug.tar.gz"
+	popd
+  fi
+  
+}
+
+
+##
+## Transfer all result files from client and database machines to the Liberty host machine
+copyAllResultsToHost()
+{
+    printf '%s\n' "
+.--------------------------
+| Copying Result Files from Client and Database to Host
+"
+  # get the throughput data
+  if [ "$SCENARIO" = "DayTraderSSL" ] || [ "$SCENARIO" = "DayTrader7SSL" ]; then
+    dt_ssl_result_files=""
+    for clientIterator in 1 2 3
+      do
+      STAF_CMD="STAF ${CLIENT} FS COPY FILE ${CLIENT_WORK_DIR}/client${clientIterator}.txt TOMACHINE ${LIBERTY_HOST} TODIRECTORY ${BENCHMARK_DIR}/tmp"
+      SSH_CMD="scp ${CLIENT_MACHINE_USER}@${CLIENT}:${CLIENT_WORK_DIR}/client${clientIterator}.txt ${BENCHMARK_DIR}/tmp"
+      LOCAL_CMD="cp ${CLIENT_WORK_DIR}/client${clientIterator}.txt ${BENCHMARK_DIR}/tmp"
+      runNetProtocolCmd -alwaysEcho
+      dt_ssl_result_files="${dt_ssl_result_files} ${BENCHMARK_DIR}/tmp/client${clientIterator}.txt"
+    done
+  else
+    STAF_CMD="STAF ${CLIENT} FS COPY FILE ${CLIENT_WORK_DIR}/${RESULTS} TOMACHINE ${LIBERTY_HOST} TODIRECTORY ${BENCHMARK_DIR}/tmp"
+    SSH_CMD="scp ${CLIENT_MACHINE_USER}@${CLIENT}:${CLIENT_WORK_DIR}/${RESULTS} ${BENCHMARK_DIR}/tmp"
+    LOCAL_CMD="cp ${CLIENT_WORK_DIR}/${RESULTS} ${BENCHMARK_DIR}/tmp"
+    runNetProtocolCmd -alwaysEcho
+  fi
+
+  # get the client CPU data
+  STAF_CMD="STAF ${CLIENT} FS COPY FILE ${CLIENT_WORK_DIR}/${CLIENT_CPU_RESULTS} TOMACHINE ${LIBERTY_HOST} TODIRECTORY ${BENCHMARK_DIR}/tmp"
+  SSH_CMD="scp ${CLIENT_MACHINE_USER}@${CLIENT}:${CLIENT_WORK_DIR}/${CLIENT_CPU_RESULTS} ${BENCHMARK_DIR}/tmp"
+  LOCAL_CMD="cp ${CLIENT_WORK_DIR}/${CLIENT_CPU_RESULTS} ${BENCHMARK_DIR}/tmp"
+  runNetProtocolCmd -alwaysEcho
+  # server one is created in the working dir
+
+  if [ "${SCENARIO}" = "TradeApp" ]; then
+    # get the db host CPU data
+    STAF_CMD="STAF ${DB_MACHINE} FS COPY FILE ${DB_SERVER_WORKDIR}/${DB_CPU_RESULTS} TOMACHINE ${LIBERTY_HOST} TODIRECTORY ${BENCHMARK_DIR}/tmp"
+    SSH_CMD="scp ${DB_MACHINE_USER}@${DB_MACHINE}:${DB_SERVER_WORKDIR}/${DB_CPU_RESULTS} ${BENCHMARK_DIR}/tmp"
+    LOCAL_CMD="cp ${DB_SERVER_WORKDIR}/${DB_CPU_RESULTS} ${BENCHMARK_DIR}/tmp"
+    runNetProtocolCmd -alwaysEcho
+  fi
+  if [[ "${SCENARIO}" = DayTrader* ]]; then
+    # get the db host CPU data
+    STAF_CMD="STAF ${DB_MACHINE} FS COPY FILE ${DB_SERVER_WORKDIR}/${DB_CPU_RESULTS} TOMACHINE ${LIBERTY_HOST} TODIRECTORY ${BENCHMARK_DIR}/tmp"
+    SSH_CMD="scp ${DB_MACHINE_USER}@${DB_MACHINE}:${DB_SERVER_WORKDIR}/${DB_CPU_RESULTS} ${BENCHMARK_DIR}/tmp"
+    LOCAL_CMD="cp ${DB_SERVER_WORKDIR}/${DB_CPU_RESULTS} ${BENCHMARK_DIR}/tmp"
+    runNetProtocolCmd -alwaysEcho
+  fi
+  local tp_drivertmp=`echo $THROUGHPUT_DRIVER|awk {'print tolower($0)'}`
+  if [[ "${tp_drivertmp}" = "jmeter" ]]; then
+    STAF_CMD="STAF ${CLIENT} FS COPY FILE ${CLIENT_WORK_DIR}/results_bkup.txt TOMACHINE ${LIBERTY_HOST} TODIRECTORY ${BENCHMARK_DIR}/tmp"
+    SSH_CMD="scp ${CLIENT_MACHINE_USER}@${CLIENT}:${CLIENT_WORK_DIR}/results_bkup.txt ${BENCHMARK_DIR}/tmp"
+    LOCAL_CMD="cp ${CLIENT_WORK_DIR}/results_bkup.txt ${BENCHMARK_DIR}/tmp"
+    runNetProtocolCmd -alwaysEcho
+  fi
+}
+
+
+#######################################################################################
+# BEGIN THROUGHPUT BENCHMARK
+#######################################################################################
+
+# Handle any script arguments given when running the benchmark
+while [ ! $1 = "" ]; do
+    case $1 in
+        -help|--help)
+            usage
+            exit
+            ;;
+        *)
+            echo "Invalid benchmark argument: ${1}"
+            usage
+            exit
+            ;;
+    esac
+done
+
+BENCHMARK_TYPE=THROUGHPUT
+
+# Import the common utilities needed to run this benchmark
+. "$(dirname $0)"/database_utils.sh
+
+# Import the common utilities needed to run this benchmark
+. "$(dirname $0)"/common_utils.sh
+
+# Print Liberty header for script identification
+printLibertyHeader
+
+# Print Throughput header with script version
+echo "Throughput Benchmark Launch Script for Liberty
+###########################################################################
+
+"
+
+# echo the local time, helps match logs up if local time not correct
+echo "Local date: `date`"
+echo "Local time: $(perl $(dirname $0)/time.pl)"
+
+setMachinePlatform
+setBenchmarkTopLevelDir
+
+if [ ! -z "$PROFILING_TOOL" ]; then
+	supportedProfilingToolsValidation
+fi
+
+checkAndSetCommonEnvVars
+checkAndSetThroughputEnvVars
+
+###############
+# Liberty Host Environment Setup
+###############
+
+# remove results files from previous runs
+removeResultsFromClient
+removeAllResultFilesOnHost
+
+# Tmp folder stores any files created during the running of the benchmark
+if [ ! -d "${BENCHMARK_DIR}/tmp" ]; then
+  mkdir ${BENCHMARK_DIR}/tmp
+fi
+
+VALID_SCENARIOS=(
+    "AcmeAir"
+    "TradeApp"
+    "TradeAppDerby"
+    "Primitive"
+    "DayTrader"
+    "DayTrader7"
+    "DayTraderJDBC"
+    "DayTrader7JDBC"
+    "DayTraderCrypto"
+    "DayTraderRU"
+    "DayTraderSSL"
+    "DayTrader7SSL"
+    "JMS"
+)
+scenarioValidation
+
+jdkEnvSetup
+
+if [ "${SDK_SUPPORTS_SCC}" = "true" ]; then
+    # set shared class cache (SCC) name from given JVM args
+    getSharedClassCacheName
+    if [ -z "$SCCNAME" ]; then
+        case ${SCENARIO} in
+            AcmeAir)
+                SCCNAME=liberty-acmeair-throughput-${JDK}
+                ;;
+            TradeApp)
+                SCCNAME=liberty-tradeapp-throughput-${JDK}
+                ;;
+            TradeAppDerby)
+                SCCNAME=liberty-tradeappderby-throughput-${JDK}
+                ;;
+            Primitive)
+                SCCNAME=liberty-primitive-throughput-${JDK}
+                ;;
+            DayTrader)
+                SCCNAME=liberty-dt-throughput-${JDK}
+                ;;
+            DayTrader7)
+                SCCNAME=liberty-dt7-throughput-${JDK}
+                ;;
+            DayTraderJDBC)
+                SCCNAME=liberty-dtjdbc-throughput-${JDK}
+                ;;
+            DayTrader7JDBC)
+                SCCNAME=liberty-dt7jdbc-throughput-${JDK}
+                ;;
+            DayTraderCrypto)
+                SCCNAME=liberty-dtcrypto-throughput-${JDK}
+                ;;
+            DayTraderRU)
+                SCCNAME=liberty-dtru-throughput-${JDK}
+                ;;
+            DayTraderSSL)
+                SCCNAME=liberty-dtssl-throughput-${JDK}
+                ;;
+            DayTrader7SSL)
+                SCCNAME=liberty-dt7ssl-throughput-${JDK}
+                ;;
+            JMS)
+                SCCNAME=liberty-jms-throughput-${JDK}
+                ;;
+            *)
+                SCCNAME=liberty-throughput-${JDK}
+                ;;
+        esac
+        echo "Couldn't work out SCCNAME - setting to ${SCCNAME}"
+    else
+        echo "SCCNAME worked out to be ${SCCNAME} from given JVM_ARGS"
+    fi
+    echo "SCCNAME: ${SCCNAME} will be used for destroying and printing the SCC"
+fi
+
+
+
+if [ "${LARGE_THREAD_POOL}" = "true" ] ; then
+    largeThreadPoolSetup
+fi
+
+setLibertyServerDirs
+scenarioSpecificEnvSetup
+platformSpecificSetup
+
+# set environment vars for this shell
+setLocalEnv
+printSensorInfo
+
+###############
+# Liberty Server Setup
+###############
+
+# perform server setup only if user has requested it
+if [ "${NO_SETUP}" != "true" ]; then
+  # Only create if it doesn't exist
+  createLibertyServer
+  scenarioSpecificServerSetup
+  setBootstrapPropsLibertyPort
+else
+    echo "No setup - not changing server"
+fi
+
+# exit if user requested setup only
+if [ "${SETUP_ONLY}" = "true" ]; then
+    echo ""
+    echo "SETUP_ONLY flag set. Setup complete. Exiting."
+    exit
+fi
+
+configureDB
+
+terminateRunningJavaProcs
+
+# tprof will be done for Liberty server java process
+if [ ! -z "$PROFILING_TOOL" ]; then
+  addProfilingOptions
+fi
+
+# print liberty and jdk version
+printAllApplicationVersionInfo
+
+# display jvm.options
+if [ -e ${SERVER_DIR}/jvm.options ]; then
+  echo "jvm.options file exists. Contains:"
+  cat ${SERVER_DIR}/jvm.options
+fi
+
+###############
+# Pre Benchmark Cleanup
+###############
+
+# any server(s) from previous runs should not be running
+terminateRunningLibertyServer
+
+# only destroy SCC for cold (aka clean) runs, otherwise print SCC stats
+if [ "${CLEAN_RUN}" = "true" ]; then
+  setLibertyCleanRunOptions
+  if [ "${SDK_SUPPORTS_SCC}" = "true" ]; then
+    destroySharedClassCache
+  fi
+else
+  echo "CLEAN_RUN=false. Workarea and shared class caches will be warm"
+  CLEAN=""
+  if [ "${SDK_SUPPORTS_SCC}" = "true" ]; then
+    printSharedClassCacheInfo
+  fi
+fi
+###############
+# Env Variable setup for LOCAL run
+# Setup 
+##############
+
+if [ ${NET_PROTOCOL} == "LOCAL" ]; then
+    localSpecificEnvSetup
+fi
+###############
+# Client Script Setup
+###############
+
+# The staf call that runs the client side script will wait for this number of seconds
+let MAX_CLIENT_WAIT=MEASURES*MEASURE_TIME+MEASURES*10+WARMUPS*WARMUP_TIME+WARMUPS*10
+let MAX_CLIENT_WAIT=MAX_CLIENT_WAIT+500
+let MAX_CLIENT_WAIT=MAX_CLIENT_WAIT*1000
+    
+clientScriptSetup
+
+###############
+# Start and Restore Database
+###############
+
+if [ "${DATABASE}" != "derby" ]; then
+	runDatabaseRestoreScript
+fi
+###############
+# Pre Benchmark Measurement
+###############
+
+# get current HP being used for post benchmark analysis. Currenly only done for Linux platforms.
+#TODO: Once verified, zos restartRMF enabled or disabled?
+getPreBenchmarkHugePagesInUse
+
+###############
+# Start Liberty Server
+###############
+
+enableJitThreadUtilizationInfo
+
+# call the startup function, allow 2 attempts
+echoAndRunCmd "cd ${BENCHMARK_DIR}/tmp"
+startLibertyServer 1
+echoAndRunCmd "cd -"
+
+# unset Jit stat variables so that future use of Java, like when using it for GCMV and other tools does not
+# give ThreadUtilization output. (GCMV creates an error file which captures stderr. This ThreadUtilization output
+# gives a false positive that a GCMV error has occurred.)
+disableJitThreadUtilizationInfo
+
+getRunningServerPID
+libertyServerRunningCheck
+printLibertyServerProcessCommand
+
+# Must wait for liberty to finish starting up. 10s should be fine, since target is 5s
+echoAndRunCmd "sleep 10"
+
+###############
+# Run Client Side Script
+###############
+
+if [ "$PLATFORM" = "OS/390" ]; then
+  NUM_CPUS=`oeconsol "d m=cpu" | grep '[0-9][0-9A-F]  +' | tail -n 1 | awk '{print ($1 + 1)}'`
+  echo "AppServer is running with $NUM_CPUS CPUs online"
+  restartRMF ${MAX_CLIENT_WAIT}
+fi
+
+# Add extra time just in case
+
+# By default, STAF uses milliseconds as time input for the wait command. Convert to ms.
+
+#TODO: Once verified, if IWL throughput driver is twas specific remove from the client run.sh script
+runClientScript
+if [ "${SDK_SUPPORTS_SCC}" = "true" ]; then
+    printSharedClassCacheInfo
+fi
+printSensorInfo
+
+###############
+# Parse Result Data
+###############
+
+# copy result data fom client (and db) to Liberty host
+copyAllResultsToHost
+
+parseResults
+calculateScenarioSpecificStats
+
+###############
+# Post Benchmark Measurement
+###############
+
+calculateFootprint
+
+###############
+# Stop Liberty Server
+###############
+
+# Remove jvm args to stop the jit/verbose gc log files being overwritten.
+# Order of precedence (from highest/rightmost to lowest/leftmost) given within Liberty "Launch Script" (Server):
+#       OPENJ9_JAVA_OPTIONS, JVM_ARGS, JVM_OPTIONS_QUOTED (those within the jvm.options file) 
+if [ `echo ${JVM_ARGS}|grep -c "verbosegclog"` -eq 0 ]; then
+  echo "no verbosegc defined. Not changing args"
+else	
+  export JVM_ARGS="-Xverbosegclog:stopSerververbosegc.xml"
+fi
+
+###############
+#REMOVE JVM.OPTIONS (OR RESTORE ORIGINAL IF PRESENT BEFORE)
+###############
+
+if [ "${OPTIONS_EXISTED}" = true ]; then
+    if [ -e "${BENCHMARK_DIR}/tmp/backup_jvmoptions" ]; then
+        mv ${BENCHMARK_DIR}/tmp/backup_jvmoptions ${SERVER_DIR}/jvm.options
+    else
+        echo "*** Error *** File ${BENCHMARK_DIR}/tmp/backup_jvmoptions should exist but it was not found"
+    fi
+else
+    # TODO: Once verified why we delete it
+    if [ -e "${SERVER_DIR}/jvm.options" ]; then
+        rm ${SERVER_DIR}/jvm.options
+    else
+        echo "File ${SERVER_DIR}/jvm.options not found. Nothing to remove"
+    fi
+fi
+
+echoAndRunCmd "cd ${BENCHMARK_DIR}/tmp"
+stopLibertyServer
+echoAndRunCmd "cd -"
+
+
+# Run the Garbage Collection and Memory Visualization (GCMV) tool.
+# should really be run on a seperate machine so perf machine can run other jobs
+if [[ "$GCMV_ENABLED" = "true" ]]; then
+  runGCMVTool
+else
+  echo "Skipping GCMV"
+fi
+
+calculateJitCpuUtilization
+
+echo ""
+echo "Throughput Benchmark has completed successfully"
+
+###############
+# Cleanup
+###############
+zipPerfProfileFiles ${BENCHMARK_DIR}/tmp
+includeFilesToStore
+
+#TODO: Once verified if zOS files on webber are ascii
+# convert backup files to ASCII for os390
+if [[ "$PLATFORM" = "OS/390" ]]; then
+  echo "Making sure all files are in ascii"
+  ${BENCHMARK_DIR}/bin/encode.sh -toascii ${FILES_TO_STORE}
+fi
+
+# store files locally, then clone the whole results dir to a remote results machine
+storeFiles ${FILES_TO_STORE}
+FILES_TO_STORE=""
+moveResultsToRemoteMachine -z
+# TODO: Once verified, check for successful transfer to remote before deleting files on host and client
+removeResultsFromClient
+removeAllResultFilesOnHost

--- a/perf/liberty/scripts/resource/client_scripts/client_throughput_start.sh
+++ b/perf/liberty/scripts/resource/client_scripts/client_throughput_start.sh
@@ -1,0 +1,414 @@
+#!/usr/bin/env bash
+
+################################################################################
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Check environment variables
+if [ -z "${NET_PROTOCOL}" ]; then
+	echo "NET_PROTOCOL not set"
+	#TODO : Fix "echo $USAGE" to properly echo USAGE by exporting function from throughput_bencmhark.sh
+	echo ${USAGE}
+	exit
+fi
+if [ -z "${CLIENT_MACHINE_USER}" ]; then
+	echo "CLIENT_MACHINE_USER not set"
+	echo ${USAGE}
+	exit
+fi
+if [ -z "${HOST_MACHINE_USER}" ]; then
+	echo "HOST_MACHINE_USER not set"
+	echo ${USAGE}
+	exit
+fi
+if [ -z "${DB_MACHINE_USER}" ]; then
+	echo "DB_MACHINE_USER not set"
+	echo ${USAGE}
+	exit
+fi
+if [ -z "${MEASURES}" ]; then
+	echo "MEASURES not set"
+	echo ${USAGE}
+	exit
+fi
+if [ -z "${WARMUPS}" ]; then
+	echo "WARMUPS not set"
+	echo ${USAGE}
+	exit
+fi
+if [ -z "${MEASURE_TIME}" ]; then
+	echo "MEASURE_TIME not set"
+	echo ${USAGE}
+	exit
+fi
+if [ -z "${WARMUP_TIME}" ]; then
+	echo "WARMUP_TIME not set"
+	echo ${USAGE}
+	exit
+fi
+if [ -z "${DB_HOST}" ]; then
+	echo "DB_HOST not set"
+	echo ${USAGE}
+	exit
+fi
+if [ -z "${DB2_HOME}" ]; then
+	echo "DB2_HOME not set"
+	echo ${USAGE}
+	exit
+fi
+if [ -z "${DB_NAME}" ]; then
+	echo "DB_NAME not set"
+	echo ${USAGE}
+	exit
+fi
+if [ -z "${WAS_HOST}" ]; then
+	echo "WAS_HOST not set"
+	echo ${USAGE}
+	exit
+fi
+if [ -z "${WAS_PORT}" ]; then
+	echo "WAS_PORT not set"
+	echo ${USAGE}
+	exit
+fi
+if [ -z "${WAS_PORT_CONFIG}" ]; then
+	echo "WAS_PORT_CONFIG not set. Setting to 9080"
+	export WAS_PORT_CONFIG=9080
+fi
+
+if [ -z "${CLIENT}" ]; then
+	echo "CLIENT not set"
+	echo ${USAGE}
+	exit
+fi
+if [ -z "${SERVER_WORKDIR}" ]; then
+	echo "SERVER_WORKDIR not set"
+	echo ${USAGE}
+	exit
+fi
+
+if [ -z "${SCENARIO}" ]; then
+	echo "SCENARIO not set"
+	echo ${USAGE}
+	exit
+fi
+
+if [ -z "${SSL_CLIENTS}" ]; then
+	echo "SSL_CLIENTS not set"
+	echo "setting to 30"
+	SSL_CLIENTS=30
+fi
+
+if [ -z "${THROUGHPUT_DRIVER}" ]; then
+	echo "THROUGHPUT_DRIVER not set"
+	echo ${USAGE}
+	exit
+else
+	export THROUGHPUT_DRIVER=`echo $THROUGHPUT_DRIVER| awk '{print tolower($0)}'`
+fi
+
+case $THROUGHPUT_DRIVER in
+
+IWL)
+	which iwlengine > /dev/null
+	if [ $? -gt 0 ]; then
+		echo "iwlengine can't be found"
+		exit 5
+	fi
+	;;
+JMeter)
+	ls -l ${JMETER_LOC} > /dev/null
+		if [ $? -gt 0 ]; then
+		echo "JMeter can't be found at ${JMETER_LOC}"
+		exit 5
+	fi
+	;;
+esac	
+
+echo "cleaning up left over files"
+
+datestamp=`date +%Y%m%d-%H:%M:%S`
+
+for file in `ls *tmp resultstmp* jmeter.log results_bkup.txt *xml`
+do
+mkdir -p leftoverResults/${datestamp}
+mv $file leftoverResults/${datestamp}
+done
+
+echo "WAS profile and server names are defined as follows:"
+echo ""
+echo "WAS_HOST=${WAS_HOST}"
+echo "WAS_PORT=${WAS_PORT}"
+echo "DB_HOST=${DB_HOST}"
+echo "DB_NAME=${DB_NAME}"
+echo "DB2_HOME=${DB2_HOME}"
+echo ""
+
+if [ -e results.xml ]; then
+	echo "Removing previous results.xml"
+	rm -f results.xml
+fi
+
+case $SCENARIO in
+
+DayTrader7 | DayTrader7JDBC)
+	SCRIPT_JMeter=daytrader7.jmx
+	SCRIPT_IWL="daytrader7.jxs -f TradeApp.conf"
+	;;
+DayTrader | DayTraderJDBC)
+	SCRIPT_JMeter=daytrader3.jmx
+	SCRIPT_IWL="daytrader3.jxs -f TradeApp.conf"
+	;;
+TradeApp)
+	SCRIPT_IWL="TradeApp.jxs -f TradeApp.conf"
+	;;
+
+TradeAppDerby)
+	SCRIPT_IWL="TradeApp.jxs -f TradeApp.conf"
+	;;
+
+Primitive) 
+	SCRIPT_IWL="Primitive.jxs -f Primitive.conf"
+	EXTRA_IWL="--define url=/tradelite/servlet/${PRIMITIVE}"
+
+	;;
+
+DayTraderCrypto) 
+	SCRIPT_JMeter=daytrader3.jmx
+	SCRIPT_IWL="ssl_daytrader3.jxs -f TradeApp.conf"
+	;;
+
+DayTraderRU) 
+	SCRIPT_JMeter=daytrader3.jmx
+	SCRIPT_IWL="daytrader3.jxs -f TradeApp.conf"
+	;;
+
+DayTraderSSL)
+	SCRIPT_JMeter=daytrader3.jmx
+	SCRIPT_IWL="ssl_daytrader3.jxs -f TradeApp.conf"
+	;;
+
+DayTrader7SSL)
+	SCRIPT_JMeter=daytrader7_ssl.jmx
+	SCRIPT_IWL="ssl_daytrader7.jxs -f TradeApp.conf"
+	;;
+JMS)
+	SCRIPT_JMeter=jms.jmx
+	;;
+
+esac
+
+# Configure the application in either JDBC or EJB mode depending on scenario
+case $SCENARIO in
+DayTraderJDBC | DayTrader7JDBC)
+	DT3_RUNTIME_MODE="JDBC"
+	;;
+*)
+	DT3_RUNTIME_MODE="EJB"
+	;;
+esac
+
+echo "DT3_RUNTIME_MODE=${DT3_RUNTIME_MODE}"
+
+# Some scenarios create new connections on each request - adjust client TCP params to cope with this
+case $SCENARIO in
+DayTraderSSL | DayTrader7SSL | JMS)
+	echo "Setting SSL Specific values:"
+	tcp_tw_reuse=`cat  /proc/sys/net/ipv4/tcp_tw_reuse`
+	echo 'sudo su -c " echo 1 > /proc/sys/net/ipv4/tcp_tw_reuse"'
+	sudo su -c " echo 1 > /proc/sys/net/ipv4/tcp_tw_reuse"
+	tcp_fin_timeout=`cat /proc/sys/net/ipv4/tcp_fin_timeout`
+	echo 'sudo su -c " echo 30 > /proc/sys/net/ipv4/tcp_fin_timeout"'
+	sudo su -c " echo 30 > /proc/sys/net/ipv4/tcp_fin_timeout"	
+	;;
+*)
+	# Use defaults
+	;;
+esac
+
+PERM_CMD="chmod +x *.sh"
+echo ${PERM_CMD}
+${PERM_CMD}
+
+echo ""
+
+# Pre-run configuration
+
+case $SCENARIO in
+    JMS)
+        # Nothing to do
+        ;;
+    *)
+        echo ""
+        echo "Configuring server..."
+        echo ""
+
+        MAX_WAIT=30
+        WAIT_TIME=5
+		
+		#reqired for to run the configure script
+		cd ${CLIENT_WORK_DIR}
+
+        while [[ "`. ./configure.sh ${DT3_RUNTIME_MODE} | grep -c -i \"Configuration Updated\"`" == "0" ]]; do
+            let WAIT_TOTAL=WAIT_TOTAL+WAIT_TIME
+
+            # Have we waited long enough already?
+            if [ ${WAIT_TOTAL} -gt ${MAX_WAIT} ]; then
+                # TODO cleanup
+                echo "!!! ERROR !!! Configuration failed after ${WAIT_TOTAL}s. Exiting"
+                exit
+            fi
+            
+            # Keep waiting
+            echo "Waiting for configuration to succeed... (${WAIT_TOTAL})"
+            sleep ${WAIT_TIME}
+        done
+
+        echo "Configuration successful."
+
+        echo ""
+        ;;
+esac
+
+# Start run
+if [ "$SR" = "false" ]; then
+	sed -i 's/https.use.cached.ssl.context=false/https.use.cached.ssl.context=true/g' jmeter_ssl.properties
+	echo "setting to reuse session for warmups"
+	echo "sed -i 's/https.use.cached.ssl.context=false/https.use.cached.ssl.context=true/g' jmeter_ssl.properties"
+fi
+runNo=0
+results="results.xml"
+case $SCENARIO in
+
+        DayTraderSSL | DayTrader7SSL)
+                for(( clientIterator=1; clientIterator<=${JMETER_INSTANCES}; clientIterator++ ))
+                do
+                        echo "<iteration server=\"${WAS_HOST}\">" >>  client${clientIterator}.txt
+                done
+                ;;
+        *)
+	        echo "<iteration server=\"${WAS_HOST}\">" > ${results}
+		;;
+esac
+
+bash cpu.sh start ${SERVER_WORKDIR} ${WAS_HOST} ${DB_HOST} ${NET_PROTOCOL} ${HOST_MACHINE_USER} ${CLIENT_MACHINE_USER} ${DB_MACHINE_USER} ${DB_SERVER_WORKDIR}
+
+
+for (( i=0; i<${SINGLE_CLIENT_WARMUPS}; i++ ))
+do
+	let runNo=runNo+1
+	echo "Running 1 client warmup"
+	./reset.sh
+	
+	# CPU
+	bash cpu.sh 60 warmup ${runNo} ${CLIENT} ${SERVER_WORKDIR} ${WAS_HOST} ${DB_HOST} ${NET_PROTOCOL} ${HOST_MACHINE_USER} ${CLIENT_MACHINE_USER} ${DB_MACHINE_USER} ${DB_SERVER_WORKDIR} &
+	
+	CPU_PID=$!
+	
+	# trade
+	. ./trade.sh warmup warmup >> ${results}
+
+	
+	wait ${CPU_PID}
+	
+	sleep 1
+done
+
+echo "Running ${WARMUPS} warmups, ${WARMUP_TIME}s each"
+for(( i=0; i<${WARMUPS}; i++ ))
+do
+	let runNo=runNo+1
+	#./reset.sh no reset in 16_01 and later
+	
+	# CPU
+	bash cpu.sh ${WARMUP_TIME} warmup ${runNo} ${CLIENT} ${SERVER_WORKDIR} ${WAS_HOST} ${DB_HOST} ${NET_PROTOCOL} ${HOST_MACHINE_USER} ${CLIENT_MACHINE_USER} ${DB_MACHINE_USER} ${DB_SERVER_WORKDIR} &
+	
+	CPU_PID=$!
+	
+	# trade
+
+	. ./trade.sh  ${WARMUP_TIME} warmup >> ${results}
+	
+	wait ${CPU_PID}
+	
+	sleep 1
+done
+
+if [ "$SR" = "false" ]; then
+	sed -i 's/https.use.cached.ssl.context=true/https.use.cached.ssl.context=false/g' jmeter_ssl.properties
+	echo "Replaced values back to no session reuse"
+	echo "sed -i 's/https.use.cached.ssl.context=true/https.use.cached.ssl.context=false/g' jmeter_ssl.properties"
+fi
+
+echo "Running ${MEASURES} measures, ${MEASURE_TIME}s each"
+for(( i=0; i<${MEASURES}; i++ ))
+do
+	let runNo=runNo+1
+	#./reset.sh no reset in 16_01 and later
+	
+	# CPU
+	bash cpu.sh ${MEASURE_TIME} measure ${runNo} ${CLIENT} ${SERVER_WORKDIR} ${WAS_HOST} ${DB_HOST} ${NET_PROTOCOL} ${HOST_MACHINE_USER} ${CLIENT_MACHINE_USER} ${DB_MACHINE_USER} ${DB_SERVER_WORKDIR} &
+	CPU_PID=$!
+
+	if [ ! -z "$PROFILING_TOOL" ]; then
+		let PROFILING_PROFILE_TIME=MEASURE_TIME*2/3
+
+		echo "Running Profiler for 2/3 of the measure time (${MEASURE_TIME}). PROFILING_PROFILE_TIME=${PROFILING_PROFILE_TIME}"
+		. ./profile.sh
+		runProfile ${WAS_HOST} ${PROFILING_PROFILE_TIME} ${SERVER_WORKDIR} &
+		PROFILING_TOOL_PID=$!
+	fi
+
+	# trade
+	. ./trade.sh  ${MEASURE_TIME} measure >> ${results}
+	if [ ! -z "$PROFILING_TOOL" ]; then
+		wait ${PROFILING_TOOL_PID}
+	fi
+	wait ${CPU_PID}
+	
+	sleep 1
+done
+
+# Restore TCP params back to previous values
+case $SCENARIO in
+DayTraderSSL | DayTrader7SSL | JMS)
+	echo "restoring SSL specific values to default:"
+	echo "sudo su -c  echo $tcp_tw_reuse > /proc/sys/net/ipv4/tcp_tw_reuse"
+	sudo su -c " echo $tcp_tw_reuse > /proc/sys/net/ipv4/tcp_tw_reuse"
+	echo "sudo su -c  echo $tcp_fin_timeout > /proc/sys/net/ipv4/tcp_fin_timeout"
+	sudo su -c " echo $tcp_fin_timeout > /proc/sys/net/ipv4/tcp_fin_timeout"
+	;;
+*)
+	# Nothing to do
+	;;
+esac
+
+case $SCENARIO in
+	DayTraderSSL | DayTrader7SSL)
+		for(( clientIterator=1; clientIterator<=${JMETER_INSTANCES}; clientIterator++ ))
+		do
+			echo "</iteration>" >>  client${clientIterator}.txt 
+		done
+		echo "restoring SSL specific values to default:"
+		echo "sudo su -c  echo $tcp_tw_reuse > /proc/sys/net/ipv4/tcp_tw_reuse"
+		sudo su -c " echo $tcp_tw_reuse > /proc/sys/net/ipv4/tcp_tw_reuse"
+		echo "sudo su -c  echo $tcp_fin_timeout > /proc/sys/net/ipv4/tcp_fin_timeout"
+		sudo su -c " echo $tcp_fin_timeout > /proc/sys/net/ipv4/tcp_fin_timeout"
+		;;
+	*)
+		echo "</iteration>" >> ${results}
+		;;
+esac
+bash cpu.sh end ${SERVER_WORKDIR} ${WAS_HOST} ${DB_HOST} ${NET_PROTOCOL} ${HOST_MACHINE_USER} ${CLIENT_MACHINE_USER} ${DB_MACHINE_USER} ${DB_SERVER_WORKDIR}
+
+echo "Client scripts complete"

--- a/perf/liberty/scripts/resource/client_scripts/configure.sh
+++ b/perf/liberty/scripts/resource/client_scripts/configure.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+################################################################################
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+case $SCENARIO in
+
+DayTrader*)
+        # Allow either EJB or JDBC mode to be specified when configuring DayTrader
+        DT3_RUNTIME_MODE=$1
+        if [ -z "$DT3_RUNTIME_MODE" ]; then
+            echo "Runtime mode (JDBC or EJB) not specified, defaulting to EJB"
+            RUNTIME_VALUE=0
+	else
+            case $DT3_RUNTIME_MODE in
+            EJB|ejb)
+		echo "Configuring DayTrader runtime mode to 'EJB'"
+                RUNTIME_VALUE=0
+                ;;
+            JDBC|jdbc)
+		echo "Configuring DayTrader runtime mode to 'JDBC'"
+                RUNTIME_VALUE=1
+                ;;
+            *)
+                echo "Error - unknown runtime mode '$DT3_RUNTIME_MODE'"
+                ;;
+	    esac
+	fi
+	URL=/daytrader/config
+	LOGDIR=log
+	LOG=${LOGDIR}/config.out
+	RESPONSE_DOC=log/config_response.html
+	#POST_DATA="action=updateConfig&RunTimeMode=1&OrderProcessingMode=0&AcessMode=0&WorkloadMix=0&WebInterface=0&CachingType=2&MaxUsers=500&MaxQuotes=1000&primIterations=1&EnableLongRun=true"
+	POST_DATA="action=updateConfig&RunTimeMode=${RUNTIME_VALUE}&OrderProcessingMode=0&SOAP_URL=http://localhost:${WAS_PORT}/daytrader/services/TradeWSServices&WorkloadMix=0&WebInterface=0&CachingType=0&MaxUsers=15000&MaxQuotes=10000&marketSummaryInterval=20&primIterations=1&EnablePublishQuotePriceChange=on&EnableLongRun=on"
+
+	if [ -z "${WAS_HOST}" ]; then
+	  echo "WAS_HOST is not set - try running setenv"
+	  exit
+	fi
+
+	unset HTTP_PROXY
+	unset HTTPS_PROXY
+	unset FTP_PROXY
+
+	unset http_proxy
+	unset https_proxy
+	unset ftp_proxy
+
+	echo Script to configure WAS daytrader server instance - ${WAS_HOST}:${WAS_PORT}
+	echo Now setting new configuration
+	mkdir -p ${LOGDIR}
+	wget -o ${LOG} -O ${RESPONSE_DOC} --post-data=${POST_DATA} http://${WAS_HOST}:${WAS_PORT_CONFIG}${URL}
+	grep 'Updated' ${RESPONSE_DOC}
+	;;
+
+TradeLite)
+	URL=/tradelite/config
+	LOGDIR=log
+	LOG=${LOGDIR}/config.out
+	RESPONSE_DOC=log/config_response.html
+	POST_DATA="action=updateConfig&RunTimeMode=1&OrderProcessingMode=0&AcessMode=0&SOAP_URL=http://localhost/trade/services/TradeWSServices?wsdl&WorkloadMix=0&WebInterface=0&CachingType=2&MaxUsers=500&MaxQuotes=1000&primIterations=1&EnableLongRun=true"
+
+	if [ -z "${WAS_HOST}" ]; then
+	  echo "WAS_HOST is not set - try running setenv"
+	  exit
+	fi
+
+	unset HTTP_PROXY
+	unset HTTPS_PROXY
+	unset FTP_PROXY
+
+	unset http_proxy
+	unset https_proxy
+	unset ftp_proxy
+
+	echo Script to configure WAS daytrader server instance - ${WAS_HOST}:${WAS_PORT}
+	echo Now setting new configuration
+	mkdir -p ${LOGDIR}
+	wget -o ${LOG} -O ${RESPONSE_DOC} --post-data=${POST_DATA} http://${WAS_HOST}:${WAS_PORT_CONFIG}${URL}
+	grep 'Updated' ${RESPONSE_DOC}
+	;;
+esac

--- a/perf/liberty/scripts/resource/client_scripts/cpu.sh
+++ b/perf/liberty/scripts/resource/client_scripts/cpu.sh
@@ -1,0 +1,509 @@
+#!/usr/bin/env bash
+
+################################################################################
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+CLIENT_CPU_RESULTS="client_CPU_results.xml"
+SERVER_CPU_RESULTS="server_CPU_results.xml"
+DB_CPU_RESULTS="db_CPU_results.xml"
+STAF_CMD=""
+SSH_CMD=""
+LOCAL_CMD=""
+PLATFORM=""
+dirExist=""
+DB_PATCH_STRING=""
+WAS_CUR_STRING=""
+DB_CUR_STRING=""
+WAS_PLATFORM=""
+DB_PLATFORM=""
+CLIENT_PLATFORM=""
+function runNetProtocolCmd()
+{
+    case ${NET_PROTOCOL} in
+        "STAF") 
+        	echo "cpu.sh STAF_CMD=${STAF_CMD}"
+            ${STAF_CMD}
+        	;; 
+        "SSH") 
+        	echo "cpu.sh SSH_CMD=${SSH_CMD}"
+            ${SSH_CMD}
+        	;;
+        "LOCAL") 
+        	echo "cpu.sh LOCAL_CMD=${LOCAL_CMD}"
+            eval ${LOCAL_CMD}
+        	;;
+	esac
+	echo "cpu.sh Done running the command"
+}
+
+# tagGeneration function is for merging STAF command for Windows & Non Windows System it is called once machine_users are set
+# STAF on windows does not run on CYGWIN and requires different parsing system (e.g ^ instead of \ for literal) and different way of parsing \\\ 
+# in attempt to not have extra Windows command for every command we use String tag to minimize the # of commands for simplicity.
+
+function tagGeneration()
+{
+	WAS_PLATFORM=`getPlatform ${WAS_HOST} ${HOST_MACHINE_USER}`
+	DB_PLATFORM=`getPlatform ${DB_HOST} ${DB_MACHINE_USER}`
+	CLIENT_PLATFORM=`getPlatform ${CLIENT} ${CLIENT_MACHINE_USER}`
+	if [ "${WAS_PLATFORM}" = "Windows" ]; then
+		WAS_TAG_STRING="^"
+		WAS_PATCH_STRING="\""
+	else 
+		WAS_TAG_STRING="\\"
+		WAS_PATCH_STRING="\\\""
+	fi
+	if [ "${DB_PLATFORM}" = "Windows" ]; then
+		DB_TAG_STRING="^"
+		DB_PATCH_STRING="\""
+	else 
+		DB_TAG_STRING="\\"
+		DB_PATCH_STRING="\\\""
+	fi		
+}
+function getPlatform()
+{
+	if [ -z $1 ]; then
+		echo "Must provide a machine name to the getPlatform function"
+		return 0
+	fi
+
+	MACHINE_NAME=$1
+	MACHINE_USER=$2
+	STAF_CMD="STAF ${MACHINE_NAME} VAR GET SYSTEM VAR STAF/Config/OS/Name"
+	SSH_CMD="ssh ${MACHINE_USER}@${MACHINE_NAME} uname"
+	LOCAL_CMD="uname"
+	PLATFORM=`runNetProtocolCmd`
+	if [ `echo ${PLATFORM} | grep -c -i Win` != 0 ]; then
+		echo "Windows"
+	fi
+	if [ `echo ${PLATFORM} | grep -c -i Linux` != 0 ]; then
+		echo "Linux"
+	fi
+	if [ `echo ${PLATFORM} | grep -c -i AIX` != 0 ]; then
+		echo "AIX"
+	fi
+	if [ `echo ${PLATFORM} | grep -c -i OS/390` != 0 ]; then
+		echo "ZOS"
+	fi
+	if [ `echo ${PLATFORM} | grep -c -i HP-UX` != 0 ]; then
+		echo "HP-UX"
+	fi
+	if [ `echo ${PLATFORM} | grep -c -i SunOS` != 0 ]; then
+		echo "Solaris"
+	fi
+}
+
+function getCommand()
+{
+	if [ -z $1 ]; then
+		echo "Must provide a machine name to the getCommand function"
+		return 0
+	fi
+	
+	MACHINE_NAME=$1
+	MACHINE_USER=$2
+	PLATFORM=`getPlatform ${MACHINE_NAME} ${MACHINE_USER}`	
+	case ${PLATFORM} in
+		Linux)
+			echo "vmstat -n 5 ${SAMPLES}"
+			;;
+		AIX | HP-UX | Solaris)
+			echo "vmstat 5 ${SAMPLES}"
+			;;
+		Windows)
+			# Write any output from this command to nul, so it doesnt go into the xml
+			#	- logman writes to a file
+			echo "logman start ${LOGMAN_COUNTER_NAME} >nul"
+			;;
+		ZOS)
+			if [ "${ZWAS_USER}" = "" ]; then 
+				if [ "${NET_PROTOCOL}" = "STAF" ]; then
+			    	echo "monitor_cpu_vmstat ${SERVER_PID} 5 ${SAMPLES} ${NUM_CPUS} ${ZWAS_USER}" 
+				else 
+					#TODO: this should be added to path for all users? look into it
+					echo "~/bin/monitor_cpu_vmstat ${SERVER_PID} 5 ${SAMPLES} ${NUM_CPUS} ${ZWAS_USER}" 
+				fi
+			else 
+			    # When running zWAS, use a special CPU monitoring script
+			    # as there are several processes run under different user ids 
+			    echo "monitor_WAS 5 ${SAMPLES} ${NUM_CPUS}" 
+			fi
+			;;
+		*)
+			echo "OS not recognised: ${PLATFORM}" ;;
+	
+	esac
+}
+
+
+
+if [ "${1}" = "start" ]; then
+	SERVER_WORKDIR=${2}
+	WAS_HOST=${3}
+	DB_HOST=${4}
+	NET_PROTOCOL=${5}
+	HOST_MACHINE_USER=${6}
+	CLIENT_MACHINE_USER=${7}
+	DB_MACHINE_USER=${8}
+	if [ -z ${9} ]; then
+		DB_SERVER_WORKDIR=${SERVER_WORKDIR}
+	else
+		DB_SERVER_WORKDIR=${9}
+	fi
+	tagGeneration
+	echo "Creating CPU files"
+	echo "<iteration>" > ${CLIENT_CPU_RESULTS}
+	#Windows command on STAF is parsed 
+	STAF_CMD="STAF ${WAS_HOST} PROCESS START SHELL COMMAND echo PARMS ${WAS_TAG_STRING}<iteration${WAS_TAG_STRING}> WAIT STDERRTOSTDOUT STDOUT ${SERVER_WORKDIR}/${SERVER_CPU_RESULTS} WORKLOAD cpu-measure"	
+	SSH_CMD="ssh ${HOST_MACHINE_USER}@${WAS_HOST} exec -a cpu-measure sh -c \"echo \<iteration\> > ${SERVER_WORKDIR}/${SERVER_CPU_RESULTS} 2>&1\" & wait"
+	LOCAL_CMD="eval \"echo \<iteration\> > ${SERVER_WORKDIR}/${SERVER_CPU_RESULTS} 2>&1\""
+	echo "cpu.sh before runNetProtocolCmd LOCAL_CMD=${LOCAL_CMD}"
+	runNetProtocolCmd
+	if [ -n "${DB_HOST}" ]; then
+		STAF_CMD="STAF ${DB_HOST} LIST DIRECTORY ${DB_SERVER_WORKDIR} RETURNSTDOUT STDERRTOSTDOUT WAIT"
+		SSH_CMD="ssh ${DB_MACHINE_USER}@${DB_HOST} ls ${DB_SERVER_WORKDIR} 2>&1 & wait"
+		LOCAL_CMD="ls ${DB_SERVER_WORKDIR} 2>&1 & wait"
+		echo "LOCAL_CMD=${LOCAL_CMD}"
+		dirExist=`runNetProtocolCmd`
+		#STAF & shell returns different string 
+		if [[ `echo $dirExist|grep -E 'does not exist|No such file'` = $dirExist ]]; then
+			STAF_CMD="STAF ${DB_HOST} FS CREATE DIRECTORY ${DB_SERVER_WORKDIR} FULLPATH"
+			SSH_CMD="ssh ${DB_MACHINE_USER}@${DB_HOST} mkdir -p ${DB_SERVER_WORKDIR}"
+			LOCAL_CMD="mkdir -p ${DB_SERVER_WORKDIR}"
+			runNetProtocolCmd 
+		fi
+		STAF_CMD="STAF ${DB_HOST} PROCESS START SHELL COMMAND echo PARMS ${DB_TAG_STRING}<iteration${DB_TAG_STRING}> WAIT STDERRTOSTDOUT STDOUT ${DB_SERVER_WORKDIR}/${DB_CPU_RESULTS} WORKLOAD cpu-measure"
+		SSH_CMD="ssh ${DB_MACHINE_USER}@${DB_HOST} exec -a cpu-measure sh -c \"echo \<iteration\> > ${DB_SERVER_WORKDIR}/${DB_CPU_RESULTS} 2>&1\" & wait"
+		LOCAL_CMD="eval \"echo \<iteration\> > ${DB_SERVER_WORKDIR}/${DB_CPU_RESULTS} 2>&1\""
+		runNetProtocolCmd 
+	fi
+	
+	exit
+	
+elif [ "${1}" = "end" ]; then
+	SERVER_WORKDIR=${2}
+	WAS_HOST=${3}
+	DB_HOST=${4}
+	NET_PROTOCOL=${5}
+	HOST_MACHINE_USER=${6}
+	CLIENT_MACHINE_USER=${7}
+	DB_MACHINE_USER=${8}
+	if [ -z ${9} ]; then
+		DB_SERVER_WORKDIR=${SERVER_WORKDIR}
+	else
+		DB_SERVER_WORKDIR=${9}
+	fi
+	tagGeneration
+	# Make sure all previous remote workloads have stopped
+	echo "Cleaning up CPU processes on ${WAS_HOST}, ${DB_HOST}"
+	STAF_CMD="STAF ${WAS_HOST} PROCESS STOP WORKLOAD cpu-measure USING SIGKILLALL"
+	#ZOS does not have pkill need to use other way around
+	if [ ${WAS_PLATFORM} = "ZOS" ]; then
+		ZOS_PIDS="ssh ${HOST_MACHINE_USER}@${WAS_HOST} ps -elf | grep -v grep | grep cpu-measure | awk '{ print \$2 }'"
+		SSH_CMD="ssh ${HOST_MACHINE_USER}@${WAS_HOST} kill `${ZOS_PIDS}`"
+		LOCAL_CMD="kill `${ZOS_PIDS}`"
+	else 
+		SSH_CMD="ssh ${HOST_MACHINE_USER}@${WAS_HOST} pkill -f cpu-measure"
+		LOCAL_CMD="pkill -f cpu-measure"
+	fi
+	runNetProtocolCmd 
+	if [ -n "${DB_HOST}" ]; then 
+		STAF_CMD="STAF ${DB_HOST} PROCESS STOP WORKLOAD cpu-measure USING SIGKILLALL"
+		if [ ${DB_PLATFORM} = "ZOS" ]; then
+			ZOS_PIDS="ssh ${DB_MACHINE_USER}@${DB_HOST} ps -elf | grep -v grep | grep cpu-measure | awk '{ print \$2 }'"
+			SSH_CMD="ssh ${DB_MACHINE_USER}@${DB_HOST} kill `${ZOS_PIDS}`"
+			LOCAL_CMD="kill `${ZOS_PIDS}`"
+		else 
+			SSH_CMD="ssh ${DB_MACHINE_USER}@${DB_HOST} pkill -f cpu-measure"
+			LOCAL_CMD="pkill -f cpu-measure"
+		fi
+		runNetProtocolCmd
+	fi
+	
+	# now output the closing tags
+	echo "Finishing CPU files"
+	echo "</iteration>" >> ${CLIENT_CPU_RESULTS}
+	STAF_CMD="STAF ${WAS_HOST} PROCESS START SHELL COMMAND echo PARMS ${WAS_TAG_STRING}</iteration${WAS_TAG_STRING}> WAIT STDERRTOSTDOUT STDOUTAPPEND ${SERVER_WORKDIR}/${SERVER_CPU_RESULTS} WORKLOAD cpu-measure"
+	SSH_CMD="ssh ${HOST_MACHINE_USER}@${WAS_HOST} exec -a cpu-measure sh -c \"echo \</iteration\> >>${SERVER_WORKDIR}/${SERVER_CPU_RESULTS} 2>&1 & wait\" 2>&1 & wait"
+	LOCAL_CMD="eval \"echo \</iteration\> >>${SERVER_WORKDIR}/${SERVER_CPU_RESULTS} 2>&1\""
+	runNetProtocolCmd 
+	if [ -n "${DB_HOST}" ]; then
+		STAF_CMD="STAF ${DB_HOST} PROCESS START SHELL COMMAND echo ${DB_TAG_STRING}</iteration${DB_TAG_STRING}> WAIT STDERRTOSTDOUT STDOUTAPPEND ${DB_SERVER_WORKDIR}/${DB_CPU_RESULTS} WORKLOAD cpu-measure"
+		SSH_CMD="ssh ${DB_MACHINE_USER}@${DB_HOST} exec -a cpu-measure sh -c \"echo \</iteration\> >>${DB_SERVER_WORKDIR}/${DB_CPU_RESULTS} 2>&1 & wait\" 2>&1 & wait"
+		LOCAL_CMD="eval \"echo \</iteration\> >>${DB_SERVER_WORKDIR}/${DB_CPU_RESULTS} 2>&1\""
+		runNetProtocolCmd 
+	fi
+	exit
+else
+	let SAMPLES=$1/6 # setting to 6 seconds to tie in with IWL output
+	TYPE=$2
+	NUM=$3
+	CLIENT=$4
+	SERVER_WORKDIR=$5
+	WAS_HOST=$6
+	DB_HOST=$7
+	NET_PROTOCOL=${8}
+	HOST_MACHINE_USER=${9}
+	CLIENT_MACHINE_USER=${10}
+	DB_MACHINE_USER=${11}
+	if [ -z ${12} ]; then
+		DB_SERVER_WORKDIR=${SERVER_WORKDIR}
+
+	else
+		DB_SERVER_WORKDIR=${12}
+	fi
+	tagGeneration
+fi
+
+echo "SERVER_WORKDIR=${SERVER_WORKDIR}"
+
+LOGMAN_COUNTER_NAME="liberty_tradelite_cpulog"
+LOGMAN_FILE="logman.out"
+
+
+
+
+
+# get the commands
+CLIENT_COMMAND=`getCommand ${CLIENT} ${CLIENT_MACHINE_USER}`
+SERVER_COMMAND=`getCommand ${WAS_HOST} ${HOST_MACHINE_USER}`
+#If its not windows, we need to remove trailing 
+if [ ${NET_PROTOCOL} != "STAF" ] && [ ${WAS_PLATFORM} = "Windows" ]; then
+	SERVER_COMMAND=${SERVER_COMMAND/'>nul'/'1>/dev/null'} 
+fi
+echo "Client CPU command: ${CLIENT_COMMAND}"
+echo "Server CPU command: ${SERVER_COMMAND}"
+
+# runPrimitive does not send a DB_HOST
+if [ -n "${DB_HOST}" ]; then
+	DB_COMMAND=`getCommand ${DB_HOST} ${DB_MACHINE_USER}`
+	if [ ${NET_PROTOCOL} != "STAF" ] && [ ${DB_PLATFORM} = "Windows" ]; then
+		DB_COMMAND=${DB_COMMAND/'>nul'/'1>/dev/null'}
+	fi
+	echo "DB CPU command: ${DB_COMMAND}"
+fi
+
+
+# Make sure all previous remote workloads have stopped
+echo "Cleaning up CPU processes on ${WAS_HOST}, ${DB_HOST}"
+if [ ${WAS_PLATFORM} = "ZOS" ]; then
+	ZOS_PIDS="ssh ${HOST_MACHINE_USER}@${WAS_HOST} ps -elf | grep -v grep | grep cpu-measure | awk '{ print \$2 }'"
+	SSH_CMD="ssh ${HOST_MACHINE_USER}@${WAS_HOST} kill `${ZOS_PIDS}`"
+	LOCAL_CMD="kill `${ZOS_PIDS}`"
+else 
+	SSH_CMD="ssh ${HOST_MACHINE_USER}@${WAS_HOST} pkill -f cpu-measure"
+	LOCAL_CMD="pkill -f cpu-measure"
+fi
+
+runNetProtocolCmd 
+if [ -n "${DB_HOST}" ]; then 
+	STAF_CMD="STAF ${DB_HOST} PROCESS STOP WORKLOAD cpu-measure USING SIGKILLALL"
+	if [ ${DB_PLATFORM} = "ZOS" ]; then
+		ZOS_PIDS="ssh ${DB_MACHINE_USER}@${DB_HOST} ps -elf | grep -v grep | grep cpu-measure | awk '{ print \$2 }'"
+		SSH_CMD="ssh ${DB_MACHINE_USER}@${DB_HOST} kill `${ZOS_PIDS}`"
+		LOCAL_CMD="kill `${ZOS_PIDS}`"
+	else 
+		SSH_CMD="ssh ${DB_MACHINE_USER}@${DB_HOST} pkill -f cpu-measure"
+		LOCAL_CMD="pkill -f cpu-measure"
+	fi
+	runNetProtocolCmd
+fi
+
+
+# open the data tags
+echo "Opening CPU data tags"
+
+# THE FOLLOWING LINES ARE MESSY AND UNREADABLE - FIX IF CAN
+#	This is due to needing to use the cygwin echo on windows
+echo "<data runType=\"${TYPE}\" runNo=\"${NUM}\" machine=\"${CLIENT}\" os=\"${CLIENT_PLATFORM}\">" >> ${CLIENT_CPU_RESULTS}
+# Code below does not use runNetProtocolCmd as echoing double quote ("") within the string that is required for xml tag is impossible
+# Echoing double quote inside 2 double quote requires preservation of multiple back slashes (\) + this causes bash parser error 
+# e.g SSH_CMD="ssh jbench@leonard exec -a cpu-measure \"echo \<data runType=\\\"${TYPE}\\\" runNo=\\\"${NUM}\\\" machine=\\\"${WAS_HOST}\\\" \> >/java/perffarm/liberty-cleaned/testfile_2.txt 2>&1 & wait\""
+# will not be parsed correctly as below command and will give error:
+# bash: /home/jbench/echo \<data runType="" runNo="" machine="" \> >/java/perffarm/liberty-cleaned/testfile_2.txt 2>&1 & wait: No such file or directory
+case $NET_PROTOCOL in
+    "STAF") 
+		STAF ${WAS_HOST} PROCESS START SHELL COMMAND "echo ${WAS_TAG_STRING}<data runType=${WAS_PATCH_STRING}${TYPE}${WAS_PATCH_STRING} runNo=${WAS_PATCH_STRING}${NUM}${WAS_PATCH_STRING} machine=${WAS_PATCH_STRING}${WAS_HOST}${WAS_PATCH_STRING} os=${WAS_PATCH_STRING}`STAF ${WAS_HOST} VAR GET SYSTEM VAR STAF/Config/OS/Name | tail -n 1`${WAS_PATCH_STRING}${WAS_TAG_STRING}>" WAIT STDERRTOSTDOUT STDOUTAPPEND ${SERVER_WORKDIR}/${SERVER_CPU_RESULTS}
+        ;; 
+    "SSH") 
+        ssh ${HOST_MACHINE_USER}@${WAS_HOST} exec -a cpu-measure "echo \<data runType=\\\"${TYPE}\\\" runNo=\\\"${NUM}\\\" machine=\\\"${WAS_HOST}\\\" os=\\\"${WAS_PLATFORM}\\\"\> >>${SERVER_WORKDIR}/${SERVER_CPU_RESULTS} 2>&1" & wait
+    	;;
+    "LOCAL") 
+        echo \<data runType=\"${TYPE}\" runNo=\"${NUM}\" machine=\"${WAS_HOST}\" os=\"${WAS_PLATFORM}\"\> >>${SERVER_WORKDIR}/${SERVER_CPU_RESULTS} 2>&1
+    	;;
+esac
+if [ -n "${DB_HOST}" ]; then
+	case $NET_PROTOCOL in
+        "STAF") 
+			STAF ${DB_HOST} PROCESS START SHELL COMMAND "echo ${DB_TAG_STRING}<data runType=${DB_PATCH_STRING}${TYPE}${DB_PATCH_STRING} runNo=${DB_PATCH_STRING}${NUM}${DB_PATCH_STRING} machine=${DB_PATCH_STRING}${DB_HOST}${DB_PATCH_STRING} os=${DB_PATCH_STRING}`STAF ${DB_HOST} VAR GET SYSTEM VAR STAF/Config/OS/Name | tail -n 1`${DB_PATCH_STRING}${DB_TAG_STRING}>" WAIT STDERRTOSTDOUT STDOUTAPPEND ${DB_SERVER_WORKDIR}/${DB_CPU_RESULTS}
+			;; 
+        "SSH") 
+        	ssh ${DB_MACHINE_USER}@${DB_HOST} exec -a cpu-measure "echo \<data runType=\\\"${TYPE}\\\" runNo=\\\"${NUM}\\\" machine=\\\"${DB_HOST}\\\" os=\\\"${DB_PLATFORM}\\\"\> >>${DB_SERVER_WORKDIR}/${DB_CPU_RESULTS} 2>&1" & wait
+        	;;
+        "LOCAL") 
+        	echo \<data runType=\"${TYPE}\" runNo=\"${NUM}\" machine=\"${DB_HOST}\" os=\"${DB_PLATFORM}\"\> >>${DB_SERVER_WORKDIR}/${DB_CPU_RESULTS} 2>&1
+        	;;
+	esac
+fi
+echo ""
+#loop over the machines to check if any are windows, if so create the logman counter
+# don't include the client - has to be linux due to iwlengine
+# will ignore DB_HOST if not set due to how for works
+
+for i in ${WAS_HOST} ${DB_HOST}
+do
+	case `getPlatform ${i}` in
+		Windows)	
+			case ${NET_PROTOCOL} in
+				"STAF")
+					STAF ${i} PROCESS START SHELL COMMAND "logman create counter ${LOGMAN_COUNTER_NAME} -c \"\Processor(_Total)\% Processor Time\" \"\Memory\Available bytes\" -f csv -si 5 -sc ${SAMPLES} -o ${LOGMAN_FILE} -ow -m start" STDERRTOSTDOUT RETURNSTDOUT WAIT
+					;;
+				"SSH")
+					if [ "${i}" = "${WAS_HOST}" ]; then
+						TEMP_PATH=`ssh ${HOST_MACHINE_USER}@${WAS_HOST} cygpath -m ${SERVER_WORKDIR}`
+						ssh ${HOST_MACHINE_USER}@${WAS_HOST} "logman create counter ${LOGMAN_COUNTER_NAME} -c \"\Processor(_Total)\% Processor Time\" \"\Memory\Available bytes\" -f csv -si 5 -sc ${SAMPLES} -o ${TEMP_PATH}/${LOGMAN_FILE} -ow -m start" 2>&1 & wait
+					else 
+						TEMP_PATH=`ssh ${DB_MACHINE_USER}@${DB_HOST} cygpath -m ${DB_SERVER_WORKDIR}`
+						ssh ${DB_MACHINE_USER}@${DB_HOST} "logman create counter ${LOGMAN_COUNTER_NAME} -c \"\Processor(_Total)\% Processor Time\" \"\Memory\Available bytes\" -f csv -si 5 -sc ${SAMPLES} -o ${TEMP_PATH}/${LOGMAN_FILE} -ow -m start" 2>&1 & wait
+					fi
+					;;
+				"LOCAL")
+					TEMP_PATH=`cygpath -m ${SERVER_WORKDIR}`
+					eval "logman create counter ${LOGMAN_COUNTER_NAME} -c \"\Processor(_Total)\% Processor Time\" \"\Memory\Available bytes\" -f csv -si 5 -sc ${SAMPLES} -o ${TEMP_PATH}/${LOGMAN_FILE} -ow -m start" 2>&1
+					;;
+			esac
+			;;
+	esac	
+done
+
+echo ""
+#output the data
+#Windows Command does not redirect output immediately, uses logman output later SSH.
+echo "Running CPU commands"
+STAF_CMD="STAF ${WAS_HOST} PROCESS START SHELL COMMAND \"${SERVER_COMMAND}\" ASYNC STDOUTAPPEND ${SERVER_WORKDIR}/${SERVER_CPU_RESULTS} WORKLOAD cpu-measure"
+if [ "${WAS_PLATFORM}" != "Windows" ]; then
+	SSH_CMD="ssh ${HOST_MACHINE_USER}@${WAS_HOST} sh -c \"${SERVER_COMMAND} >> ${SERVER_WORKDIR}/${SERVER_CPU_RESULTS}\" &"	
+	LOCAL_CMD="eval ${SERVER_COMMAND} >> ${SERVER_WORKDIR}/${SERVER_CPU_RESULTS} &"
+else 
+	SSH_CMD="ssh ${HOST_MACHINE_USER}@${WAS_HOST} exec -a cpu-measure ${SERVER_COMMAND} &"	
+	LOCAL_CMD="eval ${SERVER_COMMAND} &"
+fi
+runNetProtocolCmd 
+if [ -n "${DB_HOST}" ]; then
+	STAF_CMD="STAF ${DB_HOST} PROCESS START SHELL COMMAND \"${DB_COMMAND}\" ASYNC STDOUTAPPEND ${DB_SERVER_WORKDIR}/${DB_CPU_RESULTS} WORKLOAD cpu-measure"
+	if [ "${DB_PLATFORM}" != "Windows" ]; then
+		SSH_CMD="ssh ${DB_MACHINE_USER}@${DB_HOST} sh -c \"${DB_COMMAND} >> ${DB_SERVER_WORKDIR}/${DB_CPU_RESULTS}\" &"
+		LOCAL_CMD="eval ${DB_COMMAND} >> ${DB_SERVER_WORKDIR}/${DB_CPU_RESULTS} &"
+	else 
+		SSH_CMD="ssh ${DB_MACHINE_USER}@${DB_HOST} exec -a cpu-measure ${DB_COMMAND} &"
+		LOCAL_CMD="eval ${DB_COMMAND} &"
+	fi
+	runNetProtocolCmd
+fi
+${CLIENT_COMMAND} >> ${CLIENT_CPU_RESULTS}
+echo ""
+
+# Make sure all previous remote workloads have stopped
+echo "Cleaning up CPU processes on ${WAS_HOST}, ${DB_HOST}"
+if [ "${WAS_PLATFORM}" = "ZOS" ]; then
+	ZOS_PIDS="ssh ${HOST_MACHINE_USER}@${WAS_HOST} ps -elf | grep -v grep | grep cpu-measure | awk '{ print \$2 }'"
+	SSH_CMD="ssh ${HOST_MACHINE_USER}@${WAS_HOST} kill `${ZOS_PIDS}`"
+else 
+	SSH_CMD="ssh ${HOST_MACHINE_USER}@${WAS_HOST} pkill -f cpu-measure"
+fi
+LOCAL_CMD="pkill -f cpu-measure"
+runNetProtocolCmd 
+if [ -n "${DB_HOST}" ]; then 
+	STAF_CMD="STAF ${DB_HOST} PROCESS STOP WORKLOAD cpu-measure USING SIGKILLALL"
+	if [ "${DB_PLATFORM}" = "ZOS" ]; then
+		ZOS_PIDS="ssh ${DB_MACHINE_USER}@${DB_HOST} ps -elf | grep -v grep | grep cpu-measure | awk '{ print \$2 }'"
+		SSH_CMD="ssh ${DB_MACHINE_USER}@${DB_HOST} kill `${ZOS_PIDS}`"
+	else 
+		SSH_CMD="ssh ${DB_MACHINE_USER}@${DB_HOST} pkill -f cpu-measure"
+	fi
+	LOCAL_CMD="pkill -f cpu-measure"
+	runNetProtocolCmd
+	fi
+echo ""
+
+#loop over the machines to check if any are windows, if so copy the logman output to the datafile
+for i in ${WAS_HOST} ${DB_HOST}
+do
+	case `getPlatform ${i}` in
+		Windows)
+			#If we use SSH & STAF need to set LOGMAN Counters path in order to access the file
+			# Sleeping for 5s is a hacky way to deal with windows sometimes being slow to release the CPU log file.
+			# Idealy we should poll the state of the CPU log/CPU monitor to check it has completed, since 5s is an arbitary number.
+			echo "Sleeping for 5s - Windows can be slow to release CPU log"
+			sleep 5
+			echo "Copying windows logman output to the cpu xml"
+			
+			if [ "${i}" = "${WAS_HOST}" ]; then
+				STAF_CMD="STAF ${WAS_HOST} PROCESS START SHELL COMMAND \"cat ${LOGMAN_FILE}* >> ${SERVER_WORKDIR}/${SERVER_CPU_RESULTS}\" STDERRTOSTDOUT RETURNSTDOUT WAIT"	
+				SSH_CMD="ssh ${HOST_MACHINE_USER}@${WAS_HOST} cat ${SERVER_WORKDIR}/${LOGMAN_FILE}* >> ${SERVER_WORKDIR}/${SERVER_CPU_RESULTS} 2>&1 & wait"
+				LOCAL_CMD="eval cat ${SERVER_WORKDIR}/${LOGMAN_FILE}* >> ${SERVER_WORKDIR}/${SERVER_CPU_RESULTS} 2>&1 & wait"
+			else 
+				STAF_CMD="STAF ${DB_HOST} PROCESS START SHELL COMMAND \"cat ${LOGMAN_FILE}* >> ${DB_SERVER_WORKDIR}/${DB_CPU_RESULTS}\" STDERRTOSTDOUT RETURNSTDOUT WAIT"
+				SSH_CMD="ssh ${DB_MACHINE_USER}@${DB_HOST} cat ${DB_SERVER_WORKDIR}/${LOGMAN_FILE}* >> ${DB_SERVER_WORKDIR}/${DB_CPU_RESULTS} 2>&1 & wait"
+				LOCAL_CMD="eval cat ${DB_SERVER_WORKDIR}/${LOGMAN_FILE}* >> ${DB_SERVER_WORKDIR}/${DB_CPU_RESULTS} 2>&1"
+			fi
+			runNetProtocolCmd 
+
+			if [ "${i}" = "${WAS_HOST}" ]; then
+				STAF_CMD="STAF ${WAS_HOST} PROCESS START SHELL COMMAND \"rm -v ${LOGMAN_FILE}*\" STDERRTOSTDOUT RETURNSTDOUT WAIT"
+				SSH_CMD="ssh ${HOST_MACHINE_USER}@${WAS_HOST} rm -v ${SERVER_WOKRDIR}/${LOGMAN_FILE}* 2>&1 & wait"
+				LOCAL_CMD="eval rm -v ${SERVER_WORKDIR}/${LOGMAN_FILE}* 2>&1"
+			else 
+				STAF_CMD="STAF ${DB_HOST} PROCESS START SHELL COMMAND \"rm -v ${LOGMAN_FILE}*\" STDERRTOSTDOUT RETURNSTDOUT WAIT"
+				SSH_CMD="ssh ${DB_MACHINE_USER}@${DB_HOST} rm -v ${DB_SERVER_WORKDIR}/${LOGMAN_FILE}* 2>&1 & wait"
+				LOCAL_CMD="eval rm -v ${DB_SERVER_WORKDIR}/${LOGMAN_FILE}* 2>&1 & wait"
+			fi
+			runNetProtocolCmd 
+			echo ""
+			;;
+	esac
+done
+
+# close the data tag
+echo "Closing CPU data tags"	
+echo "</data>" >> ${CLIENT_CPU_RESULTS}	
+STAF_CMD="STAF ${WAS_HOST} PROCESS START SHELL COMMAND echo PARMS ${WAS_TAG_STRING}</data${WAS_TAG_STRING}> WAIT STDERRTOSTDOUT STDOUTAPPEND ${SERVER_WORKDIR}/${SERVER_CPU_RESULTS} WORKLOAD cpu-measure"
+SSH_CMD="ssh ${HOST_MACHINE_USER}@${WAS_HOST} exec -a cpu-measure sh -c \"echo \</data\> >>${SERVER_WORKDIR}/${SERVER_CPU_RESULTS} 2>&1\" & wait"
+LOCAL_CMD="eval \"echo \</data\> >>${SERVER_WORKDIR}/${SERVER_CPU_RESULTS} 2>&1\""
+runNetProtocolCmd 
+if [ -n "${DB_HOST}" ]; then
+	STAF_CMD="STAF ${DB_HOST} PROCESS START SHELL COMMAND echo PARMS ${DB_TAG_STRING}</data${DB_TAG_STRING}> WAIT STDERRTOSTDOUT STDOUTAPPEND ${DB_SERVER_WORKDIR}/${DB_CPU_RESULTS}"
+	SSH_CMD="ssh ${DB_MACHINE_USER}@${DB_HOST} exec -a cpu-measure sh -c \"echo \</data\> >>${DB_SERVER_WORKDIR}/${DB_CPU_RESULTS} 2>&1\" & wait"
+	LOCAL_CMD="eval \"echo \</data\> >>${DB_SERVER_WORKDIR}/${DB_CPU_RESULTS} 2>&1\""
+	runNetProtocolCmd 
+fi
+
+#loop over the machines to check if any are windows, if so delete the logman counter
+# don't include the client - has to be linux due to iwlengine
+for i in ${WAS_HOST} ${DB_HOST}
+do
+	case "`getPlatform ${i}`" in
+		Windows)
+			LOGMAN_DELETE="logman delete ${LOGMAN_COUNTER_NAME}"
+			STAF_CMD="STAF ${i} PROCESS START SHELL COMMAND \"${LOGMAN_DELETE}\" STDERRTOSTDOUT RETURNSTDOUT WAIT"
+			if [ "${i}" = "${WAS_HOST}" ]; then
+				SSH_CMD="ssh ${HOST_MACHINE_USER}@${WAS_HOST} ${LOGMAN_DELETE} 2>&1"
+			else 
+				SSH_CMD="ssh ${DB_MACHINE_USER}@${DB_HOST} ${LOGMAN_DELETE} 2>&1"
+			fi
+			LOCAL_CMD="eval ${LOGMAN_DELETE} 2>&1"
+			runNetProtocolCmd 
+			;;
+	esac
+done

--- a/perf/liberty/scripts/resource/client_scripts/database_start_and_restore.sh
+++ b/perf/liberty/scripts/resource/client_scripts/database_start_and_restore.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+
+################################################################################
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Check environment variables
+if [ -z "${DB_HOST}" ]; then
+	echo "DB_HOST not set"
+	echo ${USAGE}
+	exit
+fi
+
+if [ -z "${DB2_HOME}" ]; then
+	echo "DB2_HOME not set"
+	echo ${USAGE}
+	exit
+fi
+
+if [ -z "${DB_NAME}" ]; then
+	echo "DB_NAME not set"
+	echo ${USAGE}
+	exit
+fi
+if [ -z "${NET_PROTOCOL}" ]; then
+    echo "NET_PROTOCOL not set"
+    echo ${USAGE}
+    exit
+fi
+echo "DB_HOST=${DB_HOST}"
+echo "DB_NAME=${DB_NAME}"
+echo "DB2_HOME=${DB2_HOME}"
+
+case $SCENARIO in
+    JMS)
+        # Nothing to do
+        ;;
+    *)
+        DB_HOST=`echo $DB_HOST|sed 's/[hH][sS]$//g'`
+
+        echo "Restoring database ${DB_NAME} on ${DB_HOST}..."
+        case $NET_PROTOCOL in
+        "STAF") 
+            DB_CMD="STAF ${DB_HOST} PROCESS START SHELL COMMAND ${DB2_HOME}/db2reset.sh ${DB_NAME} STDERRTOSTDOUT RETURNSTDOUT WAIT"
+            ;; 
+        "SSH") 
+            DB_CMD="ssh ${MACHINE_USER}@${DB_HOST} ${DB2_HOME}/db2reset.sh ${DB_NAME} 2>&1 & wait"
+            ;;
+        "LOCAL")
+            DB_CMD="${DB2_HOME}/db2reset.sh ${DB_NAME} 2>&1"
+            ;;
+        esac
+        echo "${DB_CMD}"
+        DB_RESPONSE=`${DB_CMD}`
+        echo "${DB_RESPONSE}"
+        RESTORE_COUNT=`echo "${DB_RESPONSE}" | grep -c -i "DB20000I  The RESTORE DATABASE command completed successfully."`
+
+        if [ ${RESTORE_COUNT} -gt 0 ]; then
+            echo "Database restore successful"
+        else
+            echo "!!! WARNING !!! Database restore not successful. Exiting"
+            exit
+        fi
+        ;;
+esac

--- a/perf/liberty/scripts/resource/client_scripts/jmeter_nonssl.properties
+++ b/perf/liberty/scripts/resource/client_scripts/jmeter_nonssl.properties
@@ -1,0 +1,186 @@
+################################################################################
+# Apache JMeter Property file
+################################################################################
+
+##   Licensed to the Apache Software Foundation (ASF) under one or more
+##   contributor license agreements.  See the NOTICE file distributed with
+##   this work for additional information regarding copyright ownership.
+##   The ASF licenses this file to You under the Apache License, Version 2.0
+##   (the "License"); you may not use this file except in compliance with
+##   the License.  You may obtain a copy of the License at
+## 
+##       http://www.apache.org/licenses/LICENSE-2.0
+## 
+##   Unless required by applicable law or agreed to in writing, software
+##   distributed under the License is distributed on an "AS IS" BASIS,
+##   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+##   See the License for the specific language governing permissions and
+##   limitations under the License.
+
+# Netscape HTTP Cookie file
+cookies=cookies
+
+#---------------------------------------------------------------------------
+# XML Parser
+#---------------------------------------------------------------------------
+
+# XML Reader(Parser) - Must implement SAX 2 specs
+xml.parser=org.apache.xerces.parsers.SAXParser
+
+#---------------------------------------------------------------------------
+# SSL configuration
+#---------------------------------------------------------------------------
+
+## SSL System properties are now in system.properties
+
+# JMeter no longer converts javax.xxx property entries in this file into System properties.
+# These must now be defined in the system.properties file or on the command-line.
+# The system.properties file gives more flexibility.
+
+# By default, SSL session contexts are now created per-thread, rather than being shared.
+# The original behaviour can be enabled by setting the JMeter property:
+#https.sessioncontext.shared=true
+
+# Default HTTPS protocol level:
+https.default.protocol=TLSv1.2
+# This may need to be changed here (or in user.properties) to:
+#https.default.protocol=SSLv3
+
+# List of protocols to enable. You may have to select only a subset if you find issues with target server.
+# This is needed when server does not support Socket version negotiation, this can lead to:
+# javax.net.ssl.SSLPeerUnverifiedException: peer not authenticated
+# java.net.SocketException: Connection reset
+# see https://issues.apache.org/bugzilla/show_bug.cgi?id=54759
+#https.socket.protocols=SSLv2Hello SSLv3 TLSv1 TLSv1.1 TLSv1.2
+
+# Control if we allow reuse of cached SSL context between iterations
+# set the value to 'false' to reset the SSL context each iteration
+https.use.cached.ssl.context=false
+
+# Mac apparently looks better with the System LAF
+jmeter.laf.mac=System
+
+#Components to not display in JMeter GUI (GUI class name or static label)
+# These elements are deprecated: HTML Parameter Mask,HTTP User Parameter Modifier, Webservice (SOAP) Request
+not_in_menu=org.apache.jmeter.protocol.http.modifier.gui.ParamModifierGui, HTTP User Parameter Modifier, org.apache.jmeter.protocol.http.control.gui.WebServiceSamplerGui
+
+#---------------------------------------------------------------------------
+# Remote hosts and RMI configuration
+#---------------------------------------------------------------------------
+
+# Remote Hosts - comma delimited
+remote_hosts=127.0.0.1
+
+#Logging levels for the logging categories in JMeter.  Correct values are FATAL_ERROR, ERROR, WARN, INFO, and DEBUG
+# To set the log level for a package or individual class, use:
+# log_level.[package_name].[classname]=[PRIORITY_LEVEL]
+# But omit "org.apache" from the package name.  The classname is optional.  Further examples below.
+
+log_level.jmeter=INFO
+log_level.jmeter.junit=DEBUG
+log_level.jorphan=INFO
+
+#---------------------------------------------------------------------------
+# Results file configuration
+#---------------------------------------------------------------------------
+
+# This section helps determine how result data will be saved.
+# The commented out values are the defaults.
+
+# legitimate values: xml, csv, db.  Only xml and csv are currently supported.
+jmeter.save.saveservice.output_format=xml
+
+#---------------------------------------------------------------------------
+# Settings that affect SampleResults
+#---------------------------------------------------------------------------
+
+# Save the start time stamp instead of the end
+# This also affects the timestamp stored in result files
+sampleresult.timestamp.start=true
+
+#---------------------------------------------------------------------------
+# Upgrade property
+#---------------------------------------------------------------------------
+
+# File that holds a record of name changes for backward compatibility issues
+upgrade_properties=/bin/upgrade.properties
+
+
+#---------------------------------------------------------------------------
+# HTTPSampleResponse Parser configuration
+#---------------------------------------------------------------------------
+
+# Space-separated list of parser groups
+HTTPResponse.parsers=htmlParser wmlParser
+# for each parser, there should be a parser.types and a parser.className property
+
+#---------------------------------------------------------------------------
+# HTML Parser configuration
+#---------------------------------------------------------------------------
+
+htmlParser.types=text/html application/xhtml+xml application/xml text/xml
+
+#---------------------------------------------------------------------------
+# WML Parser configuration
+#---------------------------------------------------------------------------
+
+wmlParser.className=org.apache.jmeter.protocol.http.parser.RegexpHTMLParser
+
+wmlParser.types=text/vnd.wap.wml 
+
+#---------------------------------------------------------------------------
+# Summariser - Generate Summary Results - configuration (mainly applies to non-GUI mode)
+#---------------------------------------------------------------------------
+#
+# Define the following property to automatically start a summariser with that name
+# (applies to non-GUI mode only)
+summariser.name=summary
+#
+# interval between summaries (in seconds) default 30 seconds
+summariser.interval=6
+#
+# Write messages to log file
+summariser.log=true
+#
+# Write messages to System.out
+summariser.out=true
+
+#---------------------------------------------------------------------------
+# BeanShell configuration
+#---------------------------------------------------------------------------
+
+# BeanShell Server properties
+#
+# Define the port number as non-zero to start the http server on that port
+#beanshell.server.port=9000
+# The telnet server will be started on the next port
+
+#
+# Define the server initialisation file
+beanshell.server.file=../extras/startup.bsh
+
+# Classpath finder
+# ================
+# The classpath finder currently needs to load every single JMeter class to find
+# the classes it needs.
+# For non-GUI mode, it's only necessary to scan for Function classes, but all classes
+# are still loaded.
+# All current Function classes include ".function." in their name,
+# and none include ".gui." in the name, so the number of unwanted classes loaded can be
+# reduced by checking for these. However, if a valid function class name does not match
+# these restrictions, it will not be loaded. If problems are encountered, then comment
+# or change the following properties:
+classfinder.functions.contain=.functions.
+classfinder.functions.notContain=.gui.
+
+#---------------------------------------------------------------------------
+# Additional property files to load
+#---------------------------------------------------------------------------
+
+# Should JMeter automatically load additional JMeter properties?
+# File name to look for (comment to disable)
+user.properties=user.properties
+
+# Should JMeter automatically load additional system properties?
+# File name to look for (comment to disable)
+system.properties=system.properties

--- a/perf/liberty/scripts/resource/client_scripts/profile.sh
+++ b/perf/liberty/scripts/resource/client_scripts/profile.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+
+################################################################################
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+#sh profile.sh ${WAS_HOST} ${MEASURE_TIME} ${WORKDIR}
+
+# For profiling, make sure to run STAF or Jenkins Daemon with root permissions
+# For tprof, we expect `setrunenv` file to be sourced somewhere in the bash startup scripts
+# so that we have all the libraries and other things available in the right paths
+# For perf, make sure that it's installed on the machine
+
+# Instructions
+# *** PERF INSTRUCTIONS ***
+# To run the profiling tool: perf you need to install perf, for more information consult https://perf.wiki.kernel.org/index.php/Tutorial
+# Specify perf record or perf stat in PROFILING_TOOL
+# Params for perf: PROFILING_SLEEP_TIME -> Time the perf tool will wait before starting, set this equal to warmup time of benchmark
+# PERF_EVENTS to record. The default is cycles. Please refer to https://perf.wiki.kernel.org/index.php/Tutorial for more events
+# PERF_SAMPLING_PERIOD. Default 1000. Again if you wish to change it please refer to the tutorial or leave as is.
+# PROFILING_PROFILE_TIME how long perf will run. Set to how how you want perf to collect data for.
+# You may notice perf has a function called perf archive, however this has been deprecated in recent versions and thus unreliable
+# This code contains an implementation of it and should archive data files properly allowing it to be read on a separate machine
+# Results: to read the perf.data, unzip the perf_debug.tar.gz file and copy the perf-xxxx.map to /tmp on your machine
+# Copy the .debug folder from within this zip file <UnzippedFileName>/home/<ProfileMachineUserName> and place it in your own ~/.debug
+# Perf report can now be used to view symbols
+# Recommended settings perf report --sort=dso,symbol
+
+# *** JPROF INSTRUCTION ***
+# Ensure jprof is installed on system, https://github.ibm.com/runtimes/performanceinspector/tree/standalone
+# To run a specific profiler in JPROF the following can be set in PROFILING_TOOL: jprof tprof, jprof scs, jprof callflow, jprof rtarcf, jprof calltree
+# All instructions are present in the github link provided
+
+# Further instructions present in https://ibm.ent.box.com/s/qxl8gs3t9apmm797ary1pw7ffqbm6qdp
+
+addJprofToPath () {
+    export JPROF_DIR="/opt/performanceinspector-standalone/Dpiperf"
+    export PATH=$PATH:${JPROF_DIR}/bin
+    export LD_LIBRARY_PATH=${JPROF_DIR}/lib:$LD_LIBRARY_PATH:
+    
+    CURRENT_HOST=`hostname | cut -f1 -d'.'`
+    if [[ $HOST != *$CURRENT_HOST* ]]; then
+        echo "profile.sh is being run from client machine"
+        STAF_START="STAF ${HOST} PROCESS START SHELL COMMAND export PATH=$PATH:${JPROF_DIR}/bin && export LD_LIBRARY_PATH=${JPROF_DIR}/lib:$LD_LIBRARY_PATH: && "
+        STAF_END="WORKDIR ${WORKDIR} STDERRTOSTDOUT RETURNSTDOUT WAIT"
+    fi
+}
+
+#TODO: Add ability to set Perf variables from the launcher such as events and sampling period
+#PERF_EVENTS="cycles,instructions,cache-misses,cache-references,branch-misses,branches,context-switches,page-faults,minor-faults,major-faults,alignment-faults,emulation-faults"
+
+setProfilingOptions () {
+    if [ -z "$1" ]
+    then
+       echo "Please provide a logpath for profiling"
+    else
+        LOG_DIR=$1
+    fi
+    if [ -z "$PROFILING_JAVA_OPTION" ]; then
+	        echo "Optional PROFILING_JAVA_OPTION not set."
+
+	        if [[ "${PROFILING_TOOL}" = jprof* ]]; then			  
+	          export PROFILE_TYPE=$(awk -F " " '{print $2}' <<< ${PROFILING_TOOL})
+	          echo "PROFILE_TYPE:${PROFILE_TYPE}"
+	          PROFILING_JAVA_OPTION="-agentlib:jprof=${PROFILE_TYPE},logpath=${LOG_DIR}"
+	        elif [[ "${PROFILING_TOOL}" = perf* ]]; then
+              if [[ $JDK_OPTIONS == *"Xjit"* ]]; then
+                    # Replace -Xjit:options with -Xjit:options,perfTool
+                    JDK_OPTIONS=`sed "s/-Xjit:\(\S*\)/-Xjit:\1,perfTool/" <<< ${JDK_OPTIONS}`                
+              else
+                    PROFILING_JAVA_OPTION="-Xjit:perfTool"
+              fi
+			fi   	        
+	        echo "PROFILING_JAVA_OPTION=${PROFILING_JAVA_OPTION}"
+	else
+	    	echo "Optional PROFILING_JAVA_OPTION is set to ${PROFILING_JAVA_OPTION}"
+	        
+	        # If there are multiple logpaths, then the last one takes effect. 
+	        # We append this logpath so that we know where to copy the files from 
+	        # and use them for archiving so that they can be viewed later.
+	        if [[ "${PROFILING_TOOL}" = jprof* ]]; then
+		        echo "Appending ',logpath=${LOG_DIR}' to PROFILING_JAVA_OPTION"
+		        PROFILING_JAVA_OPTION=${PROFILING_JAVA_OPTION}+",logpath=${LOG_DIR}"
+		        echo "PROFILING_JAVA_OPTION:${PROFILING_JAVA_OPTION}"
+	        fi
+	    fi
+	addJprofToPath
+}
+
+runJprof() {
+    if [ "$PROFILING_TOOL" = "jprof tprof" ]; then
+        echo "Running jprof tprof in directory"
+        cd ${WORKDIR}
+        echo `pwd`
+        echo "${STAF_START}run.tprof -s ${PROFILING_SLEEP_TIME} -r ${PROFILING_PROFILE_TIME} ${STAF_END}"
+        ${STAF_START}run.tprof -s ${PROFILING_SLEEP_TIME} -r ${PROFILING_PROFILE_TIME} ${STAF_END}   
+    elif [[ "${PROFILING_TOOL}" = "jprof scs" || "${PROFILING_TOOL}" = "jprof callflow" || "${PROFILING_TOOL}" = "jprof calltree" || "${PROFILING_TOOL}" = "jprof rtarcf" ]]; then
+        echo "Running $PROFILING_TOOL"
+        ${STAF_START}"rtdriver -l -c start -c end ${PROFILING_PROFILE_TIME}" ${STAF_END}
+    fi
+}
+
+runPerf() {
+    if [ "$PROFILING_TOOL" = "perf stat" ]; then
+        echo "Running perf stat"
+        sleep ${PROFILING_SLEEP_TIME}
+        ${STAF_START}perf stat -o ${WORKDIR}/perf_stat.txt -e ${PERF_EVENTS} -- sleep ${PROFILING_PROFILE_TIME} ${STAF_END}
+    elif [ "$PROFILING_TOOL" = "perf record" ]; then
+        echo "Running perf record"
+        sleep ${PROFILING_SLEEP_TIME}
+        echo "${STAF_START}perf record -o ${WORKDIR}/perf.data -a -e ${PERF_EVENTS} -c ${PERF_SAMPLING_PERIOD} -- sleep ${PROFILING_PROFILE_TIME} ${STAF_END}"
+        ${STAF_START}perf record -o ${WORKDIR}/perf.data -a -e ${PERF_EVENTS} -c ${PERF_SAMPLING_PERIOD} -- sleep ${PROFILING_PROFILE_TIME} ${STAF_END}
+    fi    
+}
+
+# The benchmark calling the runProfile function must set these 4 parameters in the following order
+# HOST machine the benchmark is running on
+# PROFILING_PROFILE_TIME how long to run profiling
+# WORKDIR working directory of benchmark, required to point logpath to
+# PROFILING_SLEEP_TIME how long to wait before starting profiling
+runProfile () {
+    HOST=$1
+    PROFILING_PROFILE_TIME=$2
+    WORKDIR=$3
+    PROFILING_SLEEP_TIME=$4
+
+    #Setting defaults for PERF_EVENTS, PERF_SAMPLING_PERIOD and PROFILING_SLEEP_TIME
+    if [ -z "$PERF_EVENTS" ]; then
+        PERF_EVENTS="cycles"
+    fi
+    
+    if [ -z "$PERF_SAMPLING_PERIOD" ]; then
+        PERF_SAMPLING_PERIOD="1000"
+    fi
+
+    if [ -z "$PROFILING_SLEEP_TIME" ]; then
+        PROFILING_SLEEP_TIME="0"
+    fi
+
+    echo "HOST:${HOST} PROFILING_PROFILE_TIME:${PROFILING_PROFILE_TIME} WORKDIR:${WORKDIR}"
+    echo "PERF_EVENTS:${PERF_EVENTS} PERF_SAMPLING_PERIOD:${PERF_SAMPLING_PERIOD}"
+
+    addJprofToPath
+    
+    if [[ "${PROFILING_TOOL}" = jprof* ]]; then			  
+        runJprof
+    elif [[ "${PROFILING_TOOL}" = perf* ]]; then
+        runPerf
+    fi   	        
+}
+# First argument is the directory where perf.data is stored, usually the working directory of the running benchmark
+zipPerfProfileFiles () {
+    if [ "$PROFILING_TOOL" = "perf record" ]; then
+        PERFWORKDIR=$1
+        PERF_DATA=${PERFWORKDIR}/perf.data
+
+        if [ -z $PERF_BUILDID_DIR ]; then
+            PERF_BUILDID_DIR=~/.debug/
+        fi  
+        # List all the files required to read perf.data on a separate machine
+        # -i to specify which perf.data file to read
+        # --with-hits returns a list of all the files required to read perf.data
+        debug_filelist=`perf buildid-list -i $PERF_DATA --with-hits`
+        echo "Required files for perf report"
+        echo "$debug_filelist"
+
+        temp_dir="/tmp/perf_debug/"
+        mkdir $temp_dir
+        # Copy each file in the debug_filelist to the temporary directory
+        while read -r line; do
+        # Special case for .map file
+        if [[ $line =~ .*map* ]]
+            then   
+            file=`echo "$line" | awk '{print $2}'`
+            cp $file $temp_dir 
+        else
+            file=`echo "$line" | awk '{print $2}' | sed s:^/::`
+            cp -r --parents $PERF_BUILDID_DIR$file $temp_dir
+        fi
+        done <<< "$debug_filelist"
+
+        echo "Copying .buildids"
+        # --parents creates the directory chain required. We do not want to copy all the files in this directory
+        # example: if we wanted to copy /tmp/data/obj/item.txt, and not copy the entire /tmp/data/obj directory
+        # --parents will create the directory /tmp/data/obj and then copy only the item specified
+        # only the structure and the files present in debug_filelist
+        cp -r --parents $PERF_BUILDID_DIR.build-id $temp_dir
+
+        echo "Zipping up perf_debug"
+        tar -C /tmp -czf ${PERFWORKDIR}/perf_debug.tar.gz perf_debug
+
+        echo "Removing files from local tmp"
+        rm -rf /tmp/perf_debug
+
+        
+
+    fi
+}
+	

--- a/perf/liberty/scripts/resource/client_scripts/reset.sh
+++ b/perf/liberty/scripts/resource/client_scripts/reset.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+################################################################################
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+case $SCENARIO in
+DayTrader*)
+	URL=/daytrader/config?action=resetTrade
+	;;
+
+TradeLite)
+	URL=/tradelite/config?action=resetTrade
+	;;
+JMS)
+	# Do nothing
+	;;
+*)
+	exit 3
+	;;
+esac
+
+LOGDIR=log
+LOG=${LOGDIR}/reset.out
+RESPONSE_DOC=log/reset_response.html
+
+if [ -z "${WAS_HOST}" ]; then
+  echo "WAS_HOST is not set - try running setenv"
+  exit
+fi
+
+unset HTTP_PROXY
+unset HTTPS_PROXY
+unset FTP_PROXY
+
+unset http_proxy
+unset https_proxy
+unset ftp_proxy
+
+echo Script to reset DayTrader on WAS daytrader server instance - ${WAS_HOST}:${WAS_PORT}
+mkdir -p ${LOGDIR}
+wget -o ${LOG} -O ${RESPONSE_DOC} http://${WAS_HOST}:${WAS_PORT}${URL}
+grep 'successfully' ${RESPONSE_DOC}

--- a/perf/liberty/scripts/resource/client_scripts/trade.sh
+++ b/perf/liberty/scripts/resource/client_scripts/trade.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+
+################################################################################
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+CLIENTS=50
+TIMELIMIT=$1
+runType=$2
+
+echo "${SCENARIO} Run against ${WAS_HOST}:${WAS_PORT}"
+
+if [ -z "$1" ]; then
+  echo "Usage: trade.sh <warmup | n> run_type"
+  echo "  - warmup runs a warmup with 1 client to allow the database to warm up gently."
+  echo "  - n (a number in seconds) runs with $CLIENTS clients for that number of seconds."
+  echo "  - run_type - text for the type fof run - warmup or measure."
+  exit
+fi
+
+
+rm resultstmp.txt > /dev/null 2>&1
+case $SCENARIO in
+
+JMS)
+	# JMS scenario starts with 1 client, then 5, then 20 
+	CLIENTS=20
+	if [ "${runNo}" = "2" ]; then
+	    CLIENTS=5
+	fi
+	echo "<data machine=\"${CLIENT}\" runType=\"${runType}\" runNo=\"${runNo}\">" 
+	if [ "$TIMELIMIT" == "warmup" ]; then
+	  echo "Warming up with 1 client for 60 seconds..."
+	  TIMELIMIT=60
+	  ${JMETER_LOC} -n -t ${SCRIPT_JMeter} -p jmeter_nonssl.properties -JTHREADS=1 -JDURATION=60 -JHOST=${WAS_HOST} -JPORT=9128 -JURL=JMSApp/2.0/P2P?ACTION=NonPersistent -JPAYLOAD=${PWD}/jms1KB >>resultstmp.txt  
+	else
+	  echo "Running $CLIENTS clients for $TIMELIMIT seconds..."
+	  ${JMETER_LOC} -n -t ${SCRIPT_JMeter} -p jmeter_nonssl.properties -JTHREADS=${CLIENTS} -JDURATION=$TIMELIMIT -JHOST=${WAS_HOST} -JPORT=9128 -JURL=JMSApp/2.0/P2P?ACTION=NonPersistent -JPAYLOAD=${PWD}/jms1KB >>resultstmp.txt
+	fi
+	summary=`cat resultstmp.txt|sed 's%<summary>%%g'|grep "summary = "|tail -n 1`
+	throughput=`echo $summary|awk '{print $7}' | sed 's%/s%%g'`
+	responsetime=`echo $summary|awk '{print $9}' | sed 's%/s%%g'`
+	weberrors=`echo $summary|awk '{print $15}' | sed 's%/s%%g'`
+	pages=`echo $summary|awk '{print $3}' | sed 's%/s%%g'`
+	echo "Page throughput = ${throughput} /s" 
+	echo "HTTP avg. page element response time = ${responsetime}" 
+	echo "Web server errors = ${weberrors}" 
+	echo "Network I/O errors = ${weberrors}" 
+	echo "Num of pages retrieved = ${pages}"  
+	echo "Initial number of clients = $CLIENTS"
+	echo "</data>" 
+	# Sleep, to try to reduce socket exhaustion errors
+	sleep 30
+	cat resultstmp.txt >> results_bkup.txt 2>&1
+	;;
+
+DayTraderSSL | DayTrader7SSL)
+	if [ "$TIMELIMIT" == "warmup" ]; then
+		echo "Warming up with 1 client for 60 seconds..."
+		TIMELIMIT=60
+		CLIENTS=1
+	else
+		CLIENTS=$SSL_CLIENTS
+	fi
+	for(( clientIterator=0; clientIterator<${JMETER_INSTANCES}; clientIterator++ ))
+	do
+		SPLIT_UID=`echo "9000/${JMETER_INSTANCES}"|bc`
+		BOTUID=`echo "${clientIterator}*${SPLIT_UID}"|bc`
+		TOPUID=`echo "$BOTUID+${SPLIT_UID}-1"|bc`
+		realClientIterator=`echo "${clientIterator} + 1"|bc`
+		echo "<data machine=\"${CLIENT}.${realClientIterator}\" runType=\"$runType\" runNo=\"${runNo}\">" >> client${realClientIterator}.txt 
+
+		${JMETER_LOC} -n -t ${SCRIPT_JMeter} -JTHREADS=$CLIENTS -p jmeter_ssl.properties -JDURATION=$TIMELIMIT -JHOST=${WAS_HOST} -JPROTO=https -JPORT=9443 -JBOTUID=${BOTUID} -JTOPUID=${TOPUID} |tee -a client${realClientIterator}.txt.tmp &
+		PIDS="${PIDS} $!"
+	done
+	for PID in `ps -ef|grep jmeter|grep -v grep|grep -v jar|awk {'print $2'}`
+        do
+       		wait $PID
+	done
+
+	for(( clientIterator=1; clientIterator<=${JMETER_INSTANCES}; clientIterator++ ))
+	do
+		summary=`cat client${clientIterator}.txt.tmp|sed 's%<summary>%%g'|grep "summary = "|tail -n 1`
+		throughput=`echo $summary|awk '{print $7}' | sed 's%/s%%g'`
+		responsetime=`echo $summary|awk '{print $9}' | sed 's%/s%%g'`
+		weberrors=`echo $summary|awk '{print $15}' | sed 's%/s%%g'`
+		pages=`echo $summary|awk '{print $3}' | sed 's%/s%%g'`
+		echo "Page throughput = ${throughput} /s" >> client${clientIterator}.txt
+		echo "HTTP avg. page element response time = ${responsetime}" >> client${clientIterator}.txt 
+		echo "Web server errors = ${weberrors}" >> client${clientIterator}.txt
+		echo "Network I/O errors = ${weberrors}" >> client${clientIterator}.txt
+		echo "Num of pages retrieved = ${pages}"  >> client${clientIterator}.txt
+		echo "Initial number of clients = 1" >> client${clientIterator}.txt	
+		echo "</data>" >>  client${clientIterator}.txt
+		echo $clientIterator >> results_bkup.txt
+		cat client${clientIterator}.txt >> results_bkup.txt 2>&1
+	done
+	;;
+*)
+	echo "<data machine=\"${CLIENT}\" runType=\"${runType}\" runNo=\"${runNo}\">" 
+	case $THROUGHPUT_DRIVER in
+		iwl)
+			if [ "$TIMELIMIT" == "warmup" ]; then
+			  echo "Warming up with 1 client for 60 seconds..."
+			  iwlengine -s ${SCRIPT_IWL} --define hostname=${WAS_HOST}:${WAS_PORT} --define botClient=0 --define topClient=14999 ${EXTRA_IWL} -c 1 --timelimit 60
+			else
+			  echo "Running $CLIENTS clients for $TIMELIMIT seconds..."
+			  iwlengine -s ${SCRIPT_IWL} --define hostname=${WAS_HOST}:${WAS_PORT} --define botClient=0 --define topClient=14999 ${EXTRA_IWL} -c $CLIENTS --timelimit $TIMELIMIT
+			fi
+		;;
+		jmeter)
+			if [ "$TIMELIMIT" == "warmup" ]; then
+			  echo "Warming up with 1 client for 60 seconds..."
+			  TIMELIMIT=60
+			  ${JMETER_LOC} -n -t ${SCRIPT_JMeter} -p jmeter_nonssl.properties -JTHREADS=1 -JDURATION=60 -JHOST=${WAS_HOST} >>resultstmp.txt  
+			else
+			  echo "Running $CLIENTS clients for $TIMELIMIT seconds..."
+			  ${JMETER_LOC} -n -t ${SCRIPT_JMeter} -p jmeter_nonssl.properties -JTHREADS=${CLIENTS} -JDURATION=$TIMELIMIT -JHOST=${WAS_HOST} >>resultstmp.txt
+			fi
+			
+			summary=`cat resultstmp.txt|sed 's%<summary>%%g'|grep "summary = "|tail -n 1`
+	                throughput=`echo $summary|awk '{print $7}' | sed 's%/s%%g'`
+		        responsetime=`echo $summary|awk '{print $9}' | sed 's%/s%%g'`
+		        weberrors=`echo $summary|awk '{print $15}' | sed 's%/s%%g'`
+		        pages=`echo $summary|awk '{print $3}' | sed 's%/s%%g'`
+		        echo "Page throughput = ${throughput} /s" 
+		        echo "HTTP avg. page element response time = ${responsetime}" 
+		        echo "Web server errors = ${weberrors}" 
+		        echo "Network I/O errors = ${weberrors}" 
+		        echo "Num of pages retrieved = ${pages}"  
+		        echo "Initial number of clients = $CLIENTS"
+			cat resultstmp.txt >> results_bkup.txt 2>&1
+
+		;;
+	esac
+	echo "</data>" 
+	;;
+esac

--- a/perf/liberty/scripts/resource/db2bootstrap.properties
+++ b/perf/liberty/scripts/resource/db2bootstrap.properties
@@ -1,0 +1,1 @@
+tradelite.http.port=LIBERTY_PORT_HERE

--- a/perf/liberty/scripts/resource/sufpdt7server.xml
+++ b/perf/liberty/scripts/resource/sufpdt7server.xml
@@ -31,11 +31,11 @@
 	<library filesetRef="DerbyFileset" id="DerbyLib"/>
 	<fileset dir="${shared.resource.dir}/derby" id="DerbyFileset" includes="derby.jar"/>
 
-	<authData id="TradeDataSourceAuthData" password="db_password" user="db_username"/>
-	<authData id="TradeAdminAuthData" password="db_password" user="db_username"/>
+	<authData id="TradeDataSourceAuthData" password="DB_PASSWORD_HERE" user="DB_USR_HERE"/>
+	<authData id="TradeAdminAuthData" password="DB_PASSWORD_HERE" user="DB_USR_HERE"/>
 
 	<dataSource connectionManagerRef="conMgr1" id="DefaultDataSource" isolationLevel="TRANSACTION_READ_COMMITTED" jdbcDriverRef="DerbyEmbedded" jndiName="jdbc/TradeDataSource" statementCacheSize="60">
-		<properties.derby.embedded createDatabase="create" databaseName="${shared.resource.dir}/data/tradedb7" password="db_password" user="db_username"/>
+		<properties.derby.embedded createDatabase="create" databaseName="DB_NAME_HERE" password="DB_PASSWORD_HERE" user="DB_USR_HERE"/>
 	</dataSource>
 
 	<messagingEngine id="defaultME">

--- a/perf/liberty/scripts/resource/template_nosslsystem.properties
+++ b/perf/liberty/scripts/resource/template_nosslsystem.properties
@@ -1,0 +1,21 @@
+# Sample system.properties file
+################################################################################
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Keystore properties (client certificates)
+# Location
+#javax.net.ssl.keyStore=KEYSTORE_LOC_HERE
+#
+#The password to your keystore
+#javax.net.ssl.keyStorePassword=PASSWORD_HERE


### PR DESCRIPTION
	• Add Liberty Throughput Framework
		○ This framework can run different Liberty applications such as DayTrader7, DayTrader3, AcmeAir, TradeLite, HugeEJB and more
	• Added scripts for running Liberty server, client, and database
	• Added scripts for monitoring CPU and setting JMeter configs
	• Added DT7 Throughput Benchmark
	• Renamed the Liberty tests to follow the naming convention for TRSS
	• Added support for profiling benchmarks
	• Added support to run Liberty framework with SSH
	• Added support for caching Liberty packages
		○ Liberty binaries are quite large in size and caching them can save significant time
	• Simplified the build step for downloading all Liberty packages
	• Set localhost for storing temporary perf results
	• Store Liberty logs in the correct directory so that they can be archived on Artifactory
	• Removed the old parser string printed at the start of the tests in order to use the new perf parser on Test Result Summary Service
	• Other minor fixes and clean up

Related Issues:
https://github.com/AdoptOpenJDK/openjdk-tests/issues/1127
https://github.com/AdoptOpenJDK/openjdk-tests/issues/1770

Signed-off-by: Piyush Gupta <piyush286@gmail.com>