### PR TITLE
Add spring and netty tests

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -115,6 +115,7 @@ def setupEnv() {
 def setupParallelEnv() {
 	stage('setupParallelEnv') {
 		timestamps{
+			def maxChildJobNum = 25
 			def testSubDirs = []
 			int childJobNum = 1
 			def UPSTREAM_TEST_JOB_NAME = ""
@@ -199,8 +200,8 @@ def setupParallelEnv() {
 				}
 				
 				childJobNum = testSubDirs.size()
-				if ( childJobNum > 20) {
-					assert false : "Build failed becuase childJobNum: ${childJobNum} > 20."
+				if ( childJobNum > maxChildJobNum) {
+					assert false : "Build failed becuase childJobNum: ${childJobNum} > ${maxChildJobNum}."
 				}
 			}
 			UPSTREAM_TEST_JOB_NAME = JOB_NAME

--- a/external/common_functions.sh
+++ b/external/common_functions.sh
@@ -30,7 +30,7 @@ supported_packages="jdk jre"
 supported_builds="slim full"
 
 # Supported tests
-supported_tests="camel derby elasticsearch jacoco jenkins functional-test kafka lucene-solr openliberty-mp-tck payara-mp-tck quarkus quarkus_quickstarts scala system-test thorntail-mp-tck tomcat tomee wildfly wycheproof"
+supported_tests="camel derby elasticsearch jacoco jenkins functional-test kafka lucene-solr openliberty-mp-tck payara-mp-tck quarkus quarkus_quickstarts scala system-test thorntail-mp-tck tomcat tomee wildfly wycheproof netty spring"
 
 function check_version() {
     version=$1
@@ -478,6 +478,36 @@ function set_test_info() {
         centos_packages="git wget unzip zip gcc-c++"
         clefos_packages="${centos_packages}"
         ubi_packages="git wget unzip zip gcc-c++"
+        ubi_minimal_packages="${ubi_packages}"
+        ;;
+    netty)
+        github_url="https://github.com/netty/netty.git"
+        script="netty-test.sh"
+        home_path="\${WORKDIR}"
+        test_results="testResults"
+        tag_version="4.1"
+        debian_packages="git maven autoconf automake libtool make tar gcc-multilib libaio-dev"
+        debianslim_packages="${debian_packages}"
+        ubuntu_packages="${debian_packages}"
+        alpine_packages="bash git maven"
+        centos_packages="git maven"
+        clefos_packages="${centos_packages}"
+        ubi_packages="git maven"
+        ubi_minimal_packages="${ubi_packages}"
+        ;;
+    spring)
+        github_url="https://github.com/spring-projects/spring-boot.git"
+        script="spring-test.sh"
+        home_path="\${WORKDIR}"
+        test_results="testResults"
+        gradle_version="5.1"
+        debian_packages="git wget unzip"
+        debianslim_packages="${debian_packages}"
+        ubuntu_packages="${debian_packages}"
+        alpine_packages="bash git wget unzip"
+        centos_packages="git wget unzip"
+        clefos_packages="${centos_packages}"
+        ubi_packages="git wget unzip"
         ubi_minimal_packages="${ubi_packages}"
         ;;
     *)

--- a/external/example-test/build.xml
+++ b/external/example-test/build.xml
@@ -22,7 +22,7 @@
 
 	<target name="build_image" depends="clean_image" description="build example test docker image">
 		<exec executable="docker"  failonerror="true">
-			<arg line="build -t adoptopenjdk-example-test -f dockerfile/Dockerfile --pull . --build-arg SDK=${JVM_VERSION} --build-arg IMAGE_VERSION=${dockerImageTag}"/>
+			<arg line="build --network host -t adoptopenjdk-example-test -f dockerfile/Dockerfile --pull . --build-arg SDK=${JVM_VERSION} --build-arg IMAGE_VERSION=${dockerImageTag}"/>
 		</exec>
 	</target>
 

--- a/external/netty/build.xml
+++ b/external/netty/build.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<project name="Netty-Test" default="build" basedir=".">
+	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+	<description>
+		Build Netty-Test Docker image
+	</description>
+	<import file="${TEST_ROOT}/external/build.xml"/>
+
+	<!-- set properties for this build -->
+	<property name="TEST" value="netty" />
+	<property name="DEST" value="${BUILD_ROOT}/external/${TEST}" />
+	<property name="src" location="." />
+
+	<target name="init">
+		<mkdir dir="${DEST}"/>
+	</target>
+
+	<target name="dist" depends="move_scripts,clean_image,build_image" description="generate the distribution">
+		<copy todir="${DEST}">
+			<fileset dir="${src}" includes="*.xml, *.mk"/>
+		</copy>
+	</target>
+
+	<target name="build">
+		<antcall target="dist" inheritall="true" />
+	</target>
+</project>

--- a/external/netty/dockerfile/netty-test.sh
+++ b/external/netty/dockerfile/netty-test.sh
@@ -1,0 +1,44 @@
+#/bin/bash
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#Set up Java to be used by the the example-test
+
+if [ -d /java/jre/bin ];then
+	echo "Using mounted Java8"
+	export JAVA_BIN=/java/jre/bin
+	export JAVA_HOME=/java
+	export PATH=$JAVA_BIN:$PATH
+elif [ -d /java/bin ]; then
+	echo "Using mounted Java9"
+	export JAVA_BIN=/java/bin
+	export JAVA_HOME=/java
+	export PATH=$JAVA_BIN:$PATH
+else
+	echo "Using docker image default Java"
+	java_path=$(type -p java)
+	suffix="/java"
+	java_root=${java_path%$suffix}
+	export JAVA_BIN="$java_root"
+	echo "JAVA_BIN is: $JAVA_BIN"
+	export JAVA_HOME="${java_root%/bin}"
+fi
+
+TEST_SUITE=$1
+java -version
+
+set -e
+cd /netty/
+echo "Compile and execute netty-test" && \
+mvn clean package
+set +e

--- a/external/netty/playlist.xml
+++ b/external/netty/playlist.xml
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+-->
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TKG/playlist.xsd">
+	<test>
+		<testCaseName>netty-test</testCaseName>
+		<command> $(TEST_ROOT)$(D)external$(D)external.sh --run --tag ${DOCKERIMAGE_TAG} --version ${JDK_VERSION} --impl ${JDK_IMPL} --dir netty --reportdst $(REPORTDIR) --docker_args "$(EXTRA_DOCKER_ARGS)" ; \
+			$(TEST_STATUS); \
+			$(TEST_ROOT)$(D)external$(D)external.sh --clean --tag ${DOCKERIMAGE_TAG} --version ${JDK_VERSION} --impl ${JDK_IMPL} --dir netty
+		</command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>external</group>
+		</groups>
+	</test>
+</playlist>

--- a/external/spring/build.xml
+++ b/external/spring/build.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<project name="Spring-Test" default="build" basedir=".">
+	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+	<description>
+		Build Spring-Test Docker image
+	</description>
+	<import file="${TEST_ROOT}/external/build.xml"/>
+
+	<!-- set properties for this build -->
+	<property name="TEST" value="spring" />
+	<property name="DEST" value="${BUILD_ROOT}/external/${TEST}" />
+	<property name="src" location="." />
+
+	<target name="init">
+		<mkdir dir="${DEST}"/>
+	</target>
+
+	<target name="dist" depends="move_scripts,clean_image,build_image" description="generate the distribution">
+		<copy todir="${DEST}">
+			<fileset dir="${src}" includes="*.xml, *.mk"/>
+		</copy>
+	</target>
+
+	<target name="build">
+		<antcall target="dist" inheritall="true" />
+	</target>
+</project>

--- a/external/spring/dockerfile/spring-test.sh
+++ b/external/spring/dockerfile/spring-test.sh
@@ -1,0 +1,48 @@
+#/bin/bash
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if [ -d /java/jre/bin ];then
+	echo "Using mounted Java8"
+	export JAVA_BIN=/java/jre/bin
+	export JAVA_HOME=/java
+	export PATH=$JAVA_BIN:$PATH
+elif [ -d /java/bin ]; then
+	echo "Using mounted Java9"
+	export JAVA_BIN=/java/bin
+	export JAVA_HOME=/java
+	export PATH=$JAVA_BIN:$PATH
+else
+	echo "Using docker image default Java"
+	java_path=$(type -p java)
+	suffix="/java"
+	java_root=${java_path%$suffix}
+	export JAVA_BIN="$java_root"
+	echo "JAVA_BIN is: $JAVA_BIN"
+	export JAVA_HOME="${java_root%/bin}"
+fi
+
+TEST_SUITE=$1
+java -version
+
+cd /spring-boot
+set -e
+
+echo "Compile and execute spring-test"
+echo "Building Spring  using gradle"
+./gradlew -q jar
+echo "Spring Build - Completed"
+echo "Running (ALL) Spring tests :"
+./gradlew -q test
+
+set +e

--- a/external/spring/playlist.xml
+++ b/external/spring/playlist.xml
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+-->
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TKG/playlist.xsd">
+	<test>
+		<testCaseName>spring-test</testCaseName>
+		<command> $(TEST_ROOT)$(D)external$(D)external.sh --run --tag ${DOCKERIMAGE_TAG} --version ${JDK_VERSION} --impl ${JDK_IMPL} --dir spring --reportdst $(REPORTDIR) --docker_args "$(EXTRA_DOCKER_ARGS)" ; \
+			$(TEST_STATUS); \
+			$(TEST_ROOT)$(D)external$(D)external.sh --clean --tag ${DOCKERIMAGE_TAG} --version ${JDK_VERSION} --impl ${JDK_IMPL} --dir spring
+		</command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>external</group>
+		</groups>
+	</test>
+</playlist>


### PR DESCRIPTION
Add spring netty tests for the external test set.

- Using netty 4.1( the default branch) for now
- A full run of netty and spring tasks about 40 minutes on a 4C8G machine
http://ci.dragonwell-jdk.io/job/Test_openjdk8_dragonwell_sanity.external_x86-64_linux_netty/
http://ci.dragonwell-jdk.io/job/Test_openjdk8_dragonwell_sanity.external_x86-64_linux_spring/