### PR TITLE
Exclude ProcessBuilder Basic_id0 test on aix

### DIFF
--- a/openjdk/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/ProblemList_openjdk11-openj9.txt
@@ -38,7 +38,7 @@ java/lang/ClassLoader/RecursiveSystemLoader.java	https://github.com/eclipse/open
 java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	generic-all
 java/lang/Enum/ConstantDirectoryOptimalCapacity.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/ModuleLayer/BasicLayerTest.java	https://github.com/eclipse/openj9/issues/6462	generic-all
-java/lang/ProcessBuilder/Basic.java#id0		https://github.com/eclipse/openj9/issues/9032	linux-aarch64
+java/lang/ProcessBuilder/Basic.java#id0		https://github.com/eclipse/openj9/issues/9032	linux-aarch64,aix-all
 java/lang/ProcessBuilder/Basic.java#id1		https://github.com/eclipse/openj9/issues/9032	linux-aarch64
 java/lang/ProcessBuilder/SkipTest.java https://github.com/eclipse/openj9/issues/4124 windows-all
 java/lang/StackTraceElement/PublicConstructor.java	https://github.com/eclipse/openj9/issues/6659	generic-all


### PR DESCRIPTION
ref https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1644#issuecomment-737283413

This same test has been excluded on aarch64 due to https://github.com/eclipse/openj9/issues/9032. I am excluding it on aix for the same reason. 

@smlambert Is editing this file all that is needed to exclude a test?