### PR TITLE
Add Dynamic Breadth First Scan Ordering Testing

### DIFF
--- a/system/daaLoadTest/playlist.xml
+++ b/system/daaLoadTest/playlist.xml
@@ -200,6 +200,7 @@
 			<variation>Mode610-OSRG</variation>
 			<variation>Mode612-OSRG</variation>
 			<variation>Mode645</variation>
+			<variation>-Xgcpolicy:gencon -Xgc:dynamicBreadthFirstScanOrdering</variation>
 			<!--Note: -Xint modes Mode108, Mode109, Mode109-CS, Mode159, Mode159-CS, Mode550 should be run manually -->
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test-args=$(Q)workload=daa1$(Q) -test=DaaLoadTest; \
@@ -249,6 +250,7 @@
 			<variation>Mode610-OSRG</variation>
 			<variation>Mode612-OSRG</variation>
 			<variation>Mode645</variation>
+			<variation>-Xgcpolicy:gencon -Xgc:dynamicBreadthFirstScanOrdering</variation>
 			<!--Note: -Xint modes Mode108, Mode109, Mode109-CS, Mode159, Mode159-CS, Mode550 should be run manually -->
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test-args=$(Q)workload=daa2$(Q) -test=DaaLoadTest; \
@@ -298,6 +300,7 @@
 			<variation>Mode610-OSRG</variation>
 			<variation>Mode612-OSRG</variation>
 			<variation>Mode645</variation>
+			<variation>-Xgcpolicy:gencon -Xgc:dynamicBreadthFirstScanOrdering</variation>
 			<!--Note: -Xint modes Mode108, Mode109, Mode109-CS, Mode159, Mode159-CS, Mode550 should be run manually -->
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test-args=$(Q)workload=daa3$(Q) -test=DaaLoadTest; \
@@ -347,6 +350,7 @@
 			<variation>Mode610-OSRG</variation>
 			<variation>Mode612-OSRG</variation>
 			<variation>Mode645</variation>
+			<variation>-Xgcpolicy:gencon -Xgc:dynamicBreadthFirstScanOrdering</variation>
 			<!--Note: -Xint modes Mode108, Mode109, Mode109-CS, Mode159, Mode159-CS, Mode550 should be run manually -->
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=DaaLoadTest; \

--- a/system/lambdaLoadTest/playlist.xml
+++ b/system/lambdaLoadTest/playlist.xml
@@ -145,6 +145,7 @@
 			<variation>Mode610-OSRG</variation>
 			<variation>Mode612-OSRG</variation>
 			<variation>Mode645</variation>
+			<variation>-Xgcpolicy:gencon -Xgc:dynamicBreadthFirstScanOrdering</variation>
 			<!--Note: -Xint modes Mode108, Mode109, Mode109-CS, Mode159, Mode159-CS, Mode550 should be run manually -->
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=LambdaLoadTest; \
@@ -195,6 +196,7 @@
 			<variation>Mode610-OSRG</variation>
 			<variation>Mode612-OSRG</variation>
 			<variation>Mode645</variation>
+			<variation>-Xgcpolicy:gencon -Xgc:dynamicBreadthFirstScanOrdering</variation>
 			<!--Note: -Xint modes Mode108, Mode109, Mode109-CS, Mode159, Mode159-CS, Mode550 should be run manually -->
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=LambdaLoadTest; \

--- a/system/mathLoadTest/playlist.xml
+++ b/system/mathLoadTest/playlist.xml
@@ -154,6 +154,7 @@
 			<variation>Mode610-OSRG</variation>
 			<variation>Mode612-OSRG</variation>
 			<variation>Mode645</variation>
+			<variation>-Xgcpolicy:gencon -Xgc:dynamicBreadthFirstScanOrdering</variation>
 			<!--Note: -Xint modes Mode108, Mode109, Mode109-CS, Mode159, Mode159-CS, Mode550 should be run manually -->
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MathLoadTest; \
@@ -203,6 +204,7 @@
 			<variation>Mode610-OSRG</variation>
 			<variation>Mode612-OSRG</variation>
 			<variation>Mode645</variation>
+			<variation>-Xgcpolicy:gencon -Xgc:dynamicBreadthFirstScanOrdering</variation>
 			<!--Note: -Xint modes Mode108, Mode109, Mode109-CS, Mode159, Mode159-CS, Mode550 should be run manually -->
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test-args=$(Q)workload=autoSimd$(Q) -test=MathLoadTest; \
@@ -256,6 +258,7 @@
 			<variation>Mode610-OSRG</variation>
 			<variation>Mode612-OSRG</variation>
 			<variation>Mode645</variation>
+			<variation>-Xgcpolicy:gencon -Xgc:dynamicBreadthFirstScanOrdering</variation>
 			<!--Note: -Xint modes Mode108, Mode109, Mode109-CS, Mode159, Mode159-CS, Mode550 should be run manually -->
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MathLoadTest -test-args=$(Q)workload=bigDecimal$(Q); \

--- a/system/mauveLoadTest/playlist.xml
+++ b/system/mauveLoadTest/playlist.xml
@@ -204,6 +204,7 @@
 			<variation>Mode110-OSRG</variation>
 			<variation>Mode610-OSRG</variation>
 			<variation>Mode612-OSRG</variation>
+			<variation>-Xgcpolicy:gencon -Xgc:dynamicBreadthFirstScanOrdering</variation>
 			<!--Note: -Xint modes Mode108, Mode109, Mode550 should be run manually -->
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MauveMultiThrdLoadTrc; \
@@ -257,6 +258,7 @@
 			<variation>Mode110-OSRG</variation>
 			<variation>Mode610-OSRG</variation>
 			<variation>Mode612-OSRG</variation>
+			<variation>-Xgcpolicy:gencon -Xgc:dynamicBreadthFirstScanOrdering</variation>
 			<!--Note: -Xint modes Mode108, Mode109, Mode550 should be run manually -->
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MauveSingleThrdLoadTrc; \
@@ -307,6 +309,7 @@
 			<variation>Mode110-OSRG</variation>
 			<variation>Mode610-OSRG</variation>
 			<variation>Mode612-OSRG</variation>
+			<variation>-Xgcpolicy:gencon -Xgc:dynamicBreadthFirstScanOrdering</variation>
 			<!--Note: -Xint modes Mode108, Mode109, Mode550 should be run manually -->
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MauveSingleInvocLoad; \

--- a/system/otherLoadTest/playlist.xml
+++ b/system/otherLoadTest/playlist.xml
@@ -79,6 +79,7 @@
 			<variation>Mode610-OSRG</variation>
 			<variation>Mode612-OSRG</variation>
 			<variation>Mode645</variation>
+			<variation>-Xgcpolicy:gencon -Xgc:dynamicBreadthFirstScanOrdering</variation>
 			<!--Note: -Xint modes Mode108, Mode109, Mode109-CS, Mode159, Mode159-CS, Mode550 should be run manually -->
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=ClassloadingLoadTest; \


### PR DESCRIPTION
Add Dynamic Breadth-First Scan Ordering testing so
that this new GC feature is tested on an ongoing basis.

Issue: eclipse/openj9#7552
Signed-off-by: Jonathan Oommen <jon.oommen@gmail.com>