### PR TITLE
Exclude PlatformLoggerTest.java for all platforms

### DIFF
--- a/openjdk/ProblemList_openjdk8-openj9.txt
+++ b/openjdk/ProblemList_openjdk8-openj9.txt
@@ -314,7 +314,7 @@ java/util/stream/test/org/openjdk/tests/java/util/stream/ToArrayOpTest.java		htt
 java/util/zip/InflateIn_DeflateOut.java		https://github.com/eclipse/openj9/issues/1131	generic-all
 java/util/zip/ZipFile/DeleteTempJar.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/821	windows-all
 sun/util/calendar/zi/TestZoneInfo310.java		https://github.com/eclipse/openj9/issues/1131	generic-all
-sun/util/logging/PlatformLoggerTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/830	windows-all,linux-all,macosx-all
+sun/util/logging/PlatformLoggerTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/830	generic-all
 
 ############################################################################
 


### PR DESCRIPTION
It wasn't excluded for AIX, and fails intermittently in AIX XL builds
for the same reason it was excluded on other platforms (doesn't keep a
strong reference to the loggers, which can be gc'ed).

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>