### PR TITLE
Revert "Excluding some hidden class tests on jdk15 for j9"

### DIFF
--- a/openjdk/ProblemList_openjdk15-openj9.txt
+++ b/openjdk/ProblemList_openjdk15-openj9.txt
@@ -91,12 +91,6 @@ java/lang/invoke/ArrayConstructorTest.java	https://github.com/AdoptOpenJDK/openj
 java/lang/invoke/CallerSensitiveAccess.java	https://github.com/eclipse/openj9/issues/6768	generic-all
 java/lang/invoke/ClassSpecializerTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/invoke/DefineClassTest.java		https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
-java/lang/invoke/defineHiddenClass/BasicTest.java	https://github.com/eclipse/openj9/issues/10345	generic-all
-java/lang/invoke/defineHiddenClass/LambdaNestedInnerTest.java	https://github.com/eclipse/openj9/issues/10345	generic-all
-java/lang/invoke/defineHiddenClass/SelfReferenceDescriptor.java	https://github.com/eclipse/openj9/issues/10345	generic-all
-java/lang/invoke/defineHiddenClass/TypeDescriptorTest.java	https://github.com/eclipse/openj9/issues/10345	generic-all
-java/lang/invoke/defineHiddenClass/UnloadingTest.java	https://github.com/eclipse/openj9/issues/10345	generic-all
-java/lang/reflect/AccessibleObject/HiddenClassTest.java	https://github.com/eclipse/openj9/issues/10345	generic-all
 java/lang/invoke/DropLookupModeTest.java    https://github.com/eclipse/openj9/issues/8570   generic-all
 java/lang/invoke/ExplicitCastArgumentsTest.java		https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/invoke/FindAccessTest.java		https://github.com/eclipse/openj9/issues/6868	generic-all


### PR DESCRIPTION
Reverts AdoptOpenJDK/openjdk-tests#1934

Hidden classes is mostly implemented, and expected to be completed soon. We're coming up on Milestone 2 at the end of the week. We shouldn't be hiding failures, otherwise we'll end up shipping with problems.