### PR TITLE
Remove the logic of using master node to get user email

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -714,6 +714,12 @@ def getJDKImpl(jvm_version) {
 }
 
 def addJobDescription() {
+	if (params.PERSONAL_BUILD) {
+		// update build name if personal build
+		wrap([$class: 'BuildUser']) {
+			currentBuild.displayName = "#${BUILD_NUMBER} - ${BUILD_USER_EMAIL}"
+		}
+	}
 	def description = (currentBuild.description) ? currentBuild.description + "<br>" : ""
 	currentBuild.description = description \
 		+ "TARGET: ${params.TARGET}<br/>" \

--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -119,15 +119,6 @@ if ( !params.TARGET ) {
     assert false : "Please provide TARGET value"
 }
 
-if (params.PERSONAL_BUILD) {
-    node('master') {
-        // update build name if personal build
-        wrap([$class: 'BuildUser']) {
-            currentBuild.displayName = "#${BUILD_NUMBER} - ${BUILD_USER_EMAIL}"
-        }
-    }
-}
-
 def PLATFORMS = params.PLATFORM.trim().split("\\s*,\\s*");
 def JDK_VERSIONS = params.JDK_VERSION.trim().split("\\s*,\\s*");
 def JDK_IMPLS = params.JDK_IMPL.trim().split("\\s*,\\s*");


### PR DESCRIPTION
We use master node to get user email in Grinder (PERSONAL_BUILD is
enabled), but some Jenkins may not have master. Remove the logic of
using master node to get user email. We will get user email later when
the job is scheduled on a node.

Signed-off-by: lanxia <lan_xia@ca.ibm.com>