### PR TITLE
trim arch array values

### DIFF
--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -69,7 +69,7 @@ if (binding.hasVariable('GROUPS')) {
 
 
 if (binding.hasVariable('ARCH_OS_LIST')) {
-	ARCH_OS_LIST = ARCH_OS_LIST.split(',')
+	ARCH_OS_LIST = ARCH_OS_LIST.split(',')*.trim()
 } else {
 	ARCH_OS_LIST = [
 		'aarch32_linux',


### PR DESCRIPTION
To prevent spaces accidentally ending up in the names of new
jenkins jobs that we create here.

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>