### PR TITLE
Temporarily exclude failing system tests from z/OS

### DIFF
--- a/system/jlm/playlist.xml
+++ b/system/jlm/playlist.xml
@@ -37,6 +37,7 @@
 		</groups>
 	</test>
 	<!-- Excluded from Windows due to https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/198 -->
+	<!-- Temporarily excluding from z/OS due to : jdk11-zos/issues/567 -->
 	<test>
 		<testCaseName>TestJlmRemoteClassAuth</testCaseName>
 		<variations>
@@ -50,7 +51,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
-		<platformRequirements>^os.win</platformRequirements>
+		<platformRequirements>^os.win,^os.zos</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>TestJlmRemoteClassNoAuth</testCaseName>
@@ -67,6 +68,7 @@
 		</groups>
 	</test>
 	<!-- Excluded from Windows due to https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/198 -->
+	<!-- Temporarily excluding from z/OS due to : jdk11-zos/issues/567 -->
 	<test>
 		<testCaseName>TestJlmRemoteMemoryAuth</testCaseName>
 		<variations>
@@ -80,7 +82,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
-		<platformRequirements>^os.win</platformRequirements>
+		<platformRequirements>^os.win,^os.zos</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>TestJlmRemoteMemoryNoAuth</testCaseName>
@@ -97,6 +99,7 @@
 		</groups>
 	</test>
 	<!-- Excluded from Windows due to https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/198 -->
+	<!-- Temporarily excluding from z/OS due to : jdk11-zos/issues/567 -->
 	<test>
 		<testCaseName>TestJlmRemoteNotifierProxyAuth</testCaseName>
 		<variations>
@@ -110,9 +113,10 @@
 		<groups>
 			<group>system</group>
 		</groups>
-		<platformRequirements>^os.win</platformRequirements>
+		<platformRequirements>^os.win,^os.zos</platformRequirements>
 	</test>
 	<!-- Excluded from Windows due to https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/198 -->
+	<!-- Temporarily excluding from z/OS due to : jdk11-zos/issues/567 -->
 	<test>
 		<testCaseName>TestJlmRemoteThreadAuth</testCaseName>
 		<variations>
@@ -126,7 +130,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
-		<platformRequirements>^os.win</platformRequirements>
+		<platformRequirements>^os.win,^os.zos</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>TestJlmRemoteThreadNoAuth</testCaseName>
@@ -163,6 +167,7 @@
 	</test>
 	<!--Exclude TestIBMJlmRemoteClassAuth from running on openjdk8-openj9 on ppc64le Linux. Reason: AdoptOpenJDK/openjdk-systemtest/issues/145-->
 	<!-- Excluded from Windows due to https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/198 -->
+	<!-- Temporarily excluding from z/OS due to : jdk11-zos/issues/567 -->
 	<test>
 		<testCaseName>TestIBMJlmRemoteClassAuth</testCaseName>
 		<variations>
@@ -183,9 +188,10 @@
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
-		<platformRequirements>^os.win</platformRequirements>
+		<platformRequirements>^os.win,^os.zos</platformRequirements>
 	</test>
 	<!-- Excluded from Windows due to https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/198 -->
+	<!-- Temporarily excluding from z/OS due to : jdk11-zos/issues/567 -->
 	<test>
 		<testCaseName>TestIBMJlmRemoteClassAuth_SE80</testCaseName>
 		<variations>
@@ -206,7 +212,7 @@
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
-		<platformRequirements>^os.linux,^os.win</platformRequirements>
+		<platformRequirements>^os.linux,^os.win,^os.zos</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>TestIBMJlmRemoteClassAuth_SE80_Linux</testCaseName>
@@ -298,6 +304,7 @@
 	</test>
 	<!--Exclude TestIBMJlmRemoteMemoryAuth from running on openjdk8-openj9 on ppc64le Linux. Reason: AdoptOpenJDK/openjdk-systemtest/issues/145-->
 	<!-- Excluded from Windows due to https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/198 -->
+	<!-- Temporarily excluding from z/OS due to : jdk11-zos/issues/567 -->
 	<test>
 		<testCaseName>TestIBMJlmRemoteMemoryAuth</testCaseName>
 		<variations>
@@ -318,9 +325,10 @@
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
-		<platformRequirements>^os.win</platformRequirements>
+		<platformRequirements>^os.win,^os.zos</platformRequirements>
 	</test>
 	<!-- Excluded from Windows due to https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/198 -->
