### PR TITLE
Fix tomee server slow start due to SecureRandom entropy source

### DIFF
--- a/external/dockerfile_functions.sh
+++ b/external/dockerfile_functions.sh
@@ -391,7 +391,7 @@ print_bazel_install() {
 print_java_tool_options() {
     local file=$1
 
-    echo -e "ENV JAVA_TOOL_OPTIONS=\"-Dfile.encoding=UTF8\"\n" >> ${file}
+    echo -e "ENV JAVA_TOOL_OPTIONS=\"-Dfile.encoding=UTF8 -Djava.security.egd=file:/dev/./urandom\"\n" >> ${file}
 }
 
 print_environment_variable() {

--- a/external/tomee/dockerfile/Dockerfile
+++ b/external/tomee/dockerfile/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get update; \
     ; \
     rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
+ENV JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8 -Djava.security.egd=file:/dev/./urandom"
 
 COPY ./dockerfile/tomee-test.sh /tomee-test.sh
 


### PR DESCRIPTION
tomee server may start slowly due to poor entropy source, use
```
-Djava.security.egd=file:/dev/./urandom
```
instead.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>