### PR TITLE
Enable JDK 11 testing with Jacoco test suite

### DIFF
--- a/external/jacoco/playlist.xml
+++ b/external/jacoco/playlist.xml
@@ -38,9 +38,5 @@
 		<groups>
 			<group>external</group>
 		</groups>
-		<!-- Only test with jdk 8 due to https://github.com/AdoptOpenJDK/openjdk-tests/issues/2065 -->
-		<subsets>
-			<subset>8</subset>
-		</subsets>
 	</test>
 </playlist>


### PR DESCRIPTION
Thanks to eclipse/openj9#11276, we can enable JDK 11 tests, and complete porting of Jacoco test suite to openj9 external group.

Closes:#1697 #2065
Signed-off-by: Nikola Milijevic <nmilijev@uwaterloo.ca>