### PR TITLE
Adding Jacoco tests to external group

### DIFF
--- a/external/common_functions.sh
+++ b/external/common_functions.sh
@@ -30,7 +30,7 @@ supported_packages="jdk jre"
 supported_builds="slim full"
 
 # Supported tests
-supported_tests="camel derby elasticsearch jenkins functional-test kafka lucene-solr openliberty-mp-tck payara-mp-tck quarkus quarkus_quickstarts scala system-test thorntail-mp-tck tomcat tomee wildfly wycheproof"
+supported_tests="camel derby elasticsearch jacoco jenkins functional-test kafka lucene-solr openliberty-mp-tck payara-mp-tck quarkus quarkus_quickstarts scala system-test thorntail-mp-tck tomcat tomee wildfly wycheproof"
 
 function check_version() {
     version=$1
@@ -233,6 +233,21 @@ function set_test_info() {
         centos_packages="git wget make gcc unzip"
         clefos_packages="${centos_packages}"
         ubi_packages="git wget make gcc unzip"
+        ubi_minimal_packages="${ubi_packages}"
+        ;;
+    jacoco)
+        github_url="https://github.com/jacoco/jacoco.git"
+        script="jacoco-test.sh"
+        test_results="testResults"
+        tag_version="master"
+        environment_variable="MODE=\"java\""
+        debian_packages="git maven"
+        debianslim_packages="${debian_packages}"
+        ubuntu_packages="${debian_packages}"
+        alpine_packages="git maven"
+        centos_packages="git maven"
+        clefos_packages="${centos_packages}"
+        ubi_packages="git maven"
         ubi_minimal_packages="${ubi_packages}"
         ;;
     jenkins)

--- a/external/jacoco/build.xml
+++ b/external/jacoco/build.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<project name="Jacoco-Test" default="build" basedir=".">
+	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+	<description>
+		Build jacoco-test Docker image
+	</description>
+	<import file="${TEST_ROOT}/external/build.xml"/>
+
+	<!-- set properties for this build -->
+	<property name="TEST" value="jacoco" />
+	<property name="DEST" value="${BUILD_ROOT}/external/${TEST}" />
+	<property name="src" location="." />
+
+	<target name="init">
+		<mkdir dir="${DEST}"/>
+	</target>
+
+	<target name="dist" depends="move_scripts,clean_image,build_image" description="generate the distribution">
+		<copy todir="${DEST}">
+			<fileset dir="${src}" includes="*.xml, *.mk"/>
+		</copy>
+	</target>
+
+	<target name="build">
+		<antcall target="dist" inheritall="true" />
+	</target>
+</project>

--- a/external/jacoco/dockerfile/Dockerfile
+++ b/external/jacoco/dockerfile/Dockerfile
@@ -1,0 +1,51 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This Dockerfile in external/jacoco/dockerfile dir is used to create an image with
+# AdoptOpenJDK jdk binary installed. Basic test dependent executions
+# are installed during the building process.
+#
+# Build example: `docker build -t adoptopenjdk-jacoco-test -f Dockerfile ../.`
+#
+# This Dockerfile builds image based on adoptopenjdk/openjdk8:latest.
+# If you want to build image based on other images, please use
+# `--build-arg list` to specify your base image
+#
+# Build example: `docker build --build-arg IMAGE_NAME=<image_name> --build-arg IMAGE_VERSION=<image_version >-t adoptopenjdk-jacoco-test .`
+
+ 
+ARG SDK=openjdk8
+ARG IMAGE_NAME=adoptopenjdk/$SDK
+ARG IMAGE_VERSION=nightly
+
+FROM $IMAGE_NAME:$IMAGE_VERSION
+
+# Install test dependent executable files
+RUN apt-get update \
+	&& apt-get -y install \
+	maven \
+	git \
+	wget \
+	; \
+    rm -rf /var/lib/apt/lists/*
+
+ENV JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
+ENV MODE="java"
+
+COPY ./dockerfile/jacoco-test.sh /jacoco-test.sh
+RUN mkdir testResults
+WORKDIR /
+RUN pwd
+RUN git clone https://github.com/jacoco/jacoco.git
+
+ENTRYPOINT ["/bin/bash", "/jacoco-test.sh"]
+CMD ["$MODE"]

--- a/external/jacoco/dockerfile/jacoco-test.sh
+++ b/external/jacoco/dockerfile/jacoco-test.sh
@@ -1,0 +1,51 @@
+#/bin/bash
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source $(dirname "$0")/test_base_functions.sh
+
+# Set up Java to be used by the the jacoco-test
+
+if [ -d /java/jre/bin ];then
+	echo "Using mounted Java8"
+	export JAVA_BIN=/java/jre/bin
+	export JAVA_HOME=/java
+	export PATH=$JAVA_BIN:$PATH
+elif [ -d /java/bin ]; then
+	echo "Using mounted Java"
+	export JAVA_BIN=/java/bin
+	export JAVA_HOME=/java
+	export PATH=$JAVA_BIN:$PATH
+else
+	echo "Using docker image default Java"
+	java_path=$(type -p java)
+	suffix="/java"
+	java_root=${java_path%$suffix}
+	export JAVA_BIN="$java_root"
+	echo "JAVA_BIN is: $JAVA_BIN"
+	export JAVA_HOME="${java_root%/bin}"
+fi
+
+echo_setup
+
+cd /jacoco/org.jacoco.build
+pwd
+echo "Compile and run jacoco tests"
+mvn clean verify
+test_exit_code=$?
+echo "Build jacoco completed"
+
+find ./ -type d -name 'surefire-reports' -exec cp -r "{}" /testResults \;
+echo "Test results copied"
+
+exit $test_exit_code

--- a/external/jacoco/playlist.xml
+++ b/external/jacoco/playlist.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+-->
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TestConfig/playlist.xsd">
+	<test>
+		<testCaseName>MachineInfo</testCaseName>
+		<command>$(JAVA_COMMAND) -cp $(JVM_TEST_ROOT)$(D)TKG$(D)bin$(D)TestKitGen.jar org.openj9.envInfo.EnvDetector MachineInfo; \
+		$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+			<level>extended</level>
+			<level>special</level>
+		</levels>
+		<groups>
+			<group>external</group>
+		</groups>
+	</test>
+	<test>
+		<testCaseName>jacoco_test</testCaseName>
+		<command> $(TEST_ROOT)$(D)external$(D)external.sh --run --tag ${DOCKERIMAGE_TAG} --version ${JDK_VERSION} --impl ${JDK_IMPL} --dir jacoco --reportdst $(REPORTDIR) --docker_args "$(EXTRA_DOCKER_ARGS)"; \
+		$(TEST_STATUS); \
+		$(TEST_ROOT)$(D)external$(D)external.sh --clean --tag ${DOCKERIMAGE_TAG} --version ${JDK_VERSION} --impl ${JDK_IMPL} --dir jacoco 
+		</command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>external</group>
+		</groups>
+		<!-- Only test with jdk 8 due to https://github.com/AdoptOpenJDK/openjdk-tests/issues/2065 -->
+		<subsets>
+			<subset>8</subset>
+		</subsets>
+	</test>
+</playlist>


### PR DESCRIPTION
Commit adds jacoco test suite to the openj9 external group

Signed-off-by: <nmilijev@uwaterloo.ca> Nikola Milijevic