### PR TITLE
Move windows Java process kill logic to JenkinsfileBase and enhance

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -22,6 +22,16 @@ def makeTest(testParam) {
 }
 
 def setupEnv() {
+	env.JOBSTARTTIME = sh(script: 'date -R', returnStdout: true)
+
+	// Check what existing java processes are running
+        echo "PROCESSCATCH: Java processes which are currently on the machine:"
+	if (PLATFORM.contains("windows")) {
+		sh(script:'powershell -c "Get-Process java | select id,processname,starttime"', returnStatus:true)
+	} else {
+		sh(script:'ps -fu '+"${env.USER}"+' | grep java | egrep -v "remoting.jar|agent.jar|grep"', returnStatus: true)
+	}
+
 	if ( params.JDK_VERSION ) {
 		env.ORIGIN_JDK_VERSION = params.JDK_VERSION
 		env.JDK_VERSION = params.JDK_VERSION.equalsIgnoreCase("next") ? "" : params.JDK_VERSION
@@ -683,6 +693,9 @@ def testBuild() {
 				}
 			}
 		} finally {
+			// Terminate any left over java processes
+			terminateJavaProcesses()
+
 			if (!params.KEEP_WORKSPACE) {
 				// cleanWs() does not work in some cases, so set opts below
 				cleanWs notFailBuild: true, disableDeferredWipeout: true, deleteDirs: true
@@ -697,6 +710,52 @@ def testBuild() {
 			}	
 		}
 	}
