### PR TITLE
Shorten Mauve special test names for keeping Windows path length short

### DIFF
--- a/system/mauveLoadTest/playlist.xml
+++ b/system/mauveLoadTest/playlist.xml
@@ -208,7 +208,7 @@
 			<variation>Mode612-OSRG</variation>
 			<!--Note: -Xint modes Mode108, Mode109, Mode550 should be run manually -->
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MauveMultiThreadLoadTestWithTraceOption; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MauveMultiThreadTestTrc; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -259,7 +259,7 @@
 			<variation>Mode612-OSRG</variation>
 			<!--Note: -Xint modes Mode108, Mode109, Mode550 should be run manually -->
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MauveSingleThreadLoadTestWithTraceOption; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MauveSingleThreadTestTrc; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>


### PR DESCRIPTION
Related to https://github.com/eclipse/openj9/issues/9982
Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>