### PR TITLE
Exclude failing tests on linux-aarch64

### DIFF
--- a/openjdk/ProblemList_openjdk14.txt
+++ b/openjdk/ProblemList_openjdk14.txt
@@ -24,7 +24,10 @@
 
 java/lang/Class/GetPackageBootLoaderChildLayer.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
 java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	generic-all
-java/lang/ProcessBuilder/Basic.java#id0		https://github.com/AdoptOpenJDK/openjdk-tests/issues/1397	aix-all
+java/lang/ProcessBuilder/Basic.java#id0	        https://github.com/AdoptOpenJDK/openjdk-tests/issues/1397   aix-all,linux-aarch64
+java/lang/ProcessBuilder/Basic.java#id1         https://github.com/AdoptOpenJDK/openjdk-tests/issues/1864 linux-aarch64
+java/lang/ProcessBuilder/InheritIO/InheritIO.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1864 linux-aarch64
+java/lang/ProcessBuilder/SkipTest.java          https://github.com/AdoptOpenJDK/openjdk-tests/issues/1864 linux-aarch64
 # java/lang/String/StringRepeat.java https://bugs.openjdk.java.net/browse/JDK-8221400
 java/lang/String/StringRepeat.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1272 windows-all
 java/lang/String/nativeEncoding/StringPlatformChars.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	generic-all
@@ -53,6 +56,9 @@ java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessLong.java	https://git
 java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessShort.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1118  linux-aarch64
 java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1118	linux-aarch64
 java/lang/reflect/exeCallerAccessTest/CallerAccessTest.java https://github.com/AdoptOpenJDK/openjdk-build/issues/248 generic-all
+java/lang/RuntimeTests/exec/Duped.java.Duped https://github.com/AdoptOpenJDK/openjdk-tests/issues/1864 linux-aarch64
+java/lang/RuntimeTests/exec/ExecWithLotsOfArgs.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1864 linux-aarch64
+java/lang/RuntimeTests/exec/SetCwd.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1864 linux-aarch64
 jdk/modules/etc/DefaultModules.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
 jdk/modules/incubator/ImageModules.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
 
@@ -168,7 +174,9 @@ jdk/jfr/event/compiler/TestAllocInNewTLAB.java	https://bugs.openjdk.java.net/bro
 
 java/util/concurrent/locks/Lock/TimedAcquireLeak.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
 java/util/concurrent/tck/JSR166TestCase.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1272 windows-all
+java/util/logging/LoggingDeadlock2.java         https://github.com/AdoptOpenJDK/openjdk-tests/issues/1864 linux-aarch64
 java/util/logging/TestLoggerWeakRefLeak.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
+java/util/zip/EntryCount64k.java            https://github.com/AdoptOpenJDK/openjdk-tests/issues/1864 linux-aarch64
 java/util/zip/ZipFile/Zip64SizeTest.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1443	linux-ppc64le
 
 ############################################################################

--- a/openjdk/ProblemList_openjdk14.txt
+++ b/openjdk/ProblemList_openjdk14.txt
@@ -56,7 +56,7 @@ java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessLong.java	https://git
 java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessShort.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1118  linux-aarch64
 java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1118	linux-aarch64
 java/lang/reflect/exeCallerAccessTest/CallerAccessTest.java https://github.com/AdoptOpenJDK/openjdk-build/issues/248 generic-all
-java/lang/RuntimeTests/exec/Duped.java.Duped https://github.com/AdoptOpenJDK/openjdk-tests/issues/1864 linux-aarch64
+java/lang/RuntimeTests/exec/Duped.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1864 linux-aarch64
 java/lang/RuntimeTests/exec/ExecWithLotsOfArgs.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1864 linux-aarch64
 java/lang/RuntimeTests/exec/SetCwd.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1864 linux-aarch64
 jdk/modules/etc/DefaultModules.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all


### PR DESCRIPTION
Excludes a number of failing tests for linux-aarch64 builds, caused by 64k/4k page size problem.
Issue is fixed in jdk15, test are only excluded for jdk14.