### PR TITLE
Unexclude tests affected by bad hostname setup

### DIFF
--- a/openjdk/ProblemList_openjdk8.txt
+++ b/openjdk/ProblemList_openjdk8.txt
@@ -324,12 +324,7 @@ com/sun/jdi/PopAsynchronousTest.java https://github.com/AdoptOpenJDK/openjdk-tes
 com/sun/jdi/PopSynchronousTest.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1737 linux-s390x
 com/sun/jdi/RedefineCrossStart.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1737 linux-s390x
 com/sun/jdi/redefineMethod/RedefineTest.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1737 linux-s390x
-com/sun/jdi/ProcessAttachTest.sh  https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1274  macosx-all,linux-x64
-# com/sun/jdi/ProcessAttachTest.sh on linux-x64: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1145
-com/sun/jdi/BadHandshakeTest.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1145  linux-x64
-com/sun/jdi/ExclusiveBind.java  https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1145  linux-x64
-com/sun/jdi/RunToExit.java  https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1145  linux-x64
-com/sun/jdi/JITDebug.sh https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1145  linux-x64
+com/sun/jdi/ProcessAttachTest.sh  https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1274  macosx-all
 
 ############################################################################
 


### PR DESCRIPTION
* Reincludes tests excluded by https://github.com/AdoptOpenJDK/openjdk-tests/pull/1785
* Fixed by @Willsparker in https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1145

Signed-off-by: Morgan Davies <morgan.davies@ibm.com>