### PR TITLE
Add check for jck update

### DIFF
--- a/jck/build.xml
+++ b/jck/build.xml
@@ -59,44 +59,27 @@
 					<arg line="rev-parse"/>
 					<arg line="HEAD"/>
 				</exec>
-				<echo message="localSHA Original ---${localSHAClean}---"/>
 				<loadresource property="localSHATrimmed">
 					<propertyresource name="localSHA"/>
 					<filterchain>
 						<tokenfilter>
 							<trim/>
 						</tokenfilter>
+						<striplinebreaks/>
 					</filterchain>
 				</loadresource>
-				<echo message="localSHA after trim --${localSHATrimmed}--"/>
-				<loadresource property="localSHAClean">
-					<propertyresource name="localSHATrimmed"/>
-						<filterchain>
-							<striplinebreaks/>
-						</filterchain>
-				</loadresource>
-				<echo message="localSHA after striplinebreaks --${localSHAClean}--"/>
-				
 				<exec executable="git" dir="${JCK_ROOT_USED}" outputproperty="remoteSHA">
 					<arg line="ls-remote"/>
 					<arg line="${JCK_GIT_REPO_USED}"/>
 					<arg line="${jck_branch}"/>
 				</exec>
-				<echo message="localSHA ==${localSHAClean}=="/>
+				
+				<echo message="localSHA ==${localSHATrimmed}=="/>
 				<echo message="remoteSHA==${remoteSHA}=="/>
+				
 				<condition property="local-material-uptodate">
-					<contains string="${remoteSHA}" substring="${localSHAClean}" />
+					<contains string="${remoteSHA}" substring="${localSHATrimmed}" />
 				</condition>
-				<echo message="local-material-uptodate 1 = ${local-material-uptodate}"/>
-				<if>
-					<isset property="local-material-uptodate" />
-					<then>
-						<echo message="local-material-uptodate is set"/>
-					</then>
-					<else>
-						<echo message="local-material-uptodate is NOT set"/>
-					</else>
-				</if>
 			</then>
 		</if>	
 		<if>
@@ -132,7 +115,6 @@
 							<arg value="--force" />
 							<arg value="--quiet" />
 						</exec>
-						<echo message="local-material-uptodate 2 = ${local-material-uptodate}"/>
 						<if>
 							<isset property="local-material-uptodate" />
 							<then> 
@@ -152,9 +134,8 @@
 		<if>
 			<isset property="isZOS" />
 			<then>
-				<echo message="local-material-uptodate 3 = ${local-material-uptodate}"/>
 				<if>
-					<isset property="local-material-uptodate" />
+					<isset property="local-material-uptodate"/>
 					<then> 
 						<echo message="Local copy of JCK materials are up-to-date. Skipping hard reset"/>
 					</then>

--- a/jck/build.xml
+++ b/jck/build.xml
@@ -69,6 +69,7 @@
 				<condition property="local-material-uptodate">
 					<matches pattern="${localSHA}" string="${remoteSHA}"/>
 				</condition>
+				<echo message="local-material-uptodate 1 = ${local-material-uptodate}"/>
 			</then>
 		</if>	
 		<if>
@@ -104,6 +105,7 @@
 							<arg value="--force" />
 							<arg value="--quiet" />
 						</exec>
+						<echo message="local-material-uptodate 2 = ${local-material-uptodate}"/>
 						<if>
 							<isset property="local-material-uptodate" />
 							<then> 
@@ -123,6 +125,7 @@
 		<if>
 			<isset property="isZOS" />
 			<then>
+				<echo message="local-material-uptodate 3 = ${local-material-uptodate}"/>
 				<if>
 					<isset property="local-material-uptodate" />
 					<then> 

--- a/jck/build.xml
+++ b/jck/build.xml
@@ -52,6 +52,24 @@
 	<target name="stage_jck_material">
 		<!-- Starting downloading or updating JCK materials based on JCK GIT REPO and JCK VERSION-->
 		<if>
