### PR TITLE
Move openjdk java/util/zip/ZipFile/TestCleaner to special

### DIFF
--- a/openjdk/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/ProblemList_openjdk11-openj9.txt
@@ -261,6 +261,7 @@ java/util/stream/boottest/java.base/java/util/stream/NodeTest.java https://githu
 java/util/stream/test/org/openjdk/tests/java/util/SplittableRandomTest.java 	https://github.com/eclipse/openj9/issues/4613 	generic-all
 java/util/stream/test/org/openjdk/tests/java/util/stream/CountLargeTest.java	https://github.com/eclipse/openj9/issues/9040	linux-aarch64
 java/util/stream/test/org/openjdk/tests/java/util/stream/ToArrayOpTest.java	https://github.com/eclipse/openj9/issues/3447	generic-all
+java/util/zip/ZipFile/TestCleaner.java	https://github.com/eclipse/openj9/issues/8872 	generic-all
 
 ############################################################################
 

--- a/openjdk/ProblemList_openjdk15-openj9.txt
+++ b/openjdk/ProblemList_openjdk15-openj9.txt
@@ -294,6 +294,7 @@ java/util/logging/LogManager/TestLoggerNames.java https://github.com/eclipse/ope
 java/util/stream/boottest/java.base/java/util/stream/NodeTest.java https://github.com/eclipse/openj9/issues/4129 macosx-all
 java/util/stream/test/org/openjdk/tests/java/util/SplittableRandomTest.java https://github.com/eclipse/openj9/issues/4613 generic-all
 java/util/stream/test/org/openjdk/tests/java/util/stream/ToArrayOpTest.java	https://github.com/eclipse/openj9/issues/3447	generic-all
+java/util/zip/ZipFile/TestCleaner.java	https://github.com/eclipse/openj9/issues/8872 	generic-all
 
 ############################################################################
 

--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -296,6 +296,32 @@
 		</impls>
 	</test>
 	<test>
+		<testCaseName>jdk_util_zip_ZipFile_TestCleaner_j9</testCaseName>
+		<variations>
+			<variation>-Xjit:enableAggressiveLiveness -XX:-JITServerTechPreviewMessage</variation>
+		</variations>   
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
+	$(JTREG_BASIC_OPTIONS) $(JDK_NATIVE_OPTIONS) -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
+	-w $(Q)$(REPORTDIR)$(D)work$(Q) \
+	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
+	-jdk:$(Q)$(TEST_JDK_HOME)$(Q) \
+	$(Q)$(OPENJDK_DIR)$(D)test$(D)jdk$(D)java$(D)util$(D)zip$(D)ZipFile$(D)TestCleaner.java$(Q); \
+	$(TEST_STATUS)</command>
+		<subsets>
+			<subset>11+</subset>
+		</subsets>
+		<levels>
+			<level>special</level>
+		</levels>
+		<groups>
+			<group>openjdk</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
+	<test>
 		<testCaseName>jdk_math</testCaseName>
 		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
 	$(JTREG_BASIC_OPTIONS) -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \


### PR DESCRIPTION
Also adds the -Xjit:enableAggressiveLiveness option although testing for
https://github.com/eclipse/openj9/issues/9651 showed it doesn't fix the
problem.

Issue https://github.com/eclipse/openj9/issues/8872

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>