### PR TITLE
Revert "Exclude ClassLoader/deadlock/DelegateTest, using incompatible -Xlog"

### DIFF
--- a/openjdk/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/ProblemList_openjdk11-openj9.txt
@@ -35,7 +35,6 @@ java/lang/ClassLoader/EndorsedDirs.java	https://github.com/eclipse/openj9/issues
 java/lang/ClassLoader/ExtDirs.java	https://github.com/eclipse/openj9/issues/3055	generic-all
 java/lang/ClassLoader/LibraryPathProperty.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/ClassLoader/RecursiveSystemLoader.java	https://github.com/eclipse/openj9/issues/3178	generic-all
-java/lang/ClassLoader/deadlock/DelegateTest.java	https://github.com/eclipse/openj9/issues/10898	generic-all
 java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	generic-all
 java/lang/Enum/ConstantDirectoryOptimalCapacity.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/ModuleLayer/BasicLayerTest.java	https://github.com/eclipse/openj9/issues/6462	generic-all

--- a/openjdk/ProblemList_openjdk15-openj9.txt
+++ b/openjdk/ProblemList_openjdk15-openj9.txt
@@ -35,7 +35,6 @@ java/lang/ClassLoader/EndorsedDirs.java	https://github.com/eclipse/openj9/issues
 java/lang/ClassLoader/ExtDirs.java	https://github.com/eclipse/openj9/issues/3055	generic-all
 java/lang/ClassLoader/LibraryPathProperty.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/ClassLoader/RecursiveSystemLoader.java	https://github.com/eclipse/openj9/issues/3178	generic-all
-java/lang/ClassLoader/deadlock/DelegateTest.java	https://github.com/eclipse/openj9/issues/10898	generic-all
 java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	generic-all
 java/lang/Enum/ConstantDirectoryOptimalCapacity.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/ModuleLayer/BasicLayerTest.java	https://github.com/eclipse/openj9/issues/6462	generic-all

--- a/openjdk/ProblemList_openjdk16-openj9.txt
+++ b/openjdk/ProblemList_openjdk16-openj9.txt
@@ -35,7 +35,6 @@ java/lang/ClassLoader/EndorsedDirs.java	https://github.com/eclipse/openj9/issues
 java/lang/ClassLoader/ExtDirs.java	https://github.com/eclipse/openj9/issues/3055	generic-all
 java/lang/ClassLoader/LibraryPathProperty.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/ClassLoader/RecursiveSystemLoader.java	https://github.com/eclipse/openj9/issues/3178	generic-all
-java/lang/ClassLoader/deadlock/DelegateTest.java	https://github.com/eclipse/openj9/issues/10898	generic-all
 java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	generic-all
 java/lang/Enum/ConstantDirectoryOptimalCapacity.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/ModuleLayer/BasicLayerTest.java	https://github.com/eclipse/openj9/issues/6462	generic-all


### PR DESCRIPTION
Reverts AdoptOpenJDK/openjdk-tests#2020

Since https://github.com/eclipse/openj9/pull/11082 is merged this test can pass again.

Tested it on jdk15 https://ci.eclipse.org/openj9/view/Test/job/Grinder/1171/