### PR TITLE
Limit to clone submodules to dragonwell8 only.

### DIFF
--- a/openjdk/build.xml
+++ b/openjdk/build.xml
@@ -126,7 +126,7 @@
 					</else>
 				</if>
 				<if>
-					<contains string="${env.JDK_REPO}" substring="dragonwell"/>
+					<contains string="${env.JDK_REPO}" substring="dragonwell8"/>
 					<then>
 						<exec executable="bash" failonerror="true" dir="openjdk-jdk">
 							<arg line="get_source_dragonwell.sh -s github" />


### PR DESCRIPTION
Dragonwell 11 and up have the same directory structure as OpenJDK.

Fix #1958 

Signed-off-by: Sophia Guo <sophia.gwf@gmail.com>