### PR TITLE
Move FinalizeOverride from sanity.openjdk into special.openjdk

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -278,7 +278,7 @@
 			<subset>11+</subset>
 		</subsets>
 		<levels>
-			<level>sanity</level>
+			<level>special</level>
 		</levels>
 		<groups>
 			<group>openjdk</group>


### PR DESCRIPTION
This allows us to continue running the test as a matter of course,
as requested by the OpenJ9 group, while also increasing our ability
to identify new failures.

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>