### PR TITLE
enable jdk_security_infra test

### DIFF
--- a/openjdk/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/ProblemList_openjdk11-openj9.txt
@@ -217,6 +217,9 @@ java/rmi/server/UnicastServerRef/serialFilter/FilterUSRTest.java	https://github.
 
 # jdk_security
 
+security/infra/java/security/cert/CertPathValidator/certification/LuxTrustCA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074	generic-all
+security/infra/java/security/cert/CertPathValidator/certification/BuypassCA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074	generic-all
+security/infra/java/security/cert/CertPathValidator/certification/QuoVadisCA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074	generic-all
 ############################################################################
 
 # jdk_sound

--- a/openjdk/ProblemList_openjdk11.txt
+++ b/openjdk/ProblemList_openjdk11.txt
@@ -135,6 +135,9 @@ jdk/nio/zipfs/ZipFSTester.java	https://github.com/AdoptOpenJDK/openjdk-tests/iss
 
 # jdk_security
 
+security/infra/java/security/cert/CertPathValidator/certification/LuxTrustCA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074	generic-all
+security/infra/java/security/cert/CertPathValidator/certification/BuypassCA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074	generic-all
+security/infra/java/security/cert/CertPathValidator/certification/QuoVadisCA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074	generic-all
 ############################################################################
 
 # jdk_sound

--- a/openjdk/ProblemList_openjdk12-openj9.txt
+++ b/openjdk/ProblemList_openjdk12-openj9.txt
@@ -271,6 +271,9 @@ java/rmi/transport/runtimeThreadInheritanceLeak/RuntimeThreadInheritanceLeak.jav
 
 # jdk_security
 
+security/infra/java/security/cert/CertPathValidator/certification/LuxTrustCA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074	generic-all
+security/infra/java/security/cert/CertPathValidator/certification/BuypassCA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074	generic-all
+security/infra/java/security/cert/CertPathValidator/certification/QuoVadisCA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074	generic-all
 ############################################################################
 
 # jdk_sound

--- a/openjdk/ProblemList_openjdk12.txt
+++ b/openjdk/ProblemList_openjdk12.txt
@@ -105,6 +105,9 @@ java/rmi/module/ModuleTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/is
 
 # jdk_security
 
+security/infra/java/security/cert/CertPathValidator/certification/LuxTrustCA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074	generic-all
+security/infra/java/security/cert/CertPathValidator/certification/BuypassCA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074	generic-all
+security/infra/java/security/cert/CertPathValidator/certification/QuoVadisCA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074	generic-all
 ############################################################################
 
 # jdk_sound

--- a/openjdk/ProblemList_openjdk13-openj9.txt
+++ b/openjdk/ProblemList_openjdk13-openj9.txt
@@ -224,6 +224,9 @@ java/rmi/server/UnicastServerRef/serialFilter/FilterUSRTest.java	https://github.
 
 # jdk_security
 
+security/infra/java/security/cert/CertPathValidator/certification/LuxTrustCA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074	generic-all
+security/infra/java/security/cert/CertPathValidator/certification/BuypassCA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074	generic-all
+security/infra/java/security/cert/CertPathValidator/certification/QuoVadisCA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074	generic-all
 ############################################################################
 
 # jdk_sound

--- a/openjdk/ProblemList_openjdk13.txt
+++ b/openjdk/ProblemList_openjdk13.txt
@@ -130,6 +130,9 @@ java/nio/channels/DatagramChannel/PromiscuousIPv6.java	https://github.com/AdoptO
 
 # jdk_security
 
+security/infra/java/security/cert/CertPathValidator/certification/LuxTrustCA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074	generic-all
+security/infra/java/security/cert/CertPathValidator/certification/BuypassCA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074	generic-all
+security/infra/java/security/cert/CertPathValidator/certification/QuoVadisCA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074	generic-all
 ############################################################################
 
 # jdk_sound

--- a/openjdk/ProblemList_openjdk14-openj9.txt
+++ b/openjdk/ProblemList_openjdk14-openj9.txt
@@ -228,6 +228,9 @@ java/rmi/server/UnicastServerRef/serialFilter/FilterUSRTest.java	https://github.
 
 # jdk_security
 