+			<available file="${JCK_ROOT_USED}" type="dir" />
+			<then>
+				<!--Obtain local and remote SHA to figure out if local materials are up-to-date--> 
+				<exec executable="git" dir="${JCK_ROOT_USED}" outputproperty="localSHA">
+					<arg line="rev-parse"/>
+					<arg line="HEAD"/>
+				</exec>
+				<exec executable="git" dir="${JCK_ROOT_USED}" outputproperty="remoteSHA">
+					<arg line="ls-remote"/>
+					<arg line="${JCK_GIT_REPO_USED}"/>
+					<arg line="${jck_branch}"/>
+				</exec>
+				<condition property="local-material-uptodate">
+					<matches pattern="${localSHA}" string="${remoteSHA}"/>
+				</condition>
+			</then>
+		</if>	
+		<if>
 			<not>
 				<available file="${JCK_ROOT_USED}" type="dir" />
 			</not>
@@ -84,34 +102,51 @@
 							<arg value="--force" />
 							<arg value="--quiet" />
 						</exec>
-						<echo message="Updating ${JCK_ROOT_USED} with latest..." />
-						<exec executable="git" dir="${JCK_ROOT_USED}" failonerror="true">
-							<arg value="pull" />
-						</exec>
-					</else>
+						<if>
+							<isset property="local-material-uptodate" />
+							<then> 
+								<echo message="Local copy of JCK materials are up-to-date. Skipping update"/>
+							</then>
+							<else>
+								<echo message="Updating ${JCK_ROOT_USED} with latest..." />
+								<echo message="Updating ${JCK_ROOT_USED} with latest..." />
+								<exec executable="git" dir="${JCK_ROOT_USED}" failonerror="true">
+									<arg value="pull" />
+								</exec>
+							</else>
+						</fi>
+					</fi>
 				</if>
 			</else>
 		</if>
 		<if>
 			<isset property="isZOS" />
 			<then>
-				<echo message="Performing hard reset of ${JCK_ROOT_USED} using .gitattributes.zos for file conversions..."/>
-				<delete includeemptydirs="true" failonerror="false">
-					<fileset dir="${JCK_ROOT_USED}/.git/info" includes="**/*"/>
-				</delete>
-				<mkdir dir="${JCK_ROOT_USED}/.git/info" />
-				<move file="${JCK_ROOT_USED}/.gitattributes.zos" tofile="${JCK_ROOT_USED}/.git/info/attributes" />
-				<exec executable="git" dir="${JCK_ROOT_USED}" failonerror="false">
-					<arg value="rm" />
-					<arg value="--cached" />
-					<arg value="-r" />
-					<arg value="-q" />
-					<arg value="." />
-				</exec>
-				<exec executable="git" dir="${JCK_ROOT_USED}" failonerror="false">
-					<arg value="reset" />
-					<arg value="--hard" />
-				</exec>
+				<if>
+					<isset property="local-material-uptodate" />
+					<then> 
+						<echo message="Local copy of JCK materials are up-to-date. Skipping hard reset"/>
+					</then>
+					<else>
+						<echo message="Performing hard reset of ${JCK_ROOT_USED} using .gitattributes.zos for file conversions..."/>
+						<delete includeemptydirs="true" failonerror="false">
+							<fileset dir="${JCK_ROOT_USED}/.git/info" includes="**/*"/>
+						</delete>
+						<mkdir dir="${JCK_ROOT_USED}/.git/info" />
+						<move file="${JCK_ROOT_USED}/.gitattributes.zos" tofile="${JCK_ROOT_USED}/.git/info/attributes" />
+						<exec executable="git" dir="${JCK_ROOT_USED}" failonerror="false">
+							<arg value="rm" />
+							<arg value="--cached" />
+							<arg value="-r" />
+							<arg value="-q" />
+							<arg value="." />
+						</exec>
+						<exec executable="git" dir="${JCK_ROOT_USED}" failonerror="false">
+							<arg value="reset" />
+							<arg value="--hard" />
+						</exec>
+					</then>
+				</if>
 			</then>
 		</if>
 		<!--Make all .sh files below ${JCK_ROOT_USED} readable and executable for anyone on a UNIX system.

--- a/jck/build.xml
+++ b/jck/build.xml
@@ -114,11 +114,12 @@
 									<arg value="pull" />
 								</exec>
 							</else>
-						</fi>
-					</fi>
+						</if>
+					</else>
 				</if>
 			</else>
 		</if>
+						
 		<if>
 			<isset property="isZOS" />
 			<then>
