### PR TITLE
copy TAP for UNSTABLE builds

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -255,7 +255,7 @@ def setupParallelEnv() {
 				childParams << string(name: 'RUNTIME_NAME', value: childTest)
 
 				parallel_tests[childTest] = {
-					build job: TEST_JOB_NAME, parameters: childParams
+					build job: TEST_JOB_NAME, parameters: childParams, propagate: false
 				}
 			}
 			parallel create_jobs
@@ -822,6 +822,7 @@ def run_parallel_tests() {
 					def buildId = jobInvocation.getNumber()
 					def name = cjob.value.getProjectName()
 					try {
+						echo "${name} #${buildId} completed with status ${cjob.value.getCurrentResult()}"
 						copyArtifacts (projectName: "${name}", selector: specific("${buildId}"), filter: "**/TestTargetResult.tap", target:"${name}/${buildId}")
 					} catch (Exception e) {
 						echo "Cannot copy TestTargetResult.tap from ${name} with buildid ${buildId} . Skipping copyArtifacts..."


### PR DESCRIPTION
- add flag propagate: false to build step
- echo out the status of children builds

Grinder 8658: mixed case of success and failure children builds

Signed-off-by: Yixin Qian <Yixin.Qian@ibm.com>