### PR TITLE
Revert "Excluding Zip64SizeTest on linux-ppc64le until we can run it …

### DIFF
--- a/openjdk/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/ProblemList_openjdk11-openj9.txt
@@ -261,7 +261,6 @@ java/util/stream/boottest/java.base/java/util/stream/NodeTest.java https://githu
 java/util/stream/test/org/openjdk/tests/java/util/SplittableRandomTest.java 	https://github.com/eclipse/openj9/issues/4613 	generic-all
 java/util/stream/test/org/openjdk/tests/java/util/stream/CountLargeTest.java	https://github.com/eclipse/openj9/issues/9040	linux-aarch64
 java/util/stream/test/org/openjdk/tests/java/util/stream/ToArrayOpTest.java	https://github.com/eclipse/openj9/issues/3447	generic-all
-java/util/zip/ZipFile/Zip64SizeTest.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1443	linux-ppc64le
 
 ############################################################################
 

--- a/openjdk/ProblemList_openjdk11.txt
+++ b/openjdk/ProblemList_openjdk11.txt
@@ -166,7 +166,6 @@ java/util/concurrent/locks/Lock/TimedAcquireLeak.java	https://github.com/AdoptOp
 java/util/concurrent/tck/JSR166TestCase.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1272 windows-all
 java/util/concurrent/TimeUnit/Basic.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1665 windows-all
 java/util/logging/TestLoggerWeakRefLeak.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
-java/util/zip/ZipFile/Zip64SizeTest.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1443	linux-ppc64le
 
 ############################################################################
 

--- a/openjdk/ProblemList_openjdk14-openj9.txt
+++ b/openjdk/ProblemList_openjdk14-openj9.txt
@@ -270,7 +270,6 @@ java/util/logging/LogManager/TestLoggerNames.java https://github.com/eclipse/ope
 java/util/stream/boottest/java.base/java/util/stream/NodeTest.java https://github.com/eclipse/openj9/issues/4129 macosx-all
 java/util/stream/test/org/openjdk/tests/java/util/SplittableRandomTest.java https://github.com/eclipse/openj9/issues/4613 generic-all
 java/util/stream/test/org/openjdk/tests/java/util/stream/ToArrayOpTest.java	https://github.com/eclipse/openj9/issues/3447	generic-all
-java/util/zip/ZipFile/Zip64SizeTest.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1443	linux-ppc64le
 
 ############################################################################
 

--- a/openjdk/ProblemList_openjdk14.txt
+++ b/openjdk/ProblemList_openjdk14.txt
@@ -169,7 +169,6 @@ jdk/jfr/event/compiler/TestAllocInNewTLAB.java	https://bugs.openjdk.java.net/bro
 java/util/concurrent/locks/Lock/TimedAcquireLeak.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
 java/util/concurrent/tck/JSR166TestCase.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1272 windows-all
 java/util/logging/TestLoggerWeakRefLeak.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
-java/util/zip/ZipFile/Zip64SizeTest.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1443	linux-ppc64le
 
 ############################################################################
 

--- a/openjdk/ProblemList_openjdk15-openj9.txt
+++ b/openjdk/ProblemList_openjdk15-openj9.txt
@@ -294,7 +294,6 @@ java/util/logging/LogManager/TestLoggerNames.java https://github.com/eclipse/ope
 java/util/stream/boottest/java.base/java/util/stream/NodeTest.java https://github.com/eclipse/openj9/issues/4129 macosx-all
 java/util/stream/test/org/openjdk/tests/java/util/SplittableRandomTest.java https://github.com/eclipse/openj9/issues/4613 generic-all
 java/util/stream/test/org/openjdk/tests/java/util/stream/ToArrayOpTest.java	https://github.com/eclipse/openj9/issues/3447	generic-all
-java/util/zip/ZipFile/Zip64SizeTest.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1443	linux-ppc64le
 
 ############################################################################
 

--- a/openjdk/ProblemList_openjdk15.txt
+++ b/openjdk/ProblemList_openjdk15.txt
@@ -162,7 +162,6 @@ java/nio/channels/DatagramChannel/PromiscuousIPv6.java	https://github.com/AdoptO
 java/util/concurrent/locks/Lock/TimedAcquireLeak.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
 java/util/logging/TestLoggerWeakRefLeak.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
 java/util/concurrent/tck/JSR166TestCase.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1272 windows-all
-java/util/zip/ZipFile/Zip64SizeTest.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1443	linux-ppc64le
 ############################################################################
 
 # svc_tools


### PR DESCRIPTION
…(#1896)"

This reverts commit 3dee7446d2689a2e0653c598e53aaddef9c1bbbf.

This was excluded on the wrong platform - should have been AIX.
Underlying failure has been fixed now anyway