### PR TITLE
Add MiniMix_5min target

### DIFF
--- a/system/otherLoadTest/playlist.xml
+++ b/system/otherLoadTest/playlist.xml
@@ -18,6 +18,20 @@
 		</groups>
 	</test>
 	<test>
+		<testCaseName>MiniMix_5min</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MixedLoadTest -test-args=$(Q)timeLimit=5m$(Q);\
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>system</group>
+		</groups>
+	</test>
+	<test>
 		<testCaseName>ClassLoadingTest</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>


### PR DESCRIPTION
- Adds a target in `extended.system` to run a time-based system test 

Related to https://github.com/AdoptOpenJDK/openjdk-tests/issues/2104

FYI @ShelleyLambert @pshipton 

Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>