### PR TITLE
Use single quotation mark in java-args

### DIFF
--- a/system/daaLoadTest/playlist.xml
+++ b/system/daaLoadTest/playlist.xml
@@ -168,14 +168,6 @@
 	</test>
 	<test>
 		<testCaseName>DaaLoadTest_daa1_special</testCaseName>
-		<disabled>
-			<comment>https://github.com/AdoptOpenJDK/openjdk-tests/issues/2042</comment>
-			<variation>Mode555</variation>
-		</disabled>
-		<disabled>
-			<comment>https://github.com/AdoptOpenJDK/openjdk-tests/issues/2042</comment>
-			<variation>Mode614</variation>
-		</disabled>
 		<variations>
 			<variation>Mode101</variation>
 			<variation>Mode103</variation>
@@ -224,14 +216,6 @@
 	</test>
 	<test>
 		<testCaseName>DaaLoadTest_daa2_special</testCaseName>
-		<disabled>
-			<comment>https://github.com/AdoptOpenJDK/openjdk-tests/issues/2042</comment>
-			<variation>Mode555</variation>
-		</disabled>
-		<disabled>
-			<comment>https://github.com/AdoptOpenJDK/openjdk-tests/issues/2042</comment>
-			<variation>Mode614</variation>
-		</disabled>
 		<variations>
 			<variation>Mode101</variation>
 			<variation>Mode103</variation>
@@ -280,14 +264,6 @@
 	</test>
 	<test>
 		<testCaseName>DaaLoadTest_daa3_special</testCaseName>
-		<disabled>
-			<comment>https://github.com/AdoptOpenJDK/openjdk-tests/issues/2042</comment>
-			<variation>Mode555</variation>
-		</disabled>
-		<disabled>
-			<comment>https://github.com/AdoptOpenJDK/openjdk-tests/issues/2042</comment>
-			<variation>Mode614</variation>
-		</disabled>
 		<variations>
 			<variation>Mode101</variation>
 			<variation>Mode103</variation>
@@ -336,14 +312,6 @@
 	</test>
 	<test>
 		<testCaseName>DaaLoadTest_all_special</testCaseName>
-		<disabled>
-			<comment>https://github.com/AdoptOpenJDK/openjdk-tests/issues/2042</comment>
-			<variation>Mode555</variation>
-		</disabled>
-		<disabled>
-			<comment>https://github.com/AdoptOpenJDK/openjdk-tests/issues/2042</comment>
-			<variation>Mode614</variation>
-		</disabled>
 		<variations>
 			<variation>Mode101</variation>
 			<variation>Mode103</variation>

--- a/system/lambdaLoadTest/playlist.xml
+++ b/system/lambdaLoadTest/playlist.xml
@@ -111,14 +111,6 @@
 	</test>
 	<test>
 		<testCaseName>LambdaLoadTest_OpenJ9_NonLinux_special</testCaseName>
-		<disabled>
-			<comment>https://github.com/AdoptOpenJDK/openjdk-tests/issues/2042</comment>
-			<variation>Mode555</variation>
-		</disabled>
-		<disabled>
-			<comment>https://github.com/AdoptOpenJDK/openjdk-tests/issues/2042</comment>
-			<variation>Mode614</variation>
-		</disabled>
 		<variations>
 			<variation>Mode101</variation>
 			<variation>Mode103</variation>
@@ -168,14 +160,6 @@
 	</test>
 	<test>
 		<testCaseName>LambdaLoadTest_OpenJ9_Linux_CompressedRefs_special</testCaseName>
-		<disabled>
-			<comment>https://github.com/AdoptOpenJDK/openjdk-tests/issues/2042</comment>
-			<variation>Mode555</variation>
-		</disabled>
-		<disabled>
-			<comment>https://github.com/AdoptOpenJDK/openjdk-tests/issues/2042</comment>
-			<variation>Mode614</variation>
-		</disabled>
 		<variations>
 			<variation>Mode101</variation>
 			<variation>Mode103</variation>

--- a/system/mathLoadTest/playlist.xml
+++ b/system/mathLoadTest/playlist.xml
@@ -122,14 +122,6 @@
 			<comment>rtc 139897</comment>
 			<variation>Mode554</variation>
 		</disabled>
-		<disabled>
-			<comment>https://github.com/AdoptOpenJDK/openjdk-tests/issues/2042</comment>
-			<variation>Mode555</variation>
-		</disabled>
-		<disabled>
-			<comment>https://github.com/AdoptOpenJDK/openjdk-tests/issues/2042</comment>
-			<variation>Mode614</variation>
-		</disabled>
 		<variations>
 			<variation>Mode101</variation>
 			<variation>Mode103</variation>
@@ -178,14 +170,6 @@
 	</test>
 	<test>
 		<testCaseName>MathLoadTest_autosimd_special</testCaseName>
