### PR TITLE
disable aot tests in jvm_compiler for openj9

### DIFF
--- a/openjdk/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/ProblemList_openjdk11-openj9.txt
@@ -285,3 +285,68 @@ sun/nio/ch/TestMaxCachedBufferSize.java		https://github.com/eclipse/openj9/issue
 vm/verifier/VerifyProtectedConstructor.java	https://github.com/eclipse/openj9/issues/7336	generic-all
 
 ############################################################################
+
+# jvm_compiler
+
+compiler/aot/DeoptimizationTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/RecompilationTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/SharedUsageTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeDynamic2CompiledTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeDynamic2InterpretedTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/TestHeapBase.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeDynamic2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeDynamic2NativeTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeInterface2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeInterface2CompiledTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeInterface2InterpretedTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeInterface2NativeTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeSpecial2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeSpecial2CompiledTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeSpecial2InterpretedTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeSpecial2NativeTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeStatic2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeStatic2CompiledTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeStatic2InterpretedTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeStatic2NativeTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeVirtual2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeVirtual2CompiledTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeVirtual2InterpretedTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeVirtual2NativeTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromCompiled/CompiledInvokeDynamic2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromCompiled/CompiledInvokeInterface2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromCompiled/CompiledInvokeSpecial2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromCompiled/CompiledInvokeStatic2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromCompiled/CompiledInvokeVirtual2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromInterpreted/InterpretedInvokeDynamic2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromInterpreted/InterpretedInvokeInterface2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromInterpreted/InterpretedInvokeSpecial2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromInterpreted/InterpretedInvokeStatic2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromInterpreted/InterpretedInvokeVirtual2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromNative/NativeInvokeSpecial2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromNative/NativeInvokeStatic2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromNative/NativeInvokeVirtual2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/DisabledAOTWithLibraryTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/IncorrectAOTLibraryTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/MultipleAOTLibraryTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/NonExistingAOTLibraryTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/SingleAOTLibraryTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/SingleAOTOptionTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/AtFileTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/ClasspathOptionUnknownClassTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/CompileClassTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/CompileClassWithDebugTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/CompileDirectoryTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/CompileJarTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/CompileModuleTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/IgnoreErrorsTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/ListOptionNotExistingTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/ListOptionTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/ListOptionWrongFileTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/fingerprint/SelfChanged.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/fingerprint/SelfChangedCDS.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/fingerprint/SuperChanged.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/verification/ClassAndLibraryNotMatchTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/verification/vmflags/NotTrackedFlagTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/verification/vmflags/TrackedFlagTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+
+############################################################################

--- a/openjdk/ProblemList_openjdk12-openj9.txt
+++ b/openjdk/ProblemList_openjdk12-openj9.txt
@@ -336,3 +336,68 @@ com/sun/net/httpserver/Test1.java https://github.com/eclipse/openj9/issues/4125 
 vm/verifier/VerifyProtectedConstructor.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/585	generic-all
 
 ############################################################################
+
+# jvm_compiler
+
+compiler/aot/DeoptimizationTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/RecompilationTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/SharedUsageTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeDynamic2CompiledTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeDynamic2InterpretedTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/TestHeapBase.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeDynamic2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeDynamic2NativeTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeInterface2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeInterface2CompiledTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeInterface2InterpretedTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeInterface2NativeTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeSpecial2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeSpecial2CompiledTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeSpecial2InterpretedTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeSpecial2NativeTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeStatic2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeStatic2CompiledTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeStatic2InterpretedTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeStatic2NativeTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeVirtual2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeVirtual2CompiledTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeVirtual2InterpretedTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeVirtual2NativeTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromCompiled/CompiledInvokeDynamic2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromCompiled/CompiledInvokeInterface2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromCompiled/CompiledInvokeSpecial2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromCompiled/CompiledInvokeStatic2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromCompiled/CompiledInvokeVirtual2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromInterpreted/InterpretedInvokeDynamic2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromInterpreted/InterpretedInvokeInterface2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromInterpreted/InterpretedInvokeSpecial2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromInterpreted/InterpretedInvokeStatic2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromInterpreted/InterpretedInvokeVirtual2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromNative/NativeInvokeSpecial2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromNative/NativeInvokeStatic2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromNative/NativeInvokeVirtual2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/DisabledAOTWithLibraryTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/IncorrectAOTLibraryTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/MultipleAOTLibraryTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/NonExistingAOTLibraryTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/SingleAOTLibraryTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/SingleAOTOptionTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/AtFileTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/ClasspathOptionUnknownClassTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/CompileClassTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/CompileClassWithDebugTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/CompileDirectoryTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/CompileJarTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/CompileModuleTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/IgnoreErrorsTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/ListOptionNotExistingTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/ListOptionTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/ListOptionWrongFileTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/fingerprint/SelfChanged.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/fingerprint/SelfChangedCDS.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/fingerprint/SuperChanged.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/verification/ClassAndLibraryNotMatchTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/verification/vmflags/NotTrackedFlagTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/verification/vmflags/TrackedFlagTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+
+############################################################################