+	<!-- Temporarily excluding from z/OS due to : jdk11-zos/issues/567 -->
 	<test>
 		<testCaseName>TestIBMJlmRemoteMemoryAuth_SE80</testCaseName>
 		<variations>
@@ -341,7 +349,7 @@
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
-		<platformRequirements>^os.linux,^os.win</platformRequirements>
+		<platformRequirements>^os.linux,^os.win,^os.zos</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>TestIBMJlmRemoteMemoryAuth_SE80_Linux</testCaseName>

--- a/system/modularity/playlist.xml
+++ b/system/modularity/playlist.xml
@@ -264,6 +264,7 @@
 		</groups>
 		<disabled>https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/200</disabled>
 	</test>
+	<!-- Temporarily excluding from z/OS due to : jdk11-zos/issues/568 -->
 	<test>
 		<testCaseName>SLTest</testCaseName>
 		<variations>
@@ -280,6 +281,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
+		<platformRequirements>^os.zos</platformRequirements>
 	</test>
 	<!-- Temporarily excluding this test from AIX due to : https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/202 -->
 	<test>
@@ -351,7 +353,9 @@
 			<group>system</group>
 		</groups>
 	</test>
+
 	<!-- Temporarily excluding this test from AIX due to : https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/202 -->
+	<!-- Temporarily excluding from z/OS due to : jdk11-zos/issues/568 -->
 	<test>
 		<testCaseName>PatModImg_PlatMod</testCaseName>
 		<variations>
@@ -368,8 +372,9 @@
 		<groups>
 			<group>system</group>
 		</groups>
-		<platformRequirements>^os.aix</platformRequirements>
+		<platformRequirements>^os.aix,^os.zos</platformRequirements>
 	</test>
+	<!-- Temporarily excluding from z/OS due to : jdk11-zos/issues/568 -->
 	<test>
 		<testCaseName>PatModImg_AppMod</testCaseName>
 		<variations>
@@ -386,7 +391,9 @@
 		<groups>
 			<group>system</group>
 		</groups>
+		<platformRequirements>^os.zos</platformRequirements>
 	</test>
+	<!-- Temporarily excluding from z/OS due to : jdk11-zos/issues/568 -->
 	<test>
 		<testCaseName>PatModImg_Unex</testCaseName>
 		<variations>
@@ -403,7 +410,9 @@
 		<groups>
 			<group>system</group>
 		</groups>
+		<platformRequirements>^os.zos</platformRequirements>
 	</test>
+	<!-- Temporarily excluding from z/OS due to : jdk11-zos/issues/568 -->
 	<test>
 		<testCaseName>PatModImg_Adv</testCaseName>
 		<variations>
@@ -420,6 +429,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
+		<platformRequirements>^os.zos</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>UpgModPath_Exp</testCaseName>
@@ -438,6 +448,7 @@
 			<group>system</group>
 		</groups>
 	</test>
+	<!-- Temporarily excluding from z/OS due to : jdk11-zos/issues/568 -->
 	<test>
 		<testCaseName>UpgModPath_ExpImg</testCaseName>
 		<variations>
@@ -454,6 +465,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
+		<platformRequirements>^os.zos</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>UpgModPath_Jar</testCaseName>
@@ -472,6 +484,7 @@
 			<group>system</group>
 		</groups>
 	</test>
+	<!-- Temporarily excluding from z/OS due to : jdk11-zos/issues/568 -->
 	<test>
 		<testCaseName>UpgModPath_JarImg</testCaseName>
 		<variations>
@@ -488,8 +501,10 @@
 		<groups>
 			<group>system</group>
 		</groups>
+		<platformRequirements>^os.zos</platformRequirements>
 	</test>
 	<!-- Temporarily excluded from win due to : https://github.com/eclipse/openj9-systemtest/issues/68 -->
+	<!-- Temporarily excluding from z/OS due to : jdk11-zos/issues/568 -->
 	<test>
 		<testCaseName>Jlink_ReqMod</testCaseName>
 		<variations>
@@ -506,9 +521,10 @@
 		<groups>
 			<group>system</group>
 		</groups>
-		<platformRequirements>^os.win</platformRequirements>
+		<platformRequirements>^os.win,^os.zos</platformRequirements>
 	</test>
 	<!-- Temporarily excluded from win due to : https://github.com/eclipse/openj9-systemtest/issues/68 -->
