### PR TITLE
Set SparseCheckoutPath to buildenv/jenkins/

### DIFF
--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -201,8 +201,16 @@ ARCH_OS_LIST.each { ARCH_OS ->
 										cleanBeforeCheckout()
 										pruneStaleBranch()
 										cloneOptions {
+											depth(1)
 											shallow(true)
 											timeout(60)
+										}
+									}
+									configure { git ->
+										git / 'extensions' / 'hudson.plugins.git.extensions.impl.SparseCheckoutPaths' / 'sparseCheckoutPaths' {
+											'hudson.plugins.git.extensions.impl.SparseCheckoutPath' {
+												path("buildenv/jenkins/")
+											}
 										}
 									}
 								}


### PR DESCRIPTION
In order to reduce the space usage on Jenkins master, set
SparseCheckoutPath to buildenv/jenkins/. 

Fixes: #1895

Signed-off-by: lanxia <lan_xia@ca.ibm.com>