--- a/openjdk/ProblemList_openjdk13-openj9.txt
+++ b/openjdk/ProblemList_openjdk13-openj9.txt
@@ -288,3 +288,68 @@ sun/nio/ch/TestMaxCachedBufferSize.java		https://github.com/eclipse/openj9/issue
 vm/verifier/VerifyProtectedConstructor.java	https://github.com/eclipse/openj9/issues/7336	generic-all
 
 ############################################################################
+
+# jvm_compiler
+
+compiler/aot/DeoptimizationTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/RecompilationTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/SharedUsageTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeDynamic2CompiledTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeDynamic2InterpretedTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/TestHeapBase.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeDynamic2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeDynamic2NativeTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeInterface2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeInterface2CompiledTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeInterface2InterpretedTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeInterface2NativeTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeSpecial2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeSpecial2CompiledTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeSpecial2InterpretedTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeSpecial2NativeTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeStatic2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeStatic2CompiledTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeStatic2InterpretedTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeStatic2NativeTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeVirtual2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeVirtual2CompiledTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeVirtual2InterpretedTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeVirtual2NativeTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromCompiled/CompiledInvokeDynamic2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromCompiled/CompiledInvokeInterface2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromCompiled/CompiledInvokeSpecial2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromCompiled/CompiledInvokeStatic2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromCompiled/CompiledInvokeVirtual2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromInterpreted/InterpretedInvokeDynamic2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromInterpreted/InterpretedInvokeInterface2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromInterpreted/InterpretedInvokeSpecial2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromInterpreted/InterpretedInvokeStatic2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromInterpreted/InterpretedInvokeVirtual2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromNative/NativeInvokeSpecial2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromNative/NativeInvokeStatic2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromNative/NativeInvokeVirtual2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/DisabledAOTWithLibraryTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/IncorrectAOTLibraryTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/MultipleAOTLibraryTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/NonExistingAOTLibraryTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/SingleAOTLibraryTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/SingleAOTOptionTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/AtFileTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/ClasspathOptionUnknownClassTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/CompileClassTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/CompileClassWithDebugTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/CompileDirectoryTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/CompileJarTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/CompileModuleTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/IgnoreErrorsTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/ListOptionNotExistingTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/ListOptionTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/ListOptionWrongFileTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/fingerprint/SelfChanged.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/fingerprint/SelfChangedCDS.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/fingerprint/SuperChanged.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/verification/ClassAndLibraryNotMatchTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/verification/vmflags/NotTrackedFlagTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/verification/vmflags/TrackedFlagTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+
+############################################################################

--- a/openjdk/ProblemList_openjdk14-openj9.txt
+++ b/openjdk/ProblemList_openjdk14-openj9.txt
@@ -301,3 +301,68 @@ java/foreign/TestLayoutConstants.java	https://github.com/AdoptOpenJDK/openjdk-te
 java/foreign/TestNative.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1920 generic-all
 
 ############################################################################
+
+# jvm_compiler
+
+compiler/aot/DeoptimizationTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/RecompilationTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/SharedUsageTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeDynamic2CompiledTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeDynamic2InterpretedTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/TestHeapBase.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeDynamic2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeDynamic2NativeTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeInterface2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeInterface2CompiledTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeInterface2InterpretedTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeInterface2NativeTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeSpecial2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeSpecial2CompiledTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeSpecial2InterpretedTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeSpecial2NativeTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeStatic2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeStatic2CompiledTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeStatic2InterpretedTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeStatic2NativeTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeVirtual2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeVirtual2CompiledTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeVirtual2InterpretedTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeVirtual2NativeTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromCompiled/CompiledInvokeDynamic2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromCompiled/CompiledInvokeInterface2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromCompiled/CompiledInvokeSpecial2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromCompiled/CompiledInvokeStatic2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromCompiled/CompiledInvokeVirtual2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromInterpreted/InterpretedInvokeDynamic2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromInterpreted/InterpretedInvokeInterface2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromInterpreted/InterpretedInvokeSpecial2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromInterpreted/InterpretedInvokeStatic2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromInterpreted/InterpretedInvokeVirtual2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromNative/NativeInvokeSpecial2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromNative/NativeInvokeStatic2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromNative/NativeInvokeVirtual2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/DisabledAOTWithLibraryTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/IncorrectAOTLibraryTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/MultipleAOTLibraryTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/NonExistingAOTLibraryTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/SingleAOTLibraryTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/SingleAOTOptionTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/AtFileTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/ClasspathOptionUnknownClassTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/CompileClassTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/CompileClassWithDebugTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/CompileDirectoryTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/CompileJarTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/CompileModuleTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/IgnoreErrorsTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/ListOptionNotExistingTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/ListOptionTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/ListOptionWrongFileTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/fingerprint/SelfChanged.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/fingerprint/SelfChangedCDS.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/fingerprint/SuperChanged.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/verification/ClassAndLibraryNotMatchTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/verification/vmflags/NotTrackedFlagTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/verification/vmflags/TrackedFlagTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+
+############################################################################