+	<!-- Temporarily excluding from z/OS due to : jdk11-zos/issues/568 -->
 	<test>
 		<testCaseName>Jlink_AddMLimitM</testCaseName>
 		<variations>
@@ -525,8 +541,9 @@
 		<groups>
 			<group>system</group>
 		</groups>
-		<platformRequirements>^os.win</platformRequirements>
+		<platformRequirements>^os.win,^os.zos</platformRequirements>
 	</test>
+	<!-- Temporarily excluding from z/OS due to : jdk11-zos/issues/568 -->
 	<test>
 		<testCaseName>CpMpJlink</testCaseName>
 		<variations>
@@ -543,6 +560,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
+		<platformRequirements>^os.zos</platformRequirements>
 	</test>
 	<!-- Temporarily excluded from win due to : https://github.com/eclipse/openj9-systemtest/issues/68 -->
 	<test>
@@ -601,6 +619,7 @@
 			<group>system</group>
 		</groups>
 	</test>
+	<!-- Temporarily excluding from z/OS due to : jdk11-zos/issues/568 -->
 	<test>
 		<testCaseName>CLTestImg</testCaseName>
 		<variations>
@@ -617,6 +636,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
+		<platformRequirements>^os.zos</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>CLLoad</testCaseName>

--- a/system/otherLoadTest/playlist.xml
+++ b/system/otherLoadTest/playlist.xml
@@ -94,6 +94,7 @@
 			<group>system</group>
 		</groups>
 	</test>
+	<!-- Temporarily excluded from z/Os due to : jdk11-zos/issues/571-->
 	<test>
 		<testCaseName>DirectByteBufferLoadTest</testCaseName>
 		<variations>
@@ -107,6 +108,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
+		<platformRequirements>^os.zos</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>LangLoadTest</testCaseName>
@@ -137,6 +139,7 @@
 		</groups>
 	</test>
 	<!-- Temporarily exclude from Linux aarch64 for: https://github.com/eclipse/openj9/issues/3065 -->
+	<!-- Temporarily excluded from z/Os due to : jdk11-zos/issues/342-->
 	<test>
 		<testCaseName>NioLoadTest</testCaseName>
 		<variations>
@@ -150,7 +153,7 @@
 		<groups>
 			<group>system</group>
 		</groups>
-		<platformRequirements>^arch.arm</platformRequirements>
+		<platformRequirements>^arch.arm,^os.zos</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>NioLoadTest_special</testCaseName>
@@ -275,6 +278,7 @@
 		</impls>
 		<platformRequirements>bits.64,^arch.arm</platformRequirements>
 	</test>
+	<!-- Temporarily excluded from z/Os due to : jdk11-zos/issues/342-->
 	<test>
 		<testCaseName>MixedLoadTest</testCaseName>
 		<variations>
@@ -291,5 +295,6 @@
 		<impls>
 			<impl>ibm</impl>
 		</impls>
+		<platformRequirements>^os.zos</platformRequirements>
 	</test>
 </playlist>


### PR DESCRIPTION
Following tests are failing on sanity.system on z/OS build: 

```
TestJlmRemoteClassAuth_0
TestJlmRemoteMemoryAuth_0
TestJlmRemoteNotifierProxyAuth_0
TestJlmRemoteThreadAuth_0
TestIBMJlmRemoteClassAuth_0
TestIBMJlmRemoteMemoryAuth_0
ServiceLoadersTest_0
PatchModuleImgTest_PlatformMod_0
PatchModuleImgTest_AppMod_0
PatchModuleImgTest_UnexportedType_0
PatchModuleImgTest_Advanced_0
UpgradeModPathTest_ExpDirImg_0
UpgradeModPathTest_JarredImg_0
JlinkTest_RequiredMod_0
JlinkTest_AddModLimitMod_0
CpMpJlinkTest_0
CLTestImage_0
NioLoadTest_0
```

Following are failing in extended.system on z/OS build: 

```
DirectByteBufferLoadTest_0
MixedLoadTest_0
```

This PR temporarily excludes the above tests from z/OS so that we can start with a green run of sanity.system and extended.system on z/OS.

FYI @pshipton @mamatha-jv 

Signed-off-by: Mesbah_Alam@ca.ibm.com Mesbah_Alam@ca.ibm.com