### PR TITLE
Temporarily disable extended openjdk tests on openj9

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -97,6 +97,10 @@
 		<levels>
 			<level>extended</level>
 		</levels>
+		<!-- temporarily disable on openj9 due to https://github.com/eclipse/openj9/issues/10757 -->
+		<impls>
+			<impl>hotspot</impl>
+		</impls>
 		<groups>
 			<group>openjdk</group>
 		</groups>
@@ -118,6 +122,10 @@
 		<levels>
 			<level>extended</level>
 		</levels>
+		<!-- temporarily disable on openj9 due to https://github.com/eclipse/openj9/issues/10757 -->
+		<impls>
+			<impl>hotspot</impl>
+		</impls>
 		<groups>
 			<group>openjdk</group>
 		</groups>
@@ -139,6 +147,10 @@
 		<levels>
 			<level>extended</level>
 		</levels>
+		<!-- temporarily disable on openj9 due to https://github.com/eclipse/openj9/issues/10757 -->
+		<impls>
+			<impl>hotspot</impl>
+		</impls>
 		<groups>
 			<group>openjdk</group>
 		</groups>
@@ -182,6 +194,10 @@
 			<level>extended</level>
 		</levels>
 		<platformRequirements>^os.osx,^os.zos</platformRequirements>
+		<!-- temporarily disable on openj9 due to https://github.com/eclipse/openj9/issues/10757 -->
+		<impls>
+			<impl>hotspot</impl>
+		</impls>
 		<groups>
 			<group>openjdk</group>
 		</groups>
@@ -200,6 +216,10 @@
 		<levels>
 			<level>extended</level>
 		</levels>
+		<!-- temporarily disable on openj9 due to https://github.com/eclipse/openj9/issues/10757 -->
+		<impls>
+			<impl>hotspot</impl>
+		</impls>
 		<groups>
 			<group>openjdk</group>
 		</groups>
@@ -553,11 +573,15 @@
 		<levels>
 			<level>extended</level>
 		</levels>
+		<!-- temporarily disable on openj9 due to https://github.com/eclipse/openj9/issues/10757 -->
+		<impls>
+			<impl>hotspot</impl>
+		</impls>
 		<groups>
 			<group>openjdk</group>
 		</groups>
 	</test>
-		<test>
+	<test>
 		<testCaseName>jdk_security4</testCaseName>
 		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
 	$(JTREG_BASIC_OPTIONS) -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
@@ -571,6 +595,10 @@
 		<levels>
 			<level>extended</level>
 		</levels>
+		<!-- temporarily disable on openj9 due to https://github.com/eclipse/openj9/issues/10757 -->
+		<impls>
+			<impl>hotspot</impl>
+		</impls>
 		<groups>
 			<group>openjdk</group>
 		</groups>
@@ -693,6 +721,10 @@
 		<levels>
 			<level>extended</level>
 		</levels>
+		<!-- temporarily disable on openj9 due to https://github.com/eclipse/openj9/issues/10757 -->
+		<impls>
+			<impl>hotspot</impl>
+		</impls>
 		<groups>
 			<group>openjdk</group>
 		</groups>
@@ -711,6 +743,10 @@
 		<levels>
 			<level>extended</level>
 		</levels>
+		<!-- temporarily disable on openj9 due to https://github.com/eclipse/openj9/issues/10757 -->
+		<impls>
+			<impl>hotspot</impl>
+		</impls>
 		<groups>
 			<group>openjdk</group>
 		</groups>
@@ -729,6 +765,10 @@
 		<levels>
 			<level>extended</level>
 		</levels>
+		<!-- temporarily disable on openj9 due to https://github.com/eclipse/openj9/issues/10757 -->
+		<impls>
+			<impl>hotspot</impl>
+		</impls>
 		<groups>
 			<group>openjdk</group>
 		</groups>
@@ -765,6 +805,10 @@
 		<levels>
 			<level>extended</level>
 		</levels>
+		<!-- temporarily disable on openj9 due to https://github.com/eclipse/openj9/issues/10757 -->
+		<impls>
+			<impl>hotspot</impl>
+		</impls>
 		<groups>
 			<group>openjdk</group>
 		</groups>
@@ -876,6 +920,10 @@
 		<levels>
 			<level>extended</level>
 		</levels>
+		<!-- temporarily disable on openj9 due to https://github.com/eclipse/openj9/issues/10757 -->
+		<impls>
+			<impl>hotspot</impl>
+		</impls>
 		<groups>
 			<group>openjdk</group>
 		</groups>
@@ -948,6 +996,10 @@
 		<levels>
 			<level>extended</level>
 		</levels>
+		<!-- temporarily disable on openj9 due to https://github.com/eclipse/openj9/issues/10757 -->
+		<impls>
+			<impl>hotspot</impl>
+		</impls>
 		<groups>
 			<group>openjdk</group>
 		</groups>
@@ -991,6 +1043,10 @@
 		<levels>
 			<level>extended</level>
 		</levels>
+		<!-- temporarily disable on openj9 due to https://github.com/eclipse/openj9/issues/10757 -->
+		<impls>
+			<impl>hotspot</impl>
+		</impls>
 		<groups>
 			<group>openjdk</group>
 		</groups>
@@ -1012,6 +1068,10 @@
 		<levels>
 			<level>extended</level>
 		</levels>
+		<!-- temporarily disable on openj9 due to https://github.com/eclipse/openj9/issues/10757 -->
+		<impls>
+			<impl>hotspot</impl>
+		</impls>
 		<groups>
 			<group>openjdk</group>
 		</groups>
@@ -1055,6 +1115,10 @@
 		<levels>
 			<level>extended</level>
 		</levels>
+		<!-- temporarily disable on openj9 due to https://github.com/eclipse/openj9/issues/10757 -->
+		<impls>
+			<impl>hotspot</impl>
+		</impls>
 		<groups>
 			<group>openjdk</group>
 		</groups>
@@ -1076,6 +1140,10 @@
 		<levels>
 			<level>extended</level>
 		</levels>
+		<!-- temporarily disable on openj9 due to https://github.com/eclipse/openj9/issues/10757 -->
+		<impls>
+			<impl>hotspot</impl>
+		</impls>
 		<groups>
 			<group>openjdk</group>
 		</groups>


### PR DESCRIPTION
Temporarily disable the failed openjdk tests for openj9 to get a green baseline. We will investigate/triage these failures.

Related: https://github.com/eclipse/openj9/issues/10757

Signed-off-by: lanxia <lan_xia@ca.ibm.com>