--- a/openjdk/ProblemList_openjdk15-openj9.txt
+++ b/openjdk/ProblemList_openjdk15-openj9.txt
@@ -313,3 +313,68 @@ java/foreign/TestLayoutPaths.java	https://github.com/AdoptOpenJDK/openjdk-tests/
 java/foreign/TestNative.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1920 generic-all
 
 ############################################################################
+
+# jvm_compiler
+
+compiler/aot/DeoptimizationTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/RecompilationTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/SharedUsageTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeDynamic2CompiledTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeDynamic2InterpretedTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/TestHeapBase.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeDynamic2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeDynamic2NativeTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeInterface2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeInterface2CompiledTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeInterface2InterpretedTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeInterface2NativeTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeSpecial2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeSpecial2CompiledTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeSpecial2InterpretedTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeSpecial2NativeTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeStatic2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeStatic2CompiledTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeStatic2InterpretedTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeStatic2NativeTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeVirtual2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeVirtual2CompiledTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeVirtual2InterpretedTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeVirtual2NativeTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromCompiled/CompiledInvokeDynamic2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromCompiled/CompiledInvokeInterface2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromCompiled/CompiledInvokeSpecial2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromCompiled/CompiledInvokeStatic2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromCompiled/CompiledInvokeVirtual2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromInterpreted/InterpretedInvokeDynamic2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromInterpreted/InterpretedInvokeInterface2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromInterpreted/InterpretedInvokeSpecial2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromInterpreted/InterpretedInvokeStatic2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromInterpreted/InterpretedInvokeVirtual2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromNative/NativeInvokeSpecial2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromNative/NativeInvokeStatic2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromNative/NativeInvokeVirtual2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/DisabledAOTWithLibraryTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/IncorrectAOTLibraryTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/MultipleAOTLibraryTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/NonExistingAOTLibraryTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/SingleAOTLibraryTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/SingleAOTOptionTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/AtFileTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/ClasspathOptionUnknownClassTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/CompileClassTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/CompileClassWithDebugTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/CompileDirectoryTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/CompileJarTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/CompileModuleTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/IgnoreErrorsTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/ListOptionNotExistingTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/ListOptionTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/ListOptionWrongFileTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/fingerprint/SelfChanged.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/fingerprint/SelfChangedCDS.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/fingerprint/SuperChanged.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/verification/ClassAndLibraryNotMatchTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/verification/vmflags/NotTrackedFlagTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/verification/vmflags/TrackedFlagTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+
+############################################################################

--- a/openjdk/ProblemList_openjdk16-openj9.txt
+++ b/openjdk/ProblemList_openjdk16-openj9.txt
@@ -324,3 +324,68 @@ java/foreign/TestLayoutConstants.java	https://github.com/AdoptOpenJDK/openjdk-te
 java/foreign/TestNative.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1920 generic-all
 
 ############################################################################
+
+# jvm_compiler
+
+compiler/aot/DeoptimizationTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/RecompilationTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/SharedUsageTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeDynamic2CompiledTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeDynamic2InterpretedTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/TestHeapBase.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeDynamic2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeDynamic2NativeTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeInterface2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeInterface2CompiledTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeInterface2InterpretedTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeInterface2NativeTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeSpecial2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeSpecial2CompiledTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeSpecial2InterpretedTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeSpecial2NativeTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeStatic2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeStatic2CompiledTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeStatic2InterpretedTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeStatic2NativeTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeVirtual2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeVirtual2CompiledTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeVirtual2InterpretedTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromAot/AotInvokeVirtual2NativeTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromCompiled/CompiledInvokeDynamic2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromCompiled/CompiledInvokeInterface2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromCompiled/CompiledInvokeSpecial2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromCompiled/CompiledInvokeStatic2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromCompiled/CompiledInvokeVirtual2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromInterpreted/InterpretedInvokeDynamic2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromInterpreted/InterpretedInvokeInterface2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromInterpreted/InterpretedInvokeSpecial2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromInterpreted/InterpretedInvokeStatic2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromInterpreted/InterpretedInvokeVirtual2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromNative/NativeInvokeSpecial2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromNative/NativeInvokeStatic2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/calls/fromNative/NativeInvokeVirtual2AotTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/DisabledAOTWithLibraryTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/IncorrectAOTLibraryTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/MultipleAOTLibraryTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/NonExistingAOTLibraryTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/SingleAOTLibraryTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/SingleAOTOptionTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/AtFileTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/ClasspathOptionUnknownClassTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/CompileClassTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/CompileClassWithDebugTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/CompileDirectoryTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/CompileJarTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/CompileModuleTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/IgnoreErrorsTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/ListOptionNotExistingTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/ListOptionTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/cli/jaotc/ListOptionWrongFileTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/fingerprint/SelfChanged.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/fingerprint/SelfChangedCDS.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/fingerprint/SuperChanged.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/verification/ClassAndLibraryNotMatchTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/verification/vmflags/NotTrackedFlagTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+compiler/aot/verification/vmflags/TrackedFlagTest.java		https://github.com/eclipse/openj9/issues/10992		generic-all
+
+############################################################################


### PR DESCRIPTION
- openj9 does not provide aot material
- related to issue: eclipse/openj9#10992

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>