### PR TITLE
Revert "Temp exclude sun/util/calendar/zi/TestZoneInfo310.java"

### DIFF
--- a/openjdk/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/ProblemList_openjdk11-openj9.txt
@@ -261,7 +261,6 @@ java/util/stream/boottest/java.base/java/util/stream/NodeTest.java https://githu
 java/util/stream/test/org/openjdk/tests/java/util/SplittableRandomTest.java 	https://github.com/eclipse/openj9/issues/4613 	generic-all
 java/util/stream/test/org/openjdk/tests/java/util/stream/CountLargeTest.java	https://github.com/eclipse/openj9/issues/9040	linux-aarch64
 java/util/stream/test/org/openjdk/tests/java/util/stream/ToArrayOpTest.java	https://github.com/eclipse/openj9/issues/3447	generic-all
-sun/util/calendar/zi/TestZoneInfo310.java	https://github.com/eclipse/openj9/issues/9652	generic-all
 
 ############################################################################
 


### PR DESCRIPTION
Reverts AdoptOpenJDK/openjdk-tests#1793

This test is passing now. I believe it was failing earlier because the tests don't necessarily fetch the test material which matches the JDK being tested.

https://ci.eclipse.org/openj9/view/Test/job/Grinder/943/

Fixes https://github.com/eclipse/openj9/issues/9642