### PR TITLE
Revert: Add -Xdump NPE option to jdk_lang_j9 for debug

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -317,7 +317,7 @@
 	<test>
 		<testCaseName>jdk_lang_j9</testCaseName>
 		<variations>
-			<variation>-Xdump:system:none -Xdump:heap:none -Xdump:system:events=gpf+abort+traceassert+corruptcache -XX:-JITServerTechPreviewMessage -Xdump:system+java:events=throw,filter=java/lang/NullPointerException\#*java/lang/invoke/BruteArgumentMoverHandle.permuteArguments*</variation>
+			<variation>-Xdump:system:none -Xdump:heap:none -Xdump:system:events=gpf+abort+traceassert+corruptcache -XX:-JITServerTechPreviewMessage</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
 	$(JTREG_BASIC_OPTIONS) $(JDK_NATIVE_OPTIONS) -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \


### PR DESCRIPTION
Manually revert https://github.com/AdoptOpenJDK/openjdk-tests/pull/1989
The -Xdump option was added to help diagnose a problem, but I think all
it does is stop the problem from occurring.

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>