### PR TITLE
WIP: Active Node Timeout for Test Jobs

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -800,6 +800,11 @@ def run_parallel_tests() {
 	if (params.PARALLEL && params.PARALLEL != "None") {
 		stage ("Parallel Tests") {
 			def childJobs = parallel parallel_tests
+			if (params.ACTIVE_NODE_TIMEOUT && params.ACTIVE_NODE_TIMEOUT.isInteger()) {
+				waitForANodeToBecomeActive("$LABEL", params.ACTIVE_NODE_TIMEOUT)
+			} else {
+				waitForANodeToBecomeActive("$LABEL", "0")
+			}
 			node("$LABEL") {	
 				childJobs.each {
 					cjob ->
@@ -817,6 +822,32 @@ def run_parallel_tests() {
 			}	
 		}
 	}
+}
+
+def waitForANodeToBecomeActive(def label, String activeNodeTimeoutString) {
+    def nodes = nodesByLabel(label).size()
+    if (nodes < 1) {
+        // If no active node matches the label, we see if there's a timeout value set.
+        // If there is, we wait and check again periodically. If not, we fail immediately.
+
+        boolean didnt_find_node = true
+
+        int activeNodeTimeout = activeNodeTimeoutString as Integer
+
+        echo "Cannot find an active node matching this label: " + label
+        echo "Will now wait until " + activeNodeTimeoutString + " minutes (ACTIVE_NODE_TIMEOUT) has passed, re-checking periodically."
+
+        while (activeNodeTimeout > 0) {
+            sleep(60 * 1000) // 1 minute sleep
+            activeNodeTimeout--
+            if (nodesByLabel(LABEL).size() > 0) {
+                echo "A node matching the aforementioned label has become active."
+                return
+            }
+        }
+
+        assert false : "Timed out waiting for a machine that matches the LABEL: " + LABEL + " to become active."
+    }
 }
 
 def getGitRepoBranch(ownerBranch, defaultOwnerBranch, repo) {

--- a/buildenv/jenkins/getDependency
+++ b/buildenv/jenkins/getDependency
@@ -3,6 +3,11 @@
 LABEL='ci.role.test&&hw.arch.x86&&sw.os.linux'
 
 stage('Queue') {
+    if (params.ACTIVE_NODE_TIMEOUT && params.ACTIVE_NODE_TIMEOUT.isInteger()) {
+        waitForANodeToBecomeActive("$LABEL", params.ACTIVE_NODE_TIMEOUT)
+    } else {
+        waitForANodeToBecomeActive("$LABEL", "0")
+    }
     node("$LABEL") {
        cleanWs()
        testBuild()
@@ -43,6 +48,32 @@ def testBuild() {
 			cleanWs()
 		}
 	}
+}
+
+def waitForANodeToBecomeActive(def label, String activeNodeTimeoutString) {
+    def nodes = nodesByLabel(label).size()
+    if (nodes < 1) {
+        // If no active node matches the label, we see if there's a timeout value set.
+        // If there is, we wait and check again periodically. If not, we fail immediately.
+
+        boolean didnt_find_node = true
+
+        int activeNodeTimeout = activeNodeTimeoutString as Integer
+
+        echo "Cannot find an active node matching this label: " + label
+        echo "Will now wait until " + activeNodeTimeoutString + " minutes (ACTIVE_NODE_TIMEOUT) has passed, re-checking periodically."
+
+        while (activeNodeTimeout > 0) {
+            sleep(60 * 1000) // 1 minute sleep
+            activeNodeTimeout--
+            if (nodesByLabel(LABEL).size() > 0) {
+                echo "A node matching the aforementioned label has become active."
+                return
+            }
+        }
+
+        assert false : "Cannot find any machine that matches the LABEL: " + LABEL
+    }
 }
 
 return this

--- a/buildenv/jenkins/getTRSSOutput
+++ b/buildenv/jenkins/getTRSSOutput
@@ -3,6 +3,11 @@
 LABEL='ci.role.test&&hw.arch.x86&&sw.os.linux'
 
 stage('Queue') {
+    if (params.ACTIVE_NODE_TIMEOUT && params.ACTIVE_NODE_TIMEOUT.isInteger()) {
+        waitForANodeToBecomeActive("$LABEL", params.ACTIVE_NODE_TIMEOUT)
+    } else {
+        waitForANodeToBecomeActive("$LABEL", "0")
+    }
 	node("$LABEL") {
 		cleanWs()
 		getTRSSOutput()
@@ -87,5 +92,32 @@ def getTRSSOutput() {
 		}
 	}
 }
+
+def waitForANodeToBecomeActive(def label, String activeNodeTimeoutString) {
+    def nodes = nodesByLabel(label).size()
+    if (nodes < 1) {
+        // If no active node matches the label, we see if there's a timeout value set.
+        // If there is, we wait and check again periodically. If not, we fail immediately.
+
+        boolean didnt_find_node = true
+
+        int activeNodeTimeout = activeNodeTimeoutString as Integer
+
+        echo "Cannot find an active node matching this label: " + label
+        echo "Will now wait until " + activeNodeTimeoutString + " minutes (ACTIVE_NODE_TIMEOUT) has passed, re-checking periodically."
+
+        while (activeNodeTimeout > 0) {
+            sleep(60 * 1000) // 1 minute sleep
+            activeNodeTimeout--
+            if (nodesByLabel(LABEL).size() > 0) {
+                echo "A node matching the aforementioned label has become active."
+                return
+            }
+        }
+
+        assert false : "Cannot find any machine that matches the LABEL: " + LABEL
+    }
+}
+
 
 return this

--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -189,8 +189,31 @@ if (JDK_VERSIONS.size() > 1 || JDK_IMPLS.size() > 1 || PLATFORMS.size() >1 || PL
         stage('Queue') {
             def nodes = nodesByLabel(LABEL).size()
             if (nodes < 1) {
-                assert false : "Cannot find any machine that matches with the LABEL"    
+                // If no active node matches the label, we see if there's a timeout value set.
+                // If there is, we wait and check again periodically. If not, we fail immediately.
+                
+                boolean didnt_find_node = true
+
+                if (params.ACTIVE_NODE_TIMEOUT && params.ACTIVE_NODE_TIMEOUT.isInteger()) {
+                    int activeNodeTimeout = buildConfig.ACTIVE_NODE_TIMEOUT as Integer
+                    echo "Cannot find an active node matching this label: " + label
+                    echo "Will now wait until " + activeNodeTimeoutString + " minutes (ACTIVE_NODE_TIMEOUT) has passed, re-checking periodically."
+                    while (activeNodeTimeout > 0) {
+                        sleep(60 * 1000) // 1 minute sleep
+                        activeNodeTimeout--
+                        if (nodesByLabel(LABEL).size() > 0) {
+                            didnt_find_node = false
+                            activeNodeTimeout = 0
+                            echo "A node matching the aforementioned label has become active."
+                        }
+                    }
+                }
+
+                if (didnt_find_node) {
+                    assert false : "Cannot find any machine that matches the LABEL: " + LABEL
+                }
             }
+
             node(LABEL) {
                 if (params.PLATFORM.contains('zos')) {
                     /* Ensure correct CC env */

--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -166,6 +166,7 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							stringParam('JVM_OPTIONS', "", "Use this to replace the test original command line options")
 							stringParam('ITERATIONS',"1", "Number of times to repeat execution of test target")
 							stringParam('LABEL', "", "Jenkins node label to run on. Leave this blank for the default value specified in PLATFORM_MAP. Set to node name to run on a particular machine.")
+							stringParam('ACTIVE_NODE_TIMEOUT', "", "Number of minutes we will wait for a label-matching node to become active.")
 							stringParam('LABEL_ADDITION', "", "Additional label(s) to append to LABEL. Usually when you want to add a label to the default value.")
 							booleanParam('DOCKER_REQUIRED', DOCKER_REQUIRED, "Is docker required?")
 							stringParam('DOCKERIMAGE_TAG', DOCKERIMAGE_TAG, "Docker image tag")


### PR DESCRIPTION
Currently, if there are no active nodes that match a test job's
labels, we fail immediately.

This change is intended to add a modifiable timeout value, so if we
don't find an active node that matches the test job's labels, we
wait for x minutes, periodically checking to see if a node matching
the labels has come online.


Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>