### PR TITLE
Do not wait for active docker nodes

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -800,10 +800,12 @@ def run_parallel_tests() {
 	if (params.PARALLEL && params.PARALLEL != "None") {
 		stage ("Parallel Tests") {
 			def childJobs = parallel parallel_tests
-			if (params.ACTIVE_NODE_TIMEOUT && params.ACTIVE_NODE_TIMEOUT.isInteger()) {
-				waitForANodeToBecomeActive("$LABEL", params.ACTIVE_NODE_TIMEOUT)
-			} else {
-				waitForANodeToBecomeActive("$LABEL", "0")
+			if (!(params.DOCKER_REQUIRED || "$LABEL".contains("docker"))) {
+				if (params.containsKey("ACTIVE_NODE_TIMEOUT") && params.ACTIVE_NODE_TIMEOUT.isInteger()) {
+					waitForANodeToBecomeActive("$LABEL", params.ACTIVE_NODE_TIMEOUT)
+				} else {
+					waitForANodeToBecomeActive("$LABEL", "0")
+				}
 			}
 			node("$LABEL") {	
 				childJobs.each {

--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -188,7 +188,7 @@ if (JDK_VERSIONS.size() > 1 || JDK_IMPLS.size() > 1 || PLATFORMS.size() >1 || PL
 
         stage('Queue') {
             def nodes = nodesByLabel(LABEL).size()
-            if (nodes < 1) {
+            if ((nodes < 1) && !(params.DOCKER_REQUIRED || LABEL.contains("docker"))) {
                 // If no active node matches the label, we see if there's a timeout value set.
                 // If there is, we wait and check again periodically. If not, we fail immediately.
                 


### PR DESCRIPTION
Docker nodes are often spun up as needed, so waiting for one to
become active will result in us waiting forever.

Signed-off-by: Adam Farley <adfarley@redhat.com>