+}
+
+def terminateJavaProcesses() {
+	// Attempt up to 30 times or until no more Java processes spawn...
+	for(int i=0; i<30; i++) {
+		echo 'terminateJavaProcesses iteration: '+(i+1)
+
+		// Terminate Java processes
+		if (PLATFORM.contains("windows")) {
+			// Windows code based on https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1669#issuecomment-727863096
+			echo "PROCESSCATCH: Showing java processes - one will be the jenkins agent - removing any of these created since ${env.JOBSTARTTIME}:"
+			sh(script:'powershell -c "Get-Process java | select id,processname,starttime"', returnStatus:true)
+
+			def C=sh(script:'powershell -c "(Get-Process java | select id,processname,starttime | where {\\$_.StartTime -gt (Get-Date -Date \\"'+"${env.JOBSTARTTIME}"+'\\")} | measure).count" | tr -d \\\\r', returnStdout:true)
+			echo "Number of java processes = ${C}"
+			if (!C.trim().equals("0")) {
+			    echo "PROCESSCATCH: Attempting to stop the following processes:"
+			    sh(script:'powershell -c "Get-Process java | select id,processname,starttime | where {\\$_.StartTime -gt (Get-Date -Date \\"'+"${env.JOBSTARTTIME}"+'\\")}"', returnStatus:true)
+			    def sh_rc=sh(script:'powershell -c "Get-Process java | select id,processname,starttime | where {\\$_.StartTime -gt (Get-Date -Date \\"'+"${env.JOBSTARTTIME}"+'\\")} | stop-process"', returnStatus:true)
+			    echo "stop-process rc = ${sh_rc}"
+			} else {
+			    // No more spawned, we are done...
+			    break
+                        }
+		} else {
+			// Non-Windows code from https://ci.adoptopenjdk.net/job/SXA-processCheck
+			echo "PROCESSCATCH: Checking for any leftover java processes on the machine"
+			def sh_rc=sh(script:'ps -fu '+"${env.USER}"+' | grep java | egrep -v "remoting.jar|agent.jar|grep"', returnStatus: true)
+			if (sh_rc == 0) {
+			    echo "PROCESSCATCH: There are rogue processes still on the machine as per the list above"
+			    // TODO: We could kill them, but SXA-processCheck covers this in the adoptopenjdk jenkins
+			    // And this is likely to be replaced as part of https://github.com/AdoptOpenJDK/TKG/issues/45
+			}
+			break
+		}
+
+		// Pause between iterations in case of spawning processes
+		sleep(2)
+        }
+
+        echo "PROCESSCATCH: Removed processes - here is what is remaining:"
+        if (PLATFORM.contains("windows")) {
+		sh(script:'powershell -c "Get-Process java | select id,processname,starttime"', returnStatus:true)
+        } else {
+		sh(script:'ps -fu '+"${env.USER}"+' | grep java | egrep -v "remoting.jar|agent.jar|grep"', returnStatus:true)
+        }
 }
 
 def getJDKImpl(jvm_version) {

--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -268,6 +268,7 @@ if (JDK_VERSIONS.size() > 1 || JDK_IMPLS.size() > 1 || PLATFORMS.size() >1 || PL
                     checkout scm: [$class: 'GitSCM',
                         branches: [[name: "${scm.branches[0].name}"]],
                         extensions: [
+                            [$class: 'CleanBeforeCheckout'],
                             [$class: 'CloneOption', reference: ref_cache],
                             [$class: 'RelativeTargetDirectory', relativeTargetDir: 'openjdk-tests']],
                         userRemoteConfigs: [[url: "${gitConfig.getUrl()}"]]

--- a/maketest.sh
+++ b/maketest.sh
@@ -20,12 +20,6 @@ case `uname` in
     ;;
 esac
 
-if [ "$OSTYPE" = "cygwin" ]; then
-  export JOBSTARTTIME=$(date -R)
-  echo PROCESSCATCH: Java processes which are currently on the machine:
-  powershell -c "Get-Process java | select id,processname,starttime"
-fi
-
 if [ "$#" -eq 1 ];then
 	cd $1/TKG
 	$MAKE compile
@@ -35,30 +29,3 @@ else
 	$MAKE $@
 fi
 
-# For now (while this code is being prototyped) I only want this to be
-# done while running in jenkins, to avoid a potentially destabilising
-# change if people are running other java processes on their local system
-set -x
-if [ ! -z "$EXECUTOR_NUMBER" ]; then
-  if [ "$OSTYPE" = "cygwin" ]; then
-    # Windows code based on https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1669#issuecomment-727863096
-    echo PROCESSCATCH: Showing java processes - one will be the jenkins agent - removing any of these created since $JOBSTARTTIME:
-    powershell -c "Get-Process java"
-    C=`powershell -c "(Get-Process java | select id,processname,starttime | where {\\$_.StartTime -gt (Get-Date -Date \"$JOBSTARTTIME\")} | measure).count" | tr -d \\\\r`
-    if [ $C -ne 0 ]; then
-      echo PROCESSCATCH: Attempting to stop the following processes:
-      powershell -c "Get-Process java | select id,processname,starttime | where {\$_.StartTime -gt (Get-Date -Date \"$JOBSTARTTIME\")}"
-      powershell -c "Get-Process java | select id,processname,starttime | where {\$_.StartTime -gt (Get-Date -Date \"$JOBSTARTTIME\")} | stop-process"
-      echo PROCESSCATCH: Removed processes - here is what is remaining:
-      powershell -c "Get-Process java"
-    fi
-  else
-    # Non-Windows code from https://ci.adoptopenjdk.net/job/SXA-processCheck
-    echo PROCESSCATCH: Checking for any leftover java processes on the machine
-    if ps -fu $USER | grep java | egrep -v "remoting.jar|agent.jar|grep"; then
-      echo PROCESSCATCH: There are rogue processes still on the machine as per the list above
-      # TODO: We could kill them, but SXA-processCheck covers this in the adoptopenjdk jenkins
-      # And this is likely to be replaced as part of https://github.com/AdoptOpenJDK/TKG/issues/45
-    fi
-  fi
-fi


### PR DESCRIPTION
Moved post job Java process kill logic from maketest.sh to JenkinsfileBase so that it is always invoked as part of the Test job teardown and before the WS-CLEANUP.
Also enhanced the logic to iterate until no more Java processes, as they get spawned by the remaining processes.
Also added "CleanBeforeCheckout" to the openjdk-tests GitSCM checkout so that in the case where test material has been left following a bad job, it is cleaned... 

Signed-off-by: Andrew Leonard <anleonar@redhat.com>