@@ -145,7 +146,7 @@
 							<arg value="reset" />
 							<arg value="--hard" />
 						</exec>
-					</then>
+					</else>
 				</if>
 			</then>
 		</if>

--- a/jck/build.xml
+++ b/jck/build.xml
@@ -70,6 +70,15 @@
 					<matches pattern="${localSHA}" string="${remoteSHA}"/>
 				</condition>
 				<echo message="local-material-uptodate 1 = ${local-material-uptodate}"/>
+				<if>
+					<isset property="local-material-uptodate" />
+					<then>
+						<echo message="local-material-uptodate is set"/>
+					</then>
+					<else>
+						<echo message="local-material-uptodate is NOT set"/>
+					</else>
+				</if>
 			</then>
 		</if>	
 		<if>

--- a/jck/build.xml
+++ b/jck/build.xml
@@ -73,8 +73,6 @@
 						<striplinebreaks/>
 					</filterchain>
 				</loadresource>
-				<echo message="localSHA  : ${localSHATrimmed}"/>
-				<echo message="remoteSHA : ${remoteSHA}"/>
 				<condition property="local-material-uptodate">
 					<contains string="${remoteSHA}" substring="${localSHATrimmed}" />
 				</condition>

--- a/jck/build.xml
+++ b/jck/build.xml
@@ -59,6 +59,11 @@
 					<arg line="rev-parse"/>
 					<arg line="HEAD"/>
 				</exec>
+				<exec executable="git" dir="${JCK_ROOT_USED}" outputproperty="remoteSHA">
+					<arg line="ls-remote"/>
+					<arg line="${JCK_GIT_REPO_USED}"/>
+					<arg line="${jck_branch}"/>
+				</exec>
 				<loadresource property="localSHATrimmed">
 					<propertyresource name="localSHA"/>
 					<filterchain>
@@ -68,15 +73,8 @@
 						<striplinebreaks/>
 					</filterchain>
 				</loadresource>
-				<exec executable="git" dir="${JCK_ROOT_USED}" outputproperty="remoteSHA">
-					<arg line="ls-remote"/>
-					<arg line="${JCK_GIT_REPO_USED}"/>
-					<arg line="${jck_branch}"/>
-				</exec>
-				
-				<echo message="localSHA ==${localSHATrimmed}=="/>
-				<echo message="remoteSHA==${remoteSHA}=="/>
-				
+				<echo message="localSHA  : ${localSHATrimmed}"/>
+				<echo message="remoteSHA : ${remoteSHA}"/>
 				<condition property="local-material-uptodate">
 					<contains string="${remoteSHA}" substring="${localSHATrimmed}" />
 				</condition>
@@ -118,7 +116,7 @@
 						<if>
 							<isset property="local-material-uptodate" />
 							<then> 
-								<echo message="Local copy of JCK materials are up-to-date. Skipping update"/>
+								<echo message="Local JCK materials up-to-date. Skipping update"/>
 							</then>
 							<else>
 								<echo message="Updating ${JCK_ROOT_USED} with latest..." />
@@ -137,7 +135,7 @@
 				<if>
 					<isset property="local-material-uptodate"/>
 					<then> 
-						<echo message="Local copy of JCK materials are up-to-date. Skipping hard reset"/>
+						<echo message="Local JCK materials up-to-date. Skipping hard reset"/>
 					</then>
 					<else>
 						<echo message="Performing hard reset of ${JCK_ROOT_USED} using .gitattributes.zos for file conversions..."/>

--- a/jck/build.xml
+++ b/jck/build.xml
@@ -59,24 +59,33 @@
 					<arg line="rev-parse"/>
 					<arg line="HEAD"/>
 				</exec>
+				<echo message="localSHA Original ---${localSHAClean}---"/>
 				<loadresource property="localSHATrimmed">
 					<propertyresource name="localSHA"/>
 					<filterchain>
-        				<tokenfilter>
-                 				<trim/>
-       					 </tokenfilter>
-      				</filterchain>		
+						<tokenfilter>
+							<trim/>
+						</tokenfilter>
+					</filterchain>
 				</loadresource>
