### PR TITLE
Get Dragonwell subrepos

### DIFF
--- a/openjdk/build.xml
+++ b/openjdk/build.xml
@@ -125,6 +125,14 @@
 						<move file="openjdktemp" tofile="openjdk-jdk"/>
 					</else>
 				</if>
+				<if>
+					<contains string="${env.JDK_REPO}" substring="dragonwell"/>
+					<then>
+						<exec executable="bash" failonerror="true" dir="openjdk-jdk">
+							<arg line="get_source_dragonwell.sh -s github" />
+						</exec>
+					</then>
+				</if>
 			</then>
 			<else>
 				<if>


### PR DESCRIPTION
Fix test failures under https://ci.adoptopenjdk.net/job/Test_openjdk8_dragonwell_sanity.openjdk_x86-64_linux/4/, which can't find the proper test files.

Signed-off-by: Sophia Guo <sophia.gwf@gmail.com>