### PR TITLE
Reenable JlinkTest_RequiredMod on osx

### DIFF
--- a/system/modularity/playlist.xml
+++ b/system/modularity/playlist.xml
@@ -489,7 +489,6 @@
 			<group>system</group>
 		</groups>
 	</test>
-	<!-- Temporarily excluded from osx due to : https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/203 -->
 	<!-- Temporarily excluded from win due to : https://github.com/eclipse/openj9-systemtest/issues/68 -->
 	<test>
 		<testCaseName>JlinkTest_RequiredMod</testCaseName>
@@ -507,7 +506,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
-		<platformRequirements>^os.osx,^os.win</platformRequirements>
+		<platformRequirements>^os.win</platformRequirements>
 	</test>
 	<!-- Temporarily excluded from win due to : https://github.com/eclipse/openj9-systemtest/issues/68 -->
 	<test>


### PR DESCRIPTION
Signed-off-by: Simon Rushton <srushton@redhat.com>