### PR TITLE
Remove some java/foreign excludes

### DIFF
--- a/openjdk/ProblemList_openjdk15-openj9.txt
+++ b/openjdk/ProblemList_openjdk15-openj9.txt
@@ -309,8 +309,6 @@ vm/verifier/VerifyProtectedConstructor.java	https://github.com/eclipse/openj9/is
 java/foreign/TestArrays.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1701 generic-all
 java/foreign/TestLayouts.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1701 generic-all
 java/foreign/TestLayoutPaths.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1701	generic-all
-java/foreign/TestByteBuffer.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1702	generic-all
-java/foreign/TestLayoutConstants.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1702	generic-all
 java/foreign/TestNative.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1920 generic-all
 
 ############################################################################


### PR DESCRIPTION
See https://github.com/eclipse/openj9/issues/10828

These tests were excluded due to intermittent failures, which may have been machine issues. If there was a problem, it may be fixed now. We can remove the excludes and see how it goes before deciding what to do.