### PR TITLE
Use Affinity & Update Version for Liberty

### DIFF
--- a/perf/affinity.sh
+++ b/perf/affinity.sh
@@ -319,6 +319,7 @@ function setServerDBAffinities() {
 	echo "DB will be using node: DB_NODE=${DB_NODE}"
 	echo "DB affinity command is: DB_AFFINITY_CMD=${DB_AFFINITY_CMD}"
 
+	affinity_tool_install_check
 	echo "##### Setting Affinities: Done"
 }
 

--- a/perf/liberty/build.xml
+++ b/perf/liberty/build.xml
@@ -25,8 +25,6 @@
 	<property name="SRC" location="." />
 	<property environment="env" />
 	
-	<property name="BM_VERSION" value="openliberty-19.0.0.4" />	
-	
 	<target name="init">
 		<mkdir dir="${DEST}" />
 	</target>

--- a/perf/liberty/configs/dt7_sufp.sh
+++ b/perf/liberty/configs/dt7_sufp.sh
@@ -18,6 +18,18 @@ echo "***** Running Benchmark Script *****"
 
 echo "Current Dir: $(pwd)"
 
+TEST_RESROOT=${1}
+
+. "$TEST_RESROOT/../../../openjdk-tests/perf/affinity.sh" > /dev/null 2>&1
+setServerDBLoadAffinities --server-physcpu-num $SERVER_PHYSCPU_NUM --smt $SMT > /dev/null 2>&1
+
+export AFFINITY=${SERVER_AFFINITY_CMD}
+echo "AFFINITY=${AFFINITY}"
+
+if [ -z "${AFFINITY}" ]; then
+    echo "Warning!!! Affinity is NOT set. Affinity tool may NOT be installed/supported."
+fi
+
 #TODO: Remove these once the use of STAF has been eliminated from all the benchmark scripts
 export PATH=/usr/local/staf/bin:$PATH
 export LD_LIBRARY_PATH=/usr/local/staf/lib:$LD_LIBRARY_PATH
@@ -49,16 +61,13 @@ export REQUEST_CORE=""
 export SCENARIO="DayTrader7"
 export SERVER_NAME="LibertySUDTServer-$JDK"
 export PETERFP="false"
-export RESULTS_MACHINE="lowry1"
+export RESULTS_MACHINE="$(hostname)"
 export RESULTS_DIR="libertyResults"
 export LIBERTY_HOST="$(hostname)"
 export LAUNCH_SCRIPT="server"
-export LIBERTY_BINARIES_DIR="$1/libertyBinaries"
-export LIBERTY_VERSION="openliberty-19.0.0.4"
+export LIBERTY_BINARIES_DIR="${TEST_RESROOT}/libertyBinaries"
+export LIBERTY_VERSION="openliberty-20.0.0.10"
 export APP_VERSION="daytrader-ee7"
 export WLP_SKIP_MAXPERMSIZE="1"
 
-#TODO: Need to soft-code these configs. Need to add various affinity tools in the perf pre-reqs ()
-export AFFINITY=""
-
-bash ${1}/scripts/bin/sufp_benchmark.sh
+bash ${TEST_RESROOT}/scripts/bin/sufp_benchmark.sh

--- a/perf/liberty/configs/dt7_throughput.sh
+++ b/perf/liberty/configs/dt7_throughput.sh
@@ -18,6 +18,21 @@ echo "***** Running Benchmark Script *****"
 
 echo "Current Dir: $(pwd)"
 
+TEST_RESROOT=${1}
+
+. "$TEST_RESROOT/../../../openjdk-tests/perf/affinity.sh" > /dev/null 2>&1
+setServerDBLoadAffinities --server-physcpu-num $SERVER_PHYSCPU_NUM --smt $SMT > /dev/null 2>&1
+
+#TODO: We'll need to add affinity variables for client and DB in the scripts if we decide to run
+# all components (Server, Client & DB) on one machine in order to isolate them. Currently, scripts just 
+# have affinity vars for server since we always ran server on another machine before.
+export AFFINITY=${SERVER_AFFINITY_CMD}
+echo "AFFINITY=${AFFINITY}"
+
+if [ -z "${AFFINITY}" ]; then
+    echo "Warning!!! Affinity is NOT set. Affinity tool may NOT be installed/supported."
+fi
+
 #TODO: Remove these once the use of STAF has been eliminated from all the benchmark scripts
 export PATH=/usr/local/staf/bin:$PATH
 export LD_LIBRARY_PATH=/usr/local/staf/lib:$LD_LIBRARY_PATH
