### PR TITLE
Re-include hidden classes related testing

### DIFF
--- a/openjdk/ProblemList_openjdk15-openj9.txt
+++ b/openjdk/ProblemList_openjdk15-openj9.txt
@@ -91,13 +91,6 @@ java/lang/invoke/ArrayConstructorTest.java	https://github.com/AdoptOpenJDK/openj
 java/lang/invoke/CallerSensitiveAccess.java	https://github.com/eclipse/openj9/issues/6768	generic-all
 java/lang/invoke/ClassSpecializerTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/invoke/DefineClassTest.java		https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
-java/lang/invoke/defineHiddenClass/BasicTest.java https://github.com/eclipse/openj9/issues/9328   generic-all
-java/lang/invoke/defineHiddenClass/HiddenNestmateTest.java https://github.com/eclipse/openj9/issues/9328   generic-all
-java/lang/invoke/defineHiddenClass/LambdaNestedInnerTest.java https://github.com/eclipse/openj9/issues/9328   generic-all
-java/lang/invoke/defineHiddenClass/SelfReferenceDescriptor.java https://github.com/eclipse/openj9/issues/9328   generic-all
-java/lang/invoke/defineHiddenClass/TypeDescriptorTest.java https://github.com/eclipse/openj9/issues/9328   generic-all
-java/lang/invoke/defineHiddenClass/UnloadingTest.java https://github.com/eclipse/openj9/issues/9328   generic-all
-java/lang/invoke/defineHiddenClass/UnreflectTest.java https://github.com/eclipse/openj9/issues/9328   generic-all
 java/lang/invoke/DropLookupModeTest.java    https://github.com/eclipse/openj9/issues/8570   generic-all
 java/lang/invoke/ExplicitCastArgumentsTest.java		https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/invoke/FindAccessTest.java		https://github.com/eclipse/openj9/issues/6868	generic-all
@@ -136,7 +129,6 @@ java/lang/ref/FinalizerHistogramTest.java	https://github.com/AdoptOpenJDK/openjd
 java/lang/ref/NullQueue.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/ref/OOMEInReferenceHandler.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/ref/ReachabilityFenceTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
-java/lang/reflect/AccessibleObject/HiddenClassTest.java https://github.com/eclipse/openj9/issues/9328   generic-all
 java/lang/reflect/AccessibleObject/ModuleSetAccessibleTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/reflect/AccessibleObject/TrySetAccessibleTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/reflect/DefaultMethodMembers/FilterNotMostSpecific.java	https://github.com/eclipse/openj9/issues/7623	generic-all
@@ -310,7 +302,6 @@ jdk/internal/reflect/CallerSensitive/CheckCSMs.java	https://github.com/eclipse/o
 jdk/internal/reflect/constantPool/ConstantPoolTest.java	https://github.com/eclipse/openj9/issues/7249		generic-all
 
 sun/misc/SunMiscSignalTest.java		https://github.com/eclipse/openj9/issues/7264		generic-all
-sun/misc/UnsafeFieldOffsets.java	https://github.com/eclipse/openj9/issues/9657		generic-all
 sun/net/www/protocol/file/DirPermissionDenied.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/749 windows-all
 sun/nio/ch/TestMaxCachedBufferSize.java		https://github.com/eclipse/openj9/issues/5328		generic-all
 


### PR DESCRIPTION
Originally excluded via #1796

This testing needs to pass for the Java 15 release, or be excluded as
not-applicable to OpenJ9.

Although these tests don't all yet pass, I think they should be running since they need to be addressed for the Java 15 release. The OpenJDK testing already has 21 or more other failures, adding these won't impact the overall status.

A grinder shows the current status https://ci.eclipse.org/openj9/job/Grinder/1017