### PR TITLE
Remove OpenJ9 timeout handler for FinalizeOverride test

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -269,7 +269,6 @@
 		</variations>   
 		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
 	$(JTREG_BASIC_OPTIONS) $(JDK_NATIVE_OPTIONS) -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
-	-timeoutHandler:jtreg.openj9.CoreDumpTimeoutHandler -timeoutHandlerDir:$(Q)$(LIB_DIR)$(D)openj9jtregtimeouthandler.jar$(Q) \
 	-w $(Q)$(REPORTDIR)$(D)work$(Q) \
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
 	-jdk:$(Q)$(TEST_JDK_HOME)$(Q) \


### PR DESCRIPTION
It seems the test will continue to timeout/fail for some time, and we no
longer need to collect a core file each time. Disable the timeout
handler that creates the core file to save space.

Issue https://github.com/eclipse/openj9/issues/9651#issuecomment-649709751

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>