### PR TITLE
Revert "copy TAP for UNSTABLE builds"

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -259,7 +259,7 @@ def setupParallelEnv() {
 				childParams << string(name: 'RUNTIME_NAME', value: childTest)
 
 				parallel_tests[childTest] = {
-					build job: TEST_JOB_NAME, parameters: childParams, propagate: false
+					build job: TEST_JOB_NAME, parameters: childParams
 				}
 			}
 			parallel create_jobs
@@ -813,7 +813,6 @@ def run_parallel_tests() {
 					def buildId = jobInvocation.getNumber()
 					def name = cjob.value.getProjectName()
 					try {
-						echo "${name} #${buildId} completed with status ${cjob.value.getCurrentResult()}"
 						copyArtifacts (projectName: "${name}", selector: specific("${buildId}"), filter: "**/TestTargetResult.tap", target:"${name}/${buildId}")
 					} catch (Exception e) {
 						echo "Cannot copy TestTargetResult.tap from ${name} with buildid ${buildId} . Skipping copyArtifacts..."


### PR DESCRIPTION
Reverts AdoptOpenJDK/openjdk-tests#1860 due to https://github.com/eclipse/openj9/issues/10384