### PR TITLE
Handle different java.version variations in Tls13FunctionalTest

### DIFF
--- a/functional/security/src/net/adoptopenjdk/test/Tls13FunctionalTest.java
+++ b/functional/security/src/net/adoptopenjdk/test/Tls13FunctionalTest.java
@@ -130,7 +130,19 @@ public class Tls13FunctionalTest {
                 isSupportedPlatform = false;
             }
         } else {
-            int majorVersion = Integer.parseInt(versionString.substring(0, versionString.indexOf('.')));
+            int majorVersion = 0;
+            /* Handle versions like 11.0.9, 16-internal, 16 */
+            int dotIndex = versionString.indexOf('.');
+            if (dotIndex > 0) {
+                majorVersion = Integer.parseInt(versionString.substring(0, dotIndex));
+            } else {
+                int dashIndex = versionString.indexOf('-');
+                if (dashIndex > 0) {
+                    majorVersion = Integer.parseInt(versionString.substring(0, dashIndex));
+                } else {
+                    majorVersion = Integer.parseInt(versionString);
+                }
+            }
             if (majorVersion < 11) {
                 logger.warn("Skipping tests because JDK is unsupported: " + versionString);
                 isSupportedPlatform = false;


### PR DESCRIPTION
java.version may be like 11.0.9, 16-internal, or 16.

Fixes https://github.com/eclipse/openj9/issues/11361

Tested via https://ci.eclipse.org/openj9/view/Test/job/Grinder/1247 for 16-internal
and https://ci.eclipse.org/openj9/view/Test/job/Grinder/1248 for 11.0.10