@@ -48,7 +63,7 @@ export CLIENT="$(hostname)"
 export DB_MACHINE="$(hostname)"
 export LIBERTY_HOST="$(hostname)"
 
-export CLIENT_WORK_DIR="${1}/liberty-client"
+export CLIENT_WORK_DIR="${TEST_RESROOT}/liberty-client"
 export DB_SERVER_WORKDIR="${CLIENT_WORK_DIR}"
 export DATABASE="derby"
 export DB2_HOME="/home/db2inst1/"
@@ -62,7 +77,7 @@ export PROFILING_TOOL=""
 export PROFILING_JAVA_OPTION=""
 export LIBERTY_PORT="9080"
 export LARGE_THREAD_POOL="true"
-export JMETER_LOC="${1}/JMeter/apache-jmeter-3.3/bin/jmeter"
+export JMETER_LOC="${TEST_RESROOT}/JMeter/apache-jmeter-3.3/bin/jmeter"
 export JMETER_INSTANCES=""
 export SERVER_XML=""
 export THROUGHPUT_DRIVER="jmeter"
@@ -75,11 +90,8 @@ export CLEAN_RUN="true"
 export SETUP_ONLY="false"
 export NO_SETUP="false"
 export LAUNCH_SCRIPT="server"
-export LIBERTY_BINARIES_DIR="$1/libertyBinaries"
-export LIBERTY_VERSION="openliberty-19.0.0.4"
+export LIBERTY_BINARIES_DIR="${TEST_RESROOT}/libertyBinaries"
+export LIBERTY_VERSION="openliberty-20.0.0.10"
 export GCMV_ENABLED="false"
 
-#TODO: Need to soft-code these configs. Need to add various affinity tools in the perf pre-reqs ()
-export AFFINITY=""
-
-bash ${1}/scripts/bin/throughput_benchmark.sh 
+bash ${TEST_RESROOT}/scripts/bin/throughput_benchmark.sh

--- a/perf/liberty/playlist.xml
+++ b/perf/liberty/playlist.xml
@@ -16,7 +16,7 @@
 	xsi:noNamespaceSchemaLocation="../../TKG/playlist.xsd">
 	<test>
 		<testCaseName>liberty-dt7-startup</testCaseName>
-		<command>bash $(Q)$(TEST_RESROOT)$(D)configs$(D)dt7_sufp.sh$(Q) $(TEST_RESROOT); \
+		<command>export SERVER_PHYSCPU_NUM=2; export SMT=true; bash $(Q)$(TEST_RESROOT)$(D)configs$(D)dt7_sufp.sh$(Q) $(TEST_RESROOT); \
 		${TEST_STATUS}
 		</command>
 		<!-- scripts are only tested on linux -->
@@ -30,7 +30,7 @@
 	</test>
 	<test>
 		<testCaseName>liberty-dt7-throughput</testCaseName>
-		<command>bash $(Q)$(TEST_RESROOT)$(D)configs$(D)dt7_throughput.sh$(Q) $(TEST_RESROOT); \
+		<command>export SERVER_PHYSCPU_NUM=2; export SMT=true; bash $(Q)$(TEST_RESROOT)$(D)configs$(D)dt7_throughput.sh$(Q) $(TEST_RESROOT); \
 		${TEST_STATUS}
 		</command>
 		<!-- scripts are only tested on linux -->

--- a/perf/liberty/scripts/bin/configure_liberty.sh
+++ b/perf/liberty/scripts/bin/configure_liberty.sh
@@ -178,10 +178,11 @@ echoAndRunCmd "mkdir -p ${DEST} ${LIBERTY_DEP_CACHE_LOCATION}"
 ##########################
 
 unsetVars
