### PR TITLE
Exclude sanity.openjdk java/lang/invoke & java/foreign  tests

### DIFF
--- a/openjdk/ProblemList_openjdk16-openj9.txt
+++ b/openjdk/ProblemList_openjdk16-openj9.txt
@@ -147,6 +147,13 @@ jdk/modules/etc/DefaultModules.java	https://github.com/AdoptOpenJDK/openjdk-test
 jdk/modules/incubator/ImageModules.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
 vm/JniInvocationTest.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	macosx-all
 jdk/internal/loader/NativeLibraries/Main.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1920 generic-all
+java/lang/invoke/lambda/superProtectedMethod/SuperMethodTest.java https://github.com/eclipse/openj9/issues/11135 generic-all
+java/lang/invoke/MethodHandles/publicLookup/Driver.java https://github.com/eclipse/openj9/issues/11135 generic-all
+java/lang/invoke/MethodHandlesPermuteArgumentsTest.java https://github.com/eclipse/openj9/issues/11135 generic-all
+java/lang/invoke/MethodHandles/TestDropReturn.java https://github.com/eclipse/openj9/issues/11135 generic-all
+java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java https://github.com/eclipse/openj9/issues/11135 generic-all
+java/lang/invoke/VarHandles/VarHandleTestExact.java https://github.com/eclipse/openj9/issues/11256 generic-all
+
 ############################################################################
 
 # jdk_internal
@@ -325,10 +332,34 @@ java/foreign/TestByteBuffer.java	https://github.com/AdoptOpenJDK/openjdk-tests/i
 java/foreign/TestLayoutConstants.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1702	generic-all
 java/foreign/TestNative.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1920 generic-all
 java/foreign/TestSharedAccess.java https://github.com/eclipse/openj9/issues/11027 generic-all
-java/foreign/TestSharedAccess.java https://github.com/eclipse/openj9/issues/11027 generic-all
 java/foreign/TestSpliterator.java https://github.com/eclipse/openj9/issues/11027 generic-all
 java/foreign/TestByteBuffer.java https://github.com/eclipse/openj9/issues/11027 generic-all
 java/foreign/TestHandshake.java https://github.com/eclipse/openj9/issues/11027 generic-all
 java/foreign/TestCleaner.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/stackwalk/TestStackWalk.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/valist/VaListTest.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/StdLibTest.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestAdaptVarHandles.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestAddressHandle.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestDowncall.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestIllegalLink.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestIntrinsics.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestMemoryAccess.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestMemoryAccessStatics.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestMemoryAlignment.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestMemoryCopy.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestMemoryHandleAsUnsigned.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestMismatch.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestNativeScope.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestNulls.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestRebase.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestSegments.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestSlices.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestTypeAccess.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestUpcall.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestUpcallHighArity.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestUpcallStubs.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestVarArgs.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestVarHandleCombinators.java https://github.com/eclipse/openj9/issues/11027 generic-all
 
 ############################################################################


### PR DESCRIPTION
Excluding `sanity.openjdk` `java/lang/invoke` & `java/foreign` tests

```
java/lang/invoke/lambda/superProtectedMethod/SuperMethodTest.java
java/lang/invoke/MethodHandles/publicLookup/Driver.java
java/lang/invoke/MethodHandlesPermuteArgumentsTest.java
java/lang/invoke/MethodHandles/TestDropReturn.java
java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java
java/lang/invoke/VarHandles/VarHandleTestExact.java
```
```
java/foreign/stackwalk/TestStackWalk.java
java/foreign/valist/VaListTest.java
java/foreign/StdLibTest.java
java/foreign/TestAdaptVarHandles.java
java/foreign/TestAddressHandle.java
java/foreign/TestDowncall.java
java/foreign/TestIllegalLink.java
java/foreign/TestIntrinsics.java
java/foreign/TestMemoryAccess.java
java/foreign/TestMemoryAccessStatics.java
java/foreign/TestMemoryAlignment.java
java/foreign/TestMemoryCopy.java
java/foreign/TestMemoryHandleAsUnsigned.java
java/foreign/TestMismatch.java
java/foreign/TestNativeScope.java
java/foreign/TestNulls.java
java/foreign/TestRebase.java
java/foreign/TestSegments.java
java/foreign/TestSlices.java
java/foreign/TestTypeAccess.java
java/foreign/TestUpcall.java
java/foreign/TestUpcallHighArity.java
java/foreign/TestUpcallStubs.java
java/foreign/TestVarArgs.java
java/foreign/TestVarHandleCombinators.java
```

Signed-off-by: Jason Feng <fengj@ca.ibm.com>