### PR TITLE
Add api/java_lang/System to jck.sanity

### DIFF
--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -224,6 +224,20 @@
 		</groups>
 	</test>
 	<test>
+		<testCaseName>jck-runtime-api-java_lang-System</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>$(JCK_CMD_TEMPLATE) -test-args=$(Q)tests=api/java_lang/System,jckRoot=$(JCK_ROOT),jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>jck</group>
+		</groups>
+	</test>
+	<test>
 		<testCaseName>jck-runtime-api-java_lang-constant</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>


### PR DESCRIPTION
Added `api/java_lang/System to jck.sanity`.

Note: verified in a personal build.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>