### PR TITLE
Support & value in rerun link

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -788,6 +788,7 @@ def addGrinderLink() {
 	def url = "${HUDSON_URL}job/Grinder/parambuild/?"
 	int i = 1;
 	params.each { key, value ->
+		value = value.toString().replace("&", "%26")
 		url += "${key}=${value}"
 		if (i != params.size()) {
 			url += "&amp;"


### PR DESCRIPTION
& is special character in url. If value contains & (i.e.,
LABEL_ADDITION=ci.project.openj9&&!sw.os.cent.6&&!sw.os.rhel.6), it
should be encoded as %26

Signed-off-by: lanxia <lan_xia@ca.ibm.com>