### PR TITLE
Re-enable jdk/internal/loader/NativeLibraries/Main.java

### DIFF
--- a/openjdk/ProblemList_openjdk15-openj9.txt
+++ b/openjdk/ProblemList_openjdk15-openj9.txt
@@ -144,7 +144,6 @@ vm/JniInvocationTest.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/2
 ############################################################################
 
 # jdk_internal
-jdk/internal/loader/NativeLibraries/Main.java  https://github.com/eclipse/openj9/issues/9018  generic-all
 
 ############################################################################
 


### PR DESCRIPTION
Re-enable jdk/internal/loader/NativeLibraries/Main.java

depends on https://github.com/eclipse/openj9/pull/10653

Signed-off-by: Jason Feng <fengj@ca.ibm.com>