### PR TITLE
Excluding some hidden class tests on jdk15 for j9

### DIFF
--- a/openjdk/ProblemList_openjdk15-openj9.txt
+++ b/openjdk/ProblemList_openjdk15-openj9.txt
@@ -91,6 +91,12 @@ java/lang/invoke/ArrayConstructorTest.java	https://github.com/AdoptOpenJDK/openj
 java/lang/invoke/CallerSensitiveAccess.java	https://github.com/eclipse/openj9/issues/6768	generic-all
 java/lang/invoke/ClassSpecializerTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/invoke/DefineClassTest.java		https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
+java/lang/invoke/defineHiddenClass/BasicTest.java	https://github.com/eclipse/openj9/issues/10345	generic-all
+java/lang/invoke/defineHiddenClass/LambdaNestedInnerTest.java	https://github.com/eclipse/openj9/issues/10345	generic-all
+java/lang/invoke/defineHiddenClass/SelfReferenceDescriptor.java	https://github.com/eclipse/openj9/issues/10345	generic-all
+java/lang/invoke/defineHiddenClass/TypeDescriptorTest.java	https://github.com/eclipse/openj9/issues/10345	generic-all
+java/lang/invoke/defineHiddenClass/UnloadingTest.java	https://github.com/eclipse/openj9/issues/10345	generic-all
+java/lang/reflect/AccessibleObject/HiddenClassTest.java	https://github.com/eclipse/openj9/issues/10345	generic-all
 java/lang/invoke/DropLookupModeTest.java    https://github.com/eclipse/openj9/issues/8570   generic-all
 java/lang/invoke/ExplicitCastArgumentsTest.java		https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/invoke/FindAccessTest.java		https://github.com/eclipse/openj9/issues/6868	generic-all


### PR DESCRIPTION
Because the JEP required for these tests to work (371) has not
yet been fully implemented in OpenJ9.

See here for more details:
https://github.com/eclipse/openj9/issues/9328

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>