### PR TITLE
Fix jtreg.jar missing on zOS

### DIFF
--- a/openjdk/build.xml
+++ b/openjdk/build.xml
@@ -64,7 +64,7 @@
 			<contains string="${SPEC}" substring="zos" />
 			<then>
 				<exec executable="tar" failonerror="true">
-					<arg line="xfo ${jtregTar}" />
+					<arg line="xfo ${jtregTar} -C ${DEST}" />
 				</exec>
 			</then>
 		<else>


### PR DESCRIPTION
`-C ${DEST}` was removed in PR #2039 and it caused jtreg.jar missing for openJDK tests on zOS.
I think the cmd was removed accidentally because this cmd is specific for zos.

Fixes: runtimes/backlog/issues/418

Signed-off-by: lanxia <lan_xia@ca.ibm.com>