### PR TITLE
enable jck-runtime-vm-instr for JDK8

### DIFF
--- a/jck/runtime.vm/playlist.xml
+++ b/jck/runtime.vm/playlist.xml
@@ -157,9 +157,6 @@
 		<groups>
 			<group>jck</group>
 		</groups>
-		<subsets>
-			<subset>10+</subset>
-		</subsets>
 	</test>
 	<test>
 		<testCaseName>jck-runtime-vm-cldc</testCaseName>


### PR DESCRIPTION
Related: runtimes/backlog/issues/357 and runtimes/backlog/issues/352

Signed-off-by: lanxia <lan_xia@ca.ibm.com>