+security/infra/java/security/cert/CertPathValidator/certification/LuxTrustCA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074	generic-all
+security/infra/java/security/cert/CertPathValidator/certification/BuypassCA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074	generic-all
+security/infra/java/security/cert/CertPathValidator/certification/QuoVadisCA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074	generic-all
 ############################################################################
 
 # jdk_sound

--- a/openjdk/ProblemList_openjdk14.txt
+++ b/openjdk/ProblemList_openjdk14.txt
@@ -140,6 +140,9 @@ jdk/nio/zipfs/ZipFSTester.java	https://github.com/AdoptOpenJDK/openjdk-tests/iss
 
 # jdk_security
 
+security/infra/java/security/cert/CertPathValidator/certification/LuxTrustCA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074	generic-all
+security/infra/java/security/cert/CertPathValidator/certification/BuypassCA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074	generic-all
+security/infra/java/security/cert/CertPathValidator/certification/QuoVadisCA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074	generic-all
 ############################################################################
 
 # jdk_sound

--- a/openjdk/ProblemList_openjdk15-openj9.txt
+++ b/openjdk/ProblemList_openjdk15-openj9.txt
@@ -239,6 +239,10 @@ java/rmi/server/UnicastServerRef/serialFilter/FilterUSRTest.java	https://github.
 
 # jdk_security
 
+security/infra/java/security/cert/CertPathValidator/certification/LuxTrustCA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074	generic-all
+security/infra/java/security/cert/CertPathValidator/certification/BuypassCA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074	generic-all
+security/infra/java/security/cert/CertPathValidator/certification/QuoVadisCA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074	generic-all
+security/infra/java/security/cert/CertPathValidator/certification/GlobalSignR6CA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074	generic-all
 ############################################################################
 
 # jdk_sound

--- a/openjdk/ProblemList_openjdk15.txt
+++ b/openjdk/ProblemList_openjdk15.txt
@@ -134,6 +134,10 @@ java/nio/channels/DatagramChannel/PromiscuousIPv6.java	https://github.com/AdoptO
 
 # jdk_security
 
+security/infra/java/security/cert/CertPathValidator/certification/LuxTrustCA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074	generic-all
+security/infra/java/security/cert/CertPathValidator/certification/BuypassCA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074	generic-all
+security/infra/java/security/cert/CertPathValidator/certification/QuoVadisCA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074	generic-all
+security/infra/java/security/cert/CertPathValidator/certification/GlobalSignR6CA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074	generic-all
 ############################################################################
 
 # jdk_sound

--- a/openjdk/ProblemList_openjdk16-openj9.txt
+++ b/openjdk/ProblemList_openjdk16-openj9.txt
@@ -249,6 +249,9 @@ java/rmi/server/UnicastServerRef/serialFilter/FilterUSRTest.java	https://github.
 
 # jdk_security
 
+security/infra/java/security/cert/CertPathValidator/certification/LuxTrustCA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074	generic-all
+security/infra/java/security/cert/CertPathValidator/certification/BuypassCA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074	generic-all
+security/infra/java/security/cert/CertPathValidator/certification/QuoVadisCA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074	generic-all
 ############################################################################
 
 # jdk_sound

--- a/openjdk/ProblemList_openjdk16.txt
+++ b/openjdk/ProblemList_openjdk16.txt
@@ -133,6 +133,9 @@ java/nio/channels/DatagramChannel/PromiscuousIPv6.java	https://github.com/AdoptO
 
 # jdk_security
 
+security/infra/java/security/cert/CertPathValidator/certification/LuxTrustCA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074	generic-all
+security/infra/java/security/cert/CertPathValidator/certification/BuypassCA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074	generic-all
+security/infra/java/security/cert/CertPathValidator/certification/QuoVadisCA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074	generic-all
 ############################################################################
 
 # jdk_sound

--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -1122,9 +1122,9 @@
 		<levels>
 			<level>extended</level>
 		</levels>
-		<!-- temporarily disable on openj9 due to https://github.com/eclipse/openj9/issues/10757 -->
 		<impls>
 			<impl>hotspot</impl>
+			<impl>openj9</impl>
 		</impls>
 		<groups>
 			<group>openjdk</group>


### PR DESCRIPTION
- enable jdk_security_infra test
- Temporarily exclude 3 sub-tests for all versions: LuxTrustCA, BuypassCA, and QuoVadisCA
- Temporarily exclude 1 sub-test GlobalSignR6CA fro jdk 15 due to certificate expire
- Related to: https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074 
Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>