### PR TITLE
copy TAP if child is UNSTABLE

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -261,7 +261,7 @@ def setupParallelEnv() {
 				childParams << string(name: 'RUNTIME_NAME', value: childTest)
 
 				parallel_tests[childTest] = {
-					build job: TEST_JOB_NAME, parameters: childParams
+					build job: TEST_JOB_NAME, parameters: childParams, propagate: false
 				}
 			}
 			parallel create_jobs
@@ -807,12 +807,13 @@ def run_parallel_tests() {
 					def buildId = jobInvocation.getNumber()
 					def name = cjob.value.getProjectName()
 					try {
+						echo "${name} #${buildId} completed with status ${cjob.value.getCurrentResult()}"
 						copyArtifacts (projectName: "${name}", selector: specific("${buildId}"), filter: "**/TestTargetResult.tap", target:"${name}/${buildId}")
+						step([$class: "TapPublisher", testResults: "${name}/${buildId}/**/TestTargetResult.tap", outputTapToConsole: false, failIfNoResults: false])
 					} catch (Exception e) {
 						echo "Cannot copy TestTargetResult.tap from ${name} with buildid ${buildId} . Skipping copyArtifacts..."
 					}
 				}
-				step([$class: "TapPublisher", testResults: "**/TestTargetResult.tap", outputTapToConsole: false, failIfNoResults: false])
 			}	
 		}
 	}


### PR DESCRIPTION
-related: https://github.com/eclipse/openj9/issues/10384
-related: https://github.com/AdoptOpenJDK/openjdk-tests/pull/1935

We noticed an issue at https://github.com/eclipse/openj9/issues/10384 saying the parent copied some other unrelated children's TAP result. And we reverted https://github.com/AdoptOpenJDK/openjdk-tests/pull/1860. It turns out this is not the bug, we suspect it is a machine-related problem (workspace is not fully cleaned up so the current build has TAP from the previous build) but currently, that machine is unavailable so we can't reproduce the failed scenario. This issue is not seen on other platforms and on other windows machines.

In this PR, we process the TAP as soon as we copy one from the child, instead of processing all TAP results on the machine.
We can make sure all the TAP results posted are from children