### PR TITLE
Cache TRSS JSON output (Smart Parallelization approach 3)

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -142,6 +142,14 @@ def setupParallelEnv() {
 				}
 
 				try {
+					//get cached TRSS JSON data
+					copyArtifacts fingerprintArtifacts: true, projectName: "getTRSSOutput", selector: lastSuccessful(), target: 'openjdk-tests/TKG/resources/TRSS'
+					sh "cd ./openjdk-tests/TKG/resources/TRSS; gzip -cd TRSSOutput.tar.gz | tar xof -; rm TRSSOutput.tar.gz"
+				} catch (Exception e) {
+					echo 'Cannot get cached TRSS JSON data. Skipping copyArtifacts...'
+				}
+
+				try {
 					//get pre-staged jars from test.getDependency build
 					copyArtifacts fingerprintArtifacts: true, projectName: "test.getDependency", selector: lastSuccessful(), target: 'openjdk-tests/TKG/lib'
 				} catch (Exception e) {

--- a/buildenv/jenkins/getTRSSOutput
+++ b/buildenv/jenkins/getTRSSOutput
@@ -1,0 +1,91 @@
+#!groovy
+
+LABEL='ci.role.test&&hw.arch.x86&&sw.os.linux'
+
+stage('Queue') {
+	node("$LABEL") {
+		cleanWs()
+		getTRSSOutput()
+	}
+}
+
+def getTRSSOutput() {
+	stage('TRSS JSON') {
+		def TIME_LIMIT = params.TIME_LIMIT ? params.TIME_LIMIT.toInteger() : 30
+		timeout(time: TIME_LIMIT, unit: 'MINUTES') {
+			try {
+				def TRSS_URL = params.TRSS_URL ? params.TRSS_URL : "https://trss.adoptopenjdk.net/"
+
+				if (params.JDK_VERSIONS) {
+					JDK_VERSIONS = JDK_VERSIONS.split(',')
+				} else {
+					JDK_VERSIONS = [8, 11, 14]
+				}
+
+				if (params.JDK_IMPLS) {
+					JDK_IMPLS = JDK_IMPLS.split(',')
+				} else {
+					JDK_IMPLS = ["j9", "hs"]
+				}
+
+				if (params.GROUPS) {
+					GROUPS = GROUPS.split(',')
+				} else {
+					GROUPS = ["functional", "system", "openjdk"]
+				}
+
+				if (params.PLATFORMS) {
+					PLATFORMS = PLATFORMS.split(',')
+				} else {
+					PLATFORMS = [
+						"aarch32_linux",
+						"aarch64_linux",
+						"aarch64_linux_xl",
+						"ppc32_aix",
+						"ppc32_linux",
+						"ppc64_aix",
+						"ppc64_aix_xl",
+						"ppc64_linux",
+						"ppc64_linux_xl",
+						"ppc64le_linux",
+						"ppc64le_linux_xl",
+						"riscv64_linux",
+						"riscv64_linux_xl",
+						"s390_linux",
+						"s390_zos",
+						"s390x_linux",
+						"s390x_linux_xl",
+						"s390x_zos",
+						"s390x_zos_xl",
+						"sparcv9_solaris",
+						"x86-32_linux",
+						"x86-32_windows",
+						"x86-64_linux",
+						"x86-64_linux_xl",
+						"x86-64_mac",
+						"x86-64_mac_xl",
+						"x86-64_windows",
+						"x86-64_windows_xl" ]
+				}
+
+				JDK_VERSIONS.each { JDK_VERSION ->
+					JDK_IMPLS.each { JDK_IMPL ->
+						GROUPS.each { GROUP ->
+							PLATFORMS.each { PLATFORM ->
+								def output = "Test_openjdk${JDK_VERSION}_${JDK_IMPL}_${GROUP}_${PLATFORM}.json"
+								def url = "${TRSS_URL}/api/getTestAvgDuration?platform=${PLATFORM}&group=${GROUP}&jdkVersion=${JDK_VERSION}&impl=${JDK_IMPL}&limit=10"
+								sh "curl \'${url}\' --output ${output}"
+							}
+						}
+					}
+				}
+				sh "tar -zcvf TRSSOutput.tar.gz Test_openjdk*.json"
+				archiveArtifacts artifacts: 'TRSSOutput.tar.gz', fingerprint: true, allowEmptyArchive: false
+			} finally {
+				cleanWs()
+			}
+		}
+	}
+}
+
+return this


### PR DESCRIPTION
Part1:
- Add getTRSSOutput script that queries TRSS server to get JSON output
- Users can specify JDK_VERSIONS, JDK_IMPLS, GROUPS, PLATFORMS and
TIME_LIMIT
- The script will archive all outputs into TRSSOutput.tar.gz

Part2:
- Update JenkinsfileBase to copyArtifacts from getTRSSOutput
- Unzip TRSSOutput.tar.gz under TKG/resources/TRSS
- this code will only be triggered if PARALLEL=Dynamic

Issue: https://github.com/AdoptOpenJDK/openjdk-tests/issues/1801

Signed-off-by: lanxia <lan_xia@ca.ibm.com>