### PR TITLE
Start an X11 server for openjdk tests on AIX

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -447,26 +447,6 @@ def get_sources() {
 	}
 }
 
-// Starts an X11 server and sets the DISPLAY variable. Currently only for linux and aix
-def setEnvDisplay(spec) {
-	if (spec.startsWith('aix')) {
-		sh "nohup /usr/bin/X11/X -force -vfb -x abx -x dbe -x GLX :0 &"
-		env.DISPLAY = ":0"
-		echo "env.DISPLAY is ${env.DISPLAY}"	
-	}
-	else if (spec.startsWith('linux')) {
-		wrap([$class: 'Xvfb', autoDisplayName: true]) {
-			def DISPLAY = sh (
-				script: 'ps -f  | grep \'[X]vfb\' | awk \'{print \$9}\'',
-				returnStdout: true
-			).trim()
-			env.DISPLAY = "${DISPLAY}"
-			echo "env.DISPLAY is ${env.DISPLAY}"
-			makeTest("${RUNTEST_CMD}")
-		}
-	}
-}
-
 def make_test() {
 	// use sshagent with Jenkins credentials ID for all platforms except zOS
 	if (!env.SPEC.startsWith('zos')) {
@@ -558,8 +538,26 @@ def runTest( ) {
 			RUNTEST_CMD = "./openjdk-tests ${TARGET} ${CUSTOM_OPTION}"
 			for (int i = 0; i < ITERATIONS; i++) {
 				echo "ITERATION: ${iterationCount}/${ITERATIONS}"
-				setEnvDisplay(env.SPEC)
-				// makeTest("${RUNTEST_CMD}")
+				if (spec.startsWith('aix')) {
+					sh "nohup /usr/bin/X11/X -force -vfb -x abx -x dbe -x GLX :0 &"
+					env.DISPLAY = ":0"
+					echo "env.DISPLAY is ${env.DISPLAY}"	
+					makeTest("${RUNTEST_CMD}")
+				}
+				else if (spec.startsWith('linux')) {
+					wrap([$class: 'Xvfb', autoDisplayName: true]) {
+						def DISPLAY = sh (
+							script: 'ps -f  | grep \'[X]vfb\' | awk \'{print \$9}\'',
+							returnStdout: true
+						).trim()
+						env.DISPLAY = "${DISPLAY}"
+						echo "env.DISPLAY is ${env.DISPLAY}"
+						makeTest("${RUNTEST_CMD}")
+					}
+				} 
+				else {
+					makeTest("${RUNTEST_CMD}")
+				}
 				iterationCount++
 			}
 		}

--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -538,13 +538,13 @@ def runTest( ) {
 			RUNTEST_CMD = "./openjdk-tests ${TARGET} ${CUSTOM_OPTION}"
 			for (int i = 0; i < ITERATIONS; i++) {
 				echo "ITERATION: ${iterationCount}/${ITERATIONS}"
-				if (spec.startsWith('aix')) {
+				if (env.SPEC.startsWith('aix')) {
 					sh "nohup /usr/bin/X11/X -force -vfb -x abx -x dbe -x GLX :0 &"
 					env.DISPLAY = ":0"
 					echo "env.DISPLAY is ${env.DISPLAY}"	
 					makeTest("${RUNTEST_CMD}")
 				}
-				else if (spec.startsWith('linux')) {
+				else if (env.SPEC.startsWith('linux')) {
 					wrap([$class: 'Xvfb', autoDisplayName: true]) {
 						def DISPLAY = sh (
 							script: 'ps -f  | grep \'[X]vfb\' | awk \'{print \$9}\'',
@@ -569,8 +569,6 @@ def post(output_name) {
 		timestamps{
 			if (env.DISPLAY != null) {
 				env.DISPLAY = ""
-				// Debug code
-				echo "env.DISPLAY is ${env.DISPLAY}"
 			}
 			if (output_name.contains(',')) {
 				output_name = "specifiedTarget"

--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -538,40 +538,25 @@ def runTest( ) {
 			RUNTEST_CMD = "./openjdk-tests ${TARGET} ${CUSTOM_OPTION}"
 			for (int i = 0; i < ITERATIONS; i++) {
 				echo "ITERATION: ${iterationCount}/${ITERATIONS}"
-				if (env.BUILD_LIST == 'openjdk') {
-					if (env.SPEC.startsWith('linux_x86-64')) {
-						wrap([$class: 'Xvfb', autoDisplayName: true]) {
-							def DISPLAY = sh (
-								script: 'ps -f  | grep \'[X]vfb\' | awk \'{print \$9}\'',
-								returnStdout: true
-							).trim()
-							env.DISPLAY = "${DISPLAY}"
-							echo "env.DISPLAY is ${env.DISPLAY}"
-							makeTest("${RUNTEST_CMD}")
-						}
-					} else {
-						makeTest("${RUNTEST_CMD}")
-					}
-				} else if (env.BUILD_LIST.startsWith('jck')) {
-					if (env.SPEC.startsWith('linux')) {
-						wrap([$class: 'Xvfb', autoDisplayName: true]) {
-							def DISPLAY = sh (
-								script: 'ps -f  | grep \'[X]vfb\' | awk \'{print \$9}\'',
-								returnStdout: true
-							).trim()
-							env.DISPLAY = "${DISPLAY}"
-							echo "env.DISPLAY is ${env.DISPLAY}"
-							makeTest("${RUNTEST_CMD}")
-						}
-					} else if (env.SPEC.startsWith('aix')) {
-						sh "nohup /usr/bin/X11/X -force -vfb -x abx -x dbe -x GLX :0 &"
-						env.DISPLAY = ":0"
+				// Starting an X11 server
+				if ((env.BUILD_LIST == 'openjdk' || env.BUILD_LIST.startsWith('jck')) && env.SPEC.startsWith('aix')) {
+					sh "nohup /usr/bin/X11/X -force -vfb -x abx -x dbe -x GLX :0 &"
+					env.DISPLAY = ":0"
+					echo "env.DISPLAY is ${env.DISPLAY}"
+					makeTest("${RUNTEST_CMD}")
+				}
+				else if ((env.BUILD_LIST == 'openjdk' && env.SPEC.startsWith('linux_x86-64')) || (env.BUILD_LIST.startsWith('jck') && env.SPEC.startsWith('linux'))) {
+					wrap([$class: 'Xvfb', autoDisplayName: true]) {
+						def DISPLAY = sh (
+							script: 'ps -f  | grep \'[X]vfb\' | awk \'{print \$9}\'',
+							returnStdout: true
+						).trim()
+						env.DISPLAY = "${DISPLAY}"
 						echo "env.DISPLAY is ${env.DISPLAY}"
 						makeTest("${RUNTEST_CMD}")
-					} else {
-						makeTest("${RUNTEST_CMD}")
 					}
-				} else {
+				}
+				else {
 					makeTest("${RUNTEST_CMD}")
 				}
 				iterationCount++

--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -457,7 +457,7 @@ def setEnvDisplay(spec) {
 	else if (spec.startsWith('linux')) {
 		wrap([$class: 'Xvfb', autoDisplayName: true]) {
 			def DISPLAY = sh (
-				script: 'ps -f  | grep \'[X]vfb\' | awk \'{print \$9}\'',
+				script: 'ps -f  | grep \'[X]vfb\' | awk \'{print \$10}\'',
 				returnStdout: true
 			).trim()
 			env.DISPLAY = "${DISPLAY}"
@@ -568,6 +568,11 @@ def runTest( ) {
 def post(output_name) {
 	stage('Post') {
 		timestamps{
+			if (env.DISPLAY != null) {
+				env.DISPLAY = ""
+				// Debug code
+				echo "env.DISPLAY is ${env.DISPLAY}"
+			}
 			if (output_name.contains(',')) {
 				output_name = "specifiedTarget"
 			}

--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -447,6 +447,25 @@ def get_sources() {
 	}
 }
 
+// Starts an X11 server and sets the DISPLAY variable. Currently only for linux and aix
+def setEnvDisplay(spec) {
+	if (spec.startsWith('aix')) {
+		sh "nohup /usr/bin/X11/X -force -vfb -x abx -x dbe -x GLX :0 &"
+		env.DISPLAY = ":0"
+		echo "env.DISPLAY is ${env.DISPLAY}"	
+	}
+	else if (spec.startsWith('linux')) {
+		wrap([$class: 'Xvfb', autoDisplayName: true]) {
+			def DISPLAY = sh (
+				script: 'ps -f  | grep \'[X]vfb\' | awk \'{print \$9}\'',
+				returnStdout: true
+			).trim()
+			env.DISPLAY = "${DISPLAY}"
+			echo "env.DISPLAY is ${env.DISPLAY}"
+		}
+	}
+}
+
 def make_test() {
 	// use sshagent with Jenkins credentials ID for all platforms except zOS
 	if (!env.SPEC.startsWith('zos')) {
@@ -538,27 +557,8 @@ def runTest( ) {
 			RUNTEST_CMD = "./openjdk-tests ${TARGET} ${CUSTOM_OPTION}"
 			for (int i = 0; i < ITERATIONS; i++) {
 				echo "ITERATION: ${iterationCount}/${ITERATIONS}"
-				// Starting an X11 server
-				if ((env.BUILD_LIST == 'openjdk' || env.BUILD_LIST.startsWith('jck')) && env.SPEC.startsWith('aix')) {
-					sh "nohup /usr/bin/X11/X -force -vfb -x abx -x dbe -x GLX :0 &"
-					env.DISPLAY = ":0"
-					echo "env.DISPLAY is ${env.DISPLAY}"
-					makeTest("${RUNTEST_CMD}")
-				}
-				else if ((env.BUILD_LIST == 'openjdk' && env.SPEC.startsWith('linux_x86-64')) || (env.BUILD_LIST.startsWith('jck') && env.SPEC.startsWith('linux'))) {
-					wrap([$class: 'Xvfb', autoDisplayName: true]) {
-						def DISPLAY = sh (
-							script: 'ps -f  | grep \'[X]vfb\' | awk \'{print \$9}\'',
-							returnStdout: true
-						).trim()
-						env.DISPLAY = "${DISPLAY}"
-						echo "env.DISPLAY is ${env.DISPLAY}"
-						makeTest("${RUNTEST_CMD}")
-					}
-				}
-				else {
-					makeTest("${RUNTEST_CMD}")
-				}
+				setEnvDisplay(env.SPEC)
+				makeTest("${RUNTEST_CMD}")
 				iterationCount++
 			}
 		}

--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -462,6 +462,7 @@ def setEnvDisplay(spec) {
 			).trim()
 			env.DISPLAY = "${DISPLAY}"
 			echo "env.DISPLAY is ${env.DISPLAY}"
+			makeTest("${RUNTEST_CMD}")
 		}
 	}
 }
@@ -558,7 +559,7 @@ def runTest( ) {
 			for (int i = 0; i < ITERATIONS; i++) {
 				echo "ITERATION: ${iterationCount}/${ITERATIONS}"
 				setEnvDisplay(env.SPEC)
-				makeTest("${RUNTEST_CMD}")
+				// makeTest("${RUNTEST_CMD}")
 				iterationCount++
 			}
 		}

--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -457,7 +457,7 @@ def setEnvDisplay(spec) {
 	else if (spec.startsWith('linux')) {
 		wrap([$class: 'Xvfb', autoDisplayName: true]) {
 			def DISPLAY = sh (
-				script: 'ps -f  | grep \'[X]vfb\' | awk \'{print \$10}\'',
+				script: 'ps -f  | grep \'[X]vfb\' | awk \'{print \$9}\'',
 				returnStdout: true
 			).trim()
 			env.DISPLAY = "${DISPLAY}"

--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -152,7 +152,7 @@
 		<levels>
 			<level>extended</level>
 		</levels>
-		<platformRequirements>^os.osx,arch.x86</platformRequirements>
+		<platformRequirements>^os.osx,^os.zos</platformRequirements>
 		<groups>
 			<group>openjdk</group>
 		</groups>

--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -466,7 +466,7 @@
 		<levels>
 			<level>extended</level>
 		</levels>
-		<platformRequirements>^os.osx</platformRequirements>
+		<platformRequirements>^os.osx,^os.zos</platformRequirements>
 		<groups>
 			<group>openjdk</group>
 		</groups>


### PR DESCRIPTION
Ref https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1277

Ive tidied the code up a bit, and reduced the X11 server start up code to 2 conditions:

1.  (`BUILD_LIST` is openjdk or jck) and `SPEC` is aix 
2. (`BUILD_LIST` is openjdk and `SPEC` is linux_x86-64) or (`BUILD_LIST` is jck and `SPEC` is linux)

jdk_awt tests are run only on x86-64 architectures, [see here](https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1277#issuecomment-613663200), hence why there are 2 different conditions for `SPEC` in the second point, else this could have been a bit tidier.

Finding a way to test this.