### PR TITLE
added JVM_NATIVE_OPTIONS setting for ibm

### DIFF
--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -124,7 +124,8 @@ ifneq ($(JDK_VERSION),8)
 		endif
 		ifeq ($(JDK_IMPL), hotspot)
 			JVM_NATIVE_OPTIONS := -nativepath:"$(TESTIMAGE_PATH)$(D)hotspot$(D)jtreg$(D)native"
-		else ifeq ($(JDK_IMPL), openj9)
+		# else if JDK_IMPL is openj9 or ibm
+		else ifneq ($(filter openj9 ibm, $(JDK_IMPL)),)
 			JVM_NATIVE_OPTIONS := -nativepath:"$(TESTIMAGE_PATH)$(D)openj9"
 		endif
 		ifneq (,$(findstring /hotspot/, $(JDK_CUSTOM_TARGET))) 


### PR DESCRIPTION
- added JVM_NATIVE_OPTIONS setting for ibm
- related to issue: AdoptOpenJDK/openjdk-tests#1964
Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>