### PR TITLE
OpenJ9 AArch64: Enable UnicodeCasingTest

### DIFF
--- a/openjdk/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/ProblemList_openjdk11-openj9.txt
@@ -55,7 +55,6 @@ java/lang/String/CaseInsensitiveComparator.java	https://github.com/eclipse/openj
 java/lang/String/CompactString/IndexOf.java	https://github.com/eclipse/openj9/issues/6673	generic-all
 java/lang/String/EqualsIgnoreCase.java	https://github.com/eclipse/openj9/issues/6666	generic-all
 java/lang/String/StringRepeat.java	https://github.com/eclipse/openj9/issues/6667	generic-all
-java/lang/String/UnicodeCasingTest.java	https://github.com/eclipse/openj9/issues/9081	linux-aarch64
 java/lang/String/nativeEncoding/StringPlatformChars.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	generic-all
 java/lang/System/Logger/custom/CustomLoggerTest.java	https://github.com/eclipse/openj9/issues/6674	generic-all
 java/lang/System/Logger/default/DefaultLoggerTest.java	https://github.com/eclipse/openj9/issues/6674	generic-all


### PR DESCRIPTION
This commit enables the following test for OpenJ9 AArch64.  It was
disabled by #1710.

- java/lang/String/UnicodeCasingTest.java eclipse/openj9#9081

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>