### PR TITLE
fix wrong openjdk checkout directory

### DIFF
--- a/openjdk/build.xml
+++ b/openjdk/build.xml
@@ -118,7 +118,7 @@
 						<exec executable="git" failonerror="true">
 							<arg line="clone -q -b ${env.JDK_BRANCH} ${JDK_REPO_SPECIFIC} openjdktemp" />
 						</exec>
-						<exec executable="git" failonerror="true" dir="openjdk-jdk">
+						<exec executable="git" failonerror="true" dir="openjdktemp">
 							<arg line="checkout ${env.OPENJDK_SHA}" />
 						</exec>
 					</then>


### PR DESCRIPTION
we will run into the following error when JDK_REPO, JDK_BRANCH, and OPENJDK_SHA are all set:

```
getOpenjdk:
     [echo]  Using user specified repo and branch
     [echo] git clone -q -b test#7642 https://ms-juniper@dev.azure.com/ms-juniper/Juniper/_git/jdk11u openjdktemp

BUILD FAILED
D:\a\1\openjdk-tests\TKG\scripts\build_test.xml:60: The following error occurred while executing this line:
D:\a\1\openjdk-tests\openjdk\build.xml:269: The following error occurred while executing this line:
D:\a\1\openjdk-tests\openjdk\build.xml:121: The directory D:\a\1\openjdk-tests\openjdk\openjdk-jdk does not exist
```

the checkout directory for the following line should be the git clone directory which is the `openjdktemp`