-APP_URL="https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/2019-04-19_0642/openliberty-19.0.0.4.zip"
+#Note: We need to use "All GA Features" package as "Web Profile 8" package doesn't have all the features required for DayTrader7.
+APP_URL="https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/2020-09-15_1100/openliberty-20.0.0.10.zip"
 APP_ARCHIVE="$(basename ${APP_URL})"
 EXTRACT_ORIGINAL_NAME="wlp"
-EXTRACT_NEW_NAME="openliberty-19.0.0.4"
+EXTRACT_NEW_NAME="openliberty-20.0.0.10"
 APP_DEST="${DEST}/libertyBinaries"
 downloadDepencies
 

--- a/perf/liberty/scripts/bin/database_utils.sh
+++ b/perf/liberty/scripts/bin/database_utils.sh
@@ -32,12 +32,24 @@ configureDB()
 		if [[ "${SCENARIO}" = DayTrader7 ]]; then		
 			
 			echo "SCENARIO=${SCENARIO}"
-			DB_FILE="${LIBERTY_DIR}/usr/shared/resources/data/tradedb7/service.properties"
 			
-			if [ -e "${DB_FILE}" ]; then
+
+			#After upgrading from 19.0.0.4 to 20.0.0.10, I noticed that the DB_FILE location has changed.
+			#In 19.0.0.4, it used to be ${LIBERTY_DIR}/usr/shared/resources/data/tradedb7/service.properties irrespective of the server name.
+			#In 20.0.0.10, it depends on the server name. For example:
+			#${LIBERTY_DIR}/usr/servers/${SERVER_NAME}/tradedb7/service.properties
+			#${LIBERTY_DIR}/usr/servers/${SERVER_NAME}/DB_NAME_HERE/service.properties
+			#TODO: Need a more reliable way to find this file as location of service.properties changes according to the SERVER_NAME
+			#and we don't have that at build stage. Might need to move this to run step later. Since we're only running DayTrader7 as
+			#of now, we'll be okay since it's the same service.properties file for both startup and throughput. Once we run 
+			#other apps, then this needs to be updated.
+			
+			DB_FILE=`find ${LIBERTY_DIR} -name 'service.properties' | grep service.properties | head -n 1`
+			
+			if [ ! -z "${DB_FILE}" ]; then
 				echo "DB_FILE=${DB_FILE} exists! No need to configure database"
 			else		
-				echo "DB_FILE=${DB_FILE} doesn't exist! Need to configure database"		
+				echo "service.properties doesn't exist! Need to configure database"		
 				
 				startLibertyServer 1
 				PORT="9080"

--- a/perf/run_with_affinity.sh
+++ b/perf/run_with_affinity.sh
@@ -45,12 +45,12 @@ while [ -n "$1" ]; do
 done
 	
 . "${TEST_ROOT}/perf/affinity.sh" > /dev/null 2>&1
-setServerLoadAffinities --server-physcpu-num $SERVER_PHYSCPU_NUM --smt $SMT > /dev/null 2>&1
+setServerDBLoadAffinities --server-physcpu-num $SERVER_PHYSCPU_NUM --smt $SMT > /dev/null 2>&1
 
 if [ -z "${SERVER_AFFINITY_CMD}" ]; then
     echo "Warning!!! Affinity is NOT set. Affinity tool may NOT be installed/supported."
 fi
-   
+
 EXEC_CMD_WITH_AFFINITY="${SERVER_AFFINITY_CMD} ${EXEC_CMD}"
 echo "Running EXEC_CMD_WITH_AFFINITY=${EXEC_CMD_WITH_AFFINITY}"
 


### PR DESCRIPTION
	• Updated Liberty from 19.0.0.4 to latest 20.0.0.10
	• Used affinity to launch Liberty server to get more reliable numbers
	• Corrected results machine name to localhost
	• Updated database utils file to handle new Liberty version
	• Fixed a bug in affinity script

Issues:
https://github.com/AdoptOpenJDK/openjdk-tests/issues/1587
https://github.com/AdoptOpenJDK/TKG/issues/34

Signed-off-by: Piyush Gupta <piyush286@gmail.com>