### PR TITLE
Add full set of supported versions for java_rmi test

### DIFF
--- a/jck/compiler.api/playlist.xml
+++ b/jck/compiler.api/playlist.xml
@@ -29,7 +29,11 @@
 		</groups>
 		<subsets>
 			<subset>8</subset>
+			<subset>9</subset>
+			<subset>10</subset>
 			<subset>11</subset>
+			<subset>12</subset>
+			<subset>13</subset>
 			<subset>14</subset>
 		</subsets>
 	</test>


### PR DESCRIPTION
- `java_rmi` test applies to all supported JCK versions prior to 15 (from which it has been discontinued). So, for correctness and consistency, we should add 8,9,10,11,12,13 and 14 `<subset>` tags for its playlist target. 
 
Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>