### PR TITLE
maketest.sh: Add process cleanup for Windows at the end of testing

### DIFF
--- a/maketest.sh
+++ b/maketest.sh
@@ -20,6 +20,12 @@ case `uname` in
     ;;
 esac
 
+if [ "$OSTYPE" = "cygwin" ]; then
+  export JOBSTARTTIME=$(date -R)
+  echo PROCESSCATCH: Java processes which are currently on the machine:
+  powershell -c "Get-Process java | select id,processname,starttime"
+fi
+
 if [ "$#" -eq 1 ];then
 	cd $1/TKG
 	$MAKE compile
@@ -29,3 +35,30 @@ else
 	$MAKE $@
 fi
 
+# For now (while this code is being prototyped) I only want this to be
+# done while running in jenkins, to avoid a potentially destabilising
+# change if people are running other java processes on their local system
+set -x
+if [ ! -z "$EXECUTOR_NUMBER" ]; then
+  if [ "$OSTYPE" = "cygwin" ]; then
+    # Windows code based on https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1669#issuecomment-727863096
+    echo PROCESSCATCH: Showing java processes - one will be the jenkins agent - removing any of these created since $JOBSTARTTIME:
+    powershell -c "Get-Process java"
+    C=`powershell -c "(Get-Process java | select id,processname,starttime | where {\\$_.StartTime -gt (Get-Date -Date \"$JOBSTARTTIME\")} | measure).count" | tr -d \\\\r`
+    if [ $C -ne 0 ]; then
+      echo PROCESSCATCH: Attempting to stop the following processes:
+      powershell -c "Get-Process java | select id,processname,starttime | where {\$_.StartTime -gt (Get-Date -Date \"$JOBSTARTTIME\")}"
+      powershell -c "Get-Process java | select id,processname,starttime | where {\$_.StartTime -gt (Get-Date -Date \"$JOBSTARTTIME\")} | stop-process"
+      echo PROCESSCATCH: Removed processes - here is what is remaining:
+      powershell -c "Get-Process java"
+    fi
+  else
+    # Non-Windows code from https://ci.adoptopenjdk.net/job/SXA-processCheck
+    echo PROCESSCATCH: Checking for any leftover java processes on the machine
+    if ps -fu $USER | grep java | egrep -v "remoting.jar|agent.jar|grep"; then
+      echo PROCESSCATCH: There are rogue processes still on the machine as per the list above
+      # TODO: We could kill them, but SXA-processCheck covers this in the adoptopenjdk jenkins
+      # And this is likely to be replaced as part of https://github.com/AdoptOpenJDK/TKG/issues/45
+    fi
+  fi
+fi


### PR DESCRIPTION
Hopefully fixes https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1573 by checking for, and attempting to stop, java processes on the machine that have been created since the time that the test job was started. This should prevent process leaks across jobs which cause a number of failures either of failed tests or locked directories that cannot be cleaned up. Equivalent functionality may well be moved into TKG at a later point.

~Draft until I've verified that the functionaliy doesn't cause any new breaks~

As per https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1669#issuecomment-727863096 and https://github.com/AdoptOpenJDK/openjdk-tests/issues/2058#issuecomment-729278319

Signed-off-by: Stewart X Addison <sxa@redhat.com>