### PR TITLE
Add Mauve special tests that run with trace options on OpenJ9 SDKs

### DIFF
--- a/system/mauveLoadTest/playlist.xml
+++ b/system/mauveLoadTest/playlist.xml
@@ -208,7 +208,7 @@
 			<variation>Mode612-OSRG</variation>
 			<!--Note: -Xint modes Mode108, Mode109, Mode550 should be run manually -->
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MauveMultiThreadLoadTest; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MauveMultiThreadLoadTestWithTraceOption; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -259,7 +259,7 @@
 			<variation>Mode612-OSRG</variation>
 			<!--Note: -Xint modes Mode108, Mode109, Mode550 should be run manually -->
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MauveSingleThreadLoadTest; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MauveSingleThreadLoadTestWithTraceOption; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>


### PR DESCRIPTION
- Updates the mauve multi-threaded special and single-threaded special playlist targets to use the test classes that use the additional tracepoints options introduced by https://github.com/AdoptOpenJDK/openjdk-systemtest/pull/353

Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>

FYI @pshipton 