-		<disabled>
-			<comment>https://github.com/AdoptOpenJDK/openjdk-tests/issues/2042</comment>
-			<variation>Mode555</variation>
-		</disabled>
-		<disabled>
-			<comment>https://github.com/AdoptOpenJDK/openjdk-tests/issues/2042</comment>
-			<variation>Mode614</variation>
-		</disabled>
 		<variations>
 			<variation>Mode101</variation>
 			<variation>Mode103</variation>
@@ -235,11 +219,7 @@
 	<test>
 		<testCaseName>MathLoadTest_bigdecimal_special</testCaseName>
 		<disabled>
-			<comment>https://github.com/AdoptOpenJDK/openjdk-tests/issues/2042</comment>
-			<variation>Mode555</variation>
-		</disabled>
-		<disabled>
-			<comment>https://github.com/AdoptOpenJDK/openjdk-tests/issues/2042</comment>
+			<comment>https://github.com/eclipse/openj9/issues/9104</comment>
 			<variation>Mode614</variation>
 		</disabled>
 		<variations>

--- a/system/mauveLoadTest/playlist.xml
+++ b/system/mauveLoadTest/playlist.xml
@@ -168,14 +168,6 @@
 	<!-- The above tests are to be run using concurrentScavenge on z/OS, z/Linux, x/Linux and x/Windows using 64-bit OpenJ9 SDK -->
 	<test>
 		<testCaseName>MauveMultiThreadLoadTest_special</testCaseName>
-		<disabled>
-			<comment>https://github.com/AdoptOpenJDK/openjdk-tests/issues/2042</comment>
-			<variation>Mode555</variation>
-		</disabled>
-		<disabled>
-			<comment>https://github.com/AdoptOpenJDK/openjdk-tests/issues/2042</comment>
-			<variation>Mode614</variation>
-		</disabled>
 		<variations>
 			<variation>Mode101</variation>
 			<variation>Mode103</variation>
@@ -226,14 +218,6 @@
 	</test>
 	<test>
 		<testCaseName>MauveSingleThreadLoadTest_special</testCaseName>
-		<disabled>
-			<comment>https://github.com/AdoptOpenJDK/openjdk-tests/issues/2042</comment>
-			<variation>Mode555</variation>
-		</disabled>
-		<disabled>
-			<comment>https://github.com/AdoptOpenJDK/openjdk-tests/issues/2042</comment>
-			<variation>Mode614</variation>
-		</disabled>
 		<variations>
 			<variation>Mode101</variation>
 			<variation>Mode103</variation>
@@ -285,14 +269,6 @@
 	</test>
 	<test>
 		<testCaseName>MauveSingleInvocationLoadTest_special</testCaseName>
-		<disabled>
-			<comment>https://github.com/AdoptOpenJDK/openjdk-tests/issues/2042</comment>
-			<variation>Mode555</variation>
-		</disabled>
-		<disabled>
-			<comment>https://github.com/AdoptOpenJDK/openjdk-tests/issues/2042</comment>
-			<variation>Mode614</variation>
-		</disabled>
 		<variations>
 			<variation>Mode101</variation>
 			<variation>Mode103</variation>

--- a/system/otherLoadTest/playlist.xml
+++ b/system/otherLoadTest/playlist.xml
@@ -33,14 +33,6 @@
 	</test>
 	<test>
 		<testCaseName>ClassLoadingTest_special</testCaseName>
-		<disabled>
-			<comment>https://github.com/AdoptOpenJDK/openjdk-tests/issues/2042</comment>
-			<variation>Mode555</variation>
-		</disabled>
-		<disabled>
-			<comment>https://github.com/AdoptOpenJDK/openjdk-tests/issues/2042</comment>
-			<variation>Mode614</variation>
-		</disabled>
 		<variations>
 			<variation>Mode101</variation>
 			<variation>Mode103</variation>

--- a/system/systemtest.mk
+++ b/system/systemtest.mk
@@ -50,6 +50,6 @@ define SYSTEMTEST_CMD_TEMPLATE
 perl $(SYSTEMTEST_RESROOT)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl \
 	-test-root=$(Q)$(SYSTEMTEST_RESROOT)$(D)stf;$(SYSTEMTEST_RESROOT)$(D)openjdk-systemtest$(OPENJ9_PRAM)$(Q) \
 	-systemtest-prereqs=$(Q)$(SYSTEMTEST_RESROOT)$(D)systemtest_prereqs$(Q) \
-	-java-args=$(Q)$(JVM_OPTIONS)$(Q) \
+	-java-args=$(SQ)$(JVM_OPTIONS)$(SQ) \
 	-results-root=$(REPORTDIR)
 endef


### PR DESCRIPTION
- to escape double quotes in some JVM_OPITIONS
- enable disabled tests
- add related issue to MathLoadTest_bigdecimal_special test

Fixes #2042

Signed-off-by: renfeiw <renfeiw@ca.ibm.com>