+				<echo message="localSHA after trim --${localSHATrimmed}--"/>
+				<loadresource property="localSHAClean">
+					<propertyresource name="localSHATrimmed"/>
+						<filterchain>
+							<striplinebreaks/>
+						</filterchain>
+				</loadresource>
+				<echo message="localSHA after striplinebreaks --${localSHAClean}--"/>
 				
 				<exec executable="git" dir="${JCK_ROOT_USED}" outputproperty="remoteSHA">
 					<arg line="ls-remote"/>
 					<arg line="${JCK_GIT_REPO_USED}"/>
 					<arg line="${jck_branch}"/>
 				</exec>
-				<echo message="localSHA ==${localSHATrimmed}=="/>
+				<echo message="localSHA ==${localSHAClean}=="/>
 				<echo message="remoteSHA==${remoteSHA}=="/>
 				<condition property="local-material-uptodate">
-					<contains string="${remoteSHA}" substring="${localSHATrimmed}" />
+					<contains string="${remoteSHA}" substring="${localSHAClean}" />
 				</condition>
 				<echo message="local-material-uptodate 1 = ${local-material-uptodate}"/>
 				<if>

--- a/jck/build.xml
+++ b/jck/build.xml
@@ -64,10 +64,10 @@
 					<arg line="${JCK_GIT_REPO_USED}"/>
 					<arg line="${jck_branch}"/>
 				</exec>
-				<echo message="localSHA = ${localSHA}"/>
-				<echo message="remoteSHA= ${remoteSHA}"/>
+				<echo message="localSHA ==${localSHA}=="/>
+				<echo message="remoteSHA==${remoteSHA}=="/>
 				<condition property="local-material-uptodate">
-					<matches pattern="${localSHA}" string="${remoteSHA}"/>
+					<contains string="${remoteSHA}" substring="${localSHA}" />
 				</condition>
 				<echo message="local-material-uptodate 1 = ${local-material-uptodate}"/>
 				<if>

--- a/jck/build.xml
+++ b/jck/build.xml
@@ -64,6 +64,8 @@
 					<arg line="${JCK_GIT_REPO_USED}"/>
 					<arg line="${jck_branch}"/>
 				</exec>
+				<echo message="localSHA = ${localSHA}"/>
+				<echo message="remoteSHA= ${remoteSHA}"/>
 				<condition property="local-material-uptodate">
 					<matches pattern="${localSHA}" string="${remoteSHA}"/>
 				</condition>
@@ -109,7 +111,6 @@
 							</then>
 							<else>
 								<echo message="Updating ${JCK_ROOT_USED} with latest..." />
-								<echo message="Updating ${JCK_ROOT_USED} with latest..." />
 								<exec executable="git" dir="${JCK_ROOT_USED}" failonerror="true">
 									<arg value="pull" />
 								</exec>
@@ -119,7 +120,6 @@
 				</if>
 			</else>
 		</if>
-						
 		<if>
 			<isset property="isZOS" />
 			<then>

--- a/jck/build.xml
+++ b/jck/build.xml
@@ -59,15 +59,24 @@
 					<arg line="rev-parse"/>
 					<arg line="HEAD"/>
 				</exec>
+				<loadresource property="localSHATrimmed">
+					<propertyresource name="localSHA"/>
+					<filterchain>
+        				<tokenfilter>
+                 				<trim/>
+       					 </tokenfilter>
+      				</filterchain>		
+				</loadresource>
+				
 				<exec executable="git" dir="${JCK_ROOT_USED}" outputproperty="remoteSHA">
 					<arg line="ls-remote"/>
 					<arg line="${JCK_GIT_REPO_USED}"/>
 					<arg line="${jck_branch}"/>
 				</exec>
-				<echo message="localSHA ==${localSHA}=="/>
+				<echo message="localSHA ==${localSHATrimmed}=="/>
 				<echo message="remoteSHA==${remoteSHA}=="/>
 				<condition property="local-material-uptodate">
-					<contains string="${remoteSHA}" substring="${localSHA}" />
+					<contains string="${remoteSHA}" substring="${localSHATrimmed}" />
 				</condition>
 				<echo message="local-material-uptodate 1 = ${local-material-uptodate}"/>
 				<if>


### PR DESCRIPTION
- Adds a check to see if jck materials on disc are already up-to-date. If yes, we simply use them as is. 
- Related to backlog/issues/405

Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>