### PR TITLE
Exclude JEP 393: Foreign-Memory Access API tests

### DIFF
--- a/openjdk/ProblemList_openjdk16-openj9.txt
+++ b/openjdk/ProblemList_openjdk16-openj9.txt
@@ -324,5 +324,11 @@ java/foreign/TestLayoutPaths.java	https://github.com/AdoptOpenJDK/openjdk-tests/
 java/foreign/TestByteBuffer.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1702	generic-all
 java/foreign/TestLayoutConstants.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1702	generic-all
 java/foreign/TestNative.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1920 generic-all
+java/foreign/TestSharedAccess.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestSharedAccess.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestSpliterator.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestByteBuffer.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestHandshake.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestCleaner.java https://github.com/eclipse/openj9/issues/11027 generic-all
 
 ############################################################################


### PR DESCRIPTION
Excluding following tests:
```
java/foreign/TestSharedAccess.java
java/foreign/TestSpliterator.java
java/foreign/TestByteBuffer.java
java/foreign/TestHandshake.java
java/foreign/TestCleaner.java
```

Related https://github.com/eclipse/openj9/issues/11027
Related https://github.com/eclipse/openj9/issues/11360

Signed-off-by: Jason Feng <fengj@ca.ibm.com>