### PR TITLE
Add synthetic GC double map test to Mac OSX

### DIFF
--- a/functional/SyntheticGCWorkload/playlist.xml
+++ b/functional/SyntheticGCWorkload/playlist.xml
@@ -155,7 +155,7 @@
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -cp $(Q)$(TEST_RESROOT)$(D)SyntheticGCWorkload.jar$(Q) net.adoptopenjdk.casa.workload_sessions.Main $(TEST_RESROOT)/config/config_doubleMapStress.xml -n; \
 	${TEST_STATUS}</command>
 		<!-- Temporarily disable this test on AArch64; github.com/eclipse/openj9/issues/8034 -->
-		<platformRequirements>bits.64,os.linux,^arch.aarch64</platformRequirements>
+		<platformRequirements>bits.64,^os.aix,^os.win,^os.zos,^arch.aarch64</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>


### PR DESCRIPTION
Depends on: https://github.com/eclipse/omr/pull/5580
Depends on: https://github.com/eclipse/openj9/pull/10714

Signed-off-by: Igor Braga <higorb1@gmail.com>