### PR TITLE
Exclude Hidden class BasicTest and TypeDescriptorTest

### DIFF
--- a/openjdk/ProblemList_openjdk15-openj9.txt
+++ b/openjdk/ProblemList_openjdk15-openj9.txt
@@ -92,6 +92,8 @@ java/lang/invoke/CallerSensitiveAccess.java	https://github.com/eclipse/openj9/is
 java/lang/invoke/ClassSpecializerTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/invoke/DefineClassTest.java		https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/invoke/DropLookupModeTest.java    https://github.com/eclipse/openj9/issues/8570   generic-all
+java/lang/invoke/defineHiddenClass/BasicTest.java	https://github.com/eclipse/openj9/issues/10345	generic-all
+java/lang/invoke/defineHiddenClass/TypeDescriptorTest.java	https://github.com/eclipse/openj9/issues/10345	generic-all
 java/lang/invoke/ExplicitCastArgumentsTest.java		https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/invoke/FindAccessTest.java		https://github.com/eclipse/openj9/issues/6868	generic-all
 java/lang/invoke/LFCaching/LFMultiThreadCachingTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all


### PR DESCRIPTION
These tests assert identifier appended to hidden class name is the 
same format as hotspot. OpenJ9 has a slightly different format.

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>