### PR TITLE
Fail test build if cannot find a matching node on Jenkins

### DIFF
--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -132,6 +132,10 @@ if (PLATFORM_MAP.containsKey(params.PLATFORM)) {
     println "LABEL: ${LABEL}"
 
     stage('Queue') {
+        def nodes = nodesByLabel(LABEL).size()
+        if (nodes < 1) {
+            assert false : "Cannot find any machine that matches with the LABEL"    
+        }
         node(LABEL) {
             if (params.PLATFORM.contains('zos')) {
                 /* Ensure correct CC env */


### PR DESCRIPTION
Instead of waiting forever, fail test build if it cannot find a matching
node with the specified LABEL on Jenkins

Signed-off-by: lanxia <lan_xia@ca.ibm.com>