### PR TITLE
Add docker_prune as depends in clean_image target

### DIFF
--- a/external/build.xml
+++ b/external/build.xml
@@ -34,7 +34,7 @@
 			<property name="dockerImageTag" value="nightly"/>
 		</else>
 	</if>
-	<target name="init" depends="docker_prune">
+	<target name="init">
 		<mkdir dir="${DEST_EXTERNAL}" />
 	</target>
 
@@ -57,7 +57,7 @@
 		</exec>
 	</target>
 
-	<target name="clean_image" description="clean test docker image if there is one">
+	<target name="clean_image" depends="docker_prune" description="clean test docker image if there is one">
 		<echo message="Executing external.sh --clean --dir ${TEST} --tag ${dockerImageTag} --version ${JDK_VERSION} --impl ${JDK_IMPL} " />						
 		<exec executable="bash">
 			<arg value="${DEST_EXTERNAL}/external.sh"/>


### PR DESCRIPTION
When running using subdir, subdir/build.xml will be triggered directly.
In this case, we will not run parent dir init, which results not running
docker_prune target. To fix this, add docker_prune as depends in
clean_image target. clean_image target is called in each subdir
build.xml

Resolves: #1887

Signed-off-by: lanxia <lan_xia@ca.ibm.com>