### PR TITLE
WIP: Add vendor-specific tests for jdk builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ functional
 !functional/security
 !functional/SyntheticGCWorkload
 !functional/MBCS_Tests
+!functional/BuildTestsForSpecificVendors
 
 Utils
 systemtest_prereqs/*

--- a/functional/BuildTestsForSpecificVendors/README.md
+++ b/functional/BuildTestsForSpecificVendors/README.md
@@ -1,0 +1,69 @@
+# Vendor-Specific Testing
+
+## Build Tests
+
+### 1) Contents
+1) Contents
+2) Purpose
+3) Usage
+4) Current Tests
+5) Adding new tests
+6) FAQ
+
+### 2) Purpose
+
+The purpose of the Vendor Specific "Build" tests are to verify specific aspects of an OpenJDK build from a  
+specific vendor (like Adopt).  
+
+Specifically, tests which only verify quality when testing a build from that vendor. A build from a different  
+vendor cannot be said to be good or bad as a result of passing or failing these tests.  
+
+E.g. Adopt may decline to bundle an optional library with its builds. Builds from other providers can be  
+perfectly ok both with and without this library, but an Adopt build could only be said to be "good" if  
+the example lib was successfully excluded. So an adopt-specific test is created to test for the lib's absence 
+ 
+### 3) Usage
+
+The commands needed to run these tests locally can be found inside the playlist.xml file in this directory.
+
+When run on a regular basis, these should be run alongside the existing functional tests as part of
+a standard suite of post-build functional validation testing.
+
+### 4) Current Tests
+
+- **CUDA enabled test (AdoptOpenJDK)**: Tests that the CUDA functionality has been enabled in JDKs on supported platforms.
+  
+- **Freetype Absence test (AdoptOpenJDK)**: Tests for the absence of a bundled freetype library in any Linux JDK.
+
+### 5) Adding new tests
+
+To add a new test, follow these steps:
+
+1) Add a title and brief description of your test to the "Current Tests" section above, including
+the name/s of any vendors whose JDK builds you intend to test with this.
+
+2) Add the test source (ideally testng) to:
+```./src/net/\<vendor name\>/test/build/\<test name \(dir\)\>/```
+Note: A test template is available for reference or copying, and can be found at:
+```./src/net/adoptopenjdk/test/build/TestTemplate.java```
+
+3) (Testng tests only) Add an entry to testng.xml for your test.
+
+3) (Non-testng tests) If not a testng test, add a test execution command to the playlist.xml file in this directory, using other \<test\> elements as reference.
+
+4) (Optional) If the test requires special treatment for building, modify the build.xml file as needed. Most java-based tests should require no changes.
+
+### 5) FAQ
+
+Q1) What happens if I run one of these tests against a non-Adopt build, or a build too old for what it's testing?  
+A1) The test (if appropriate) should automatically pass if:  
+- The build was not produced by the relevant vendor.  
+- The test is being run on the wrong JDK major version.  
+- The test is being run on a build that's too old for what we're testing.  
+Note:  from: ./src/net/adoptopenjdk/test/build/common/BuildIs.java  
+
+Q2) Can I put tests for non-AdoptOpenJDK vendor builds in here?  
+A2) Yes, though you should ensure the vendor name in the source path is set correctly.
+
+Q3) Where can I ask questions?
+A3) The #testing Slack channel at AdoptOpenJDK is a good place to ask questions.

--- a/functional/BuildTestsForSpecificVendors/build.xml
+++ b/functional/BuildTestsForSpecificVendors/build.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0"?>
+
+<!--
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+-->
+
+<project name="Build Tests For Specific Vendors" default="build" basedir=".">
+	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+	<description>
+		Build Tests For Specific Vendors
+    </description>
+	<import file="${TEST_ROOT}/functional/build.xml"/>
+
+	<!-- set global properties for this build -->
+	<property name="DEST" value="${BUILD_ROOT}/functional/BuildTestsForSpecificVendors" />
+
+	<!--Properties for this particular build-->
+	<property name="src" location="./src" />
+	<property name="build" location="./bin" />
+	
+	<target name="init">
+		<mkdir dir="${DEST}" />
+		<mkdir dir="${build}" />
+	</target>
+
+	<target name="compile" depends="init" description="Using java ${JDK_VERSION} to compile the source  ">
+		<echo>Ant version is ${ant.version}</echo>
+		<echo>============COMPILER SETTINGS============</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
+		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
+			<src path="${src}" />
+			<classpath>
+				<pathelement location="${LIB_DIR}/testng.jar"/>
+				<pathelement location="${LIB_DIR}/jcommander.jar"/>
+			</classpath>
+		</javac>
+	</target>
+		
+	<target name="dist" depends="compile,dist_functional" description="generate the distribution">
+		<jar jarfile="${DEST}/BuildTestsForSpecificVendors.jar" filesonly="true">
+			<fileset dir="${build}" />
+			<fileset dir="${src}/../" includes="*.properties,*.xml" />
+		</jar>
+		<copy todir="${DEST}">
+			<fileset dir="${src}/../" includes="*.xml" />
+			<fileset dir="${src}/../" includes="*.mk" />
+		</copy>
+	</target>
+
+	<target name="clean" depends="dist" description="clean up">
+		<!-- Delete the ${build} directory trees -->
+		<delete dir="${build}" />
+	</target>
+
+	<target name="build" >
+		<antcall target="clean" inheritall="true" />
+	</target>
+</project>

--- a/functional/BuildTestsForSpecificVendors/playlist.xml
+++ b/functional/BuildTestsForSpecificVendors/playlist.xml
@@ -1,0 +1,28 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+-->
+
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TKG/playlist.xsd">
+	<test>
+		<testCaseName>BuildTestsForSpecificVendors</testCaseName>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)BuildTestsForSpecificVendors.jar$(Q) org.testng.TestNG $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -d $(REPORTDIR) -testnames BuildTestsForSpecificVendors -groups $(TEST_GROUP) -excludegroups $(DEFAULT_EXCLUDE); \
+		$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+	</test>
+</playlist>

--- a/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/TestTemplate.java
+++ b/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/TestTemplate.java
@@ -1,0 +1,36 @@
+package net.adoptopenjdk.test.build;
+
+import net.adoptopenjdk.test.build.common.BuildIs;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.testng.log4testng.Logger;
+
+/*
+ * Test description goes here.
+ */
+@Test(groups={ "level.sanity" })
+public class TestTemplate {
+
+    private static Logger logger = Logger.getLogger(TestTemplate.class);
+
+    /**
+     * Returns true if, and only if, we're running on a build & platform this test
+     * is relevant to.
+     */
+    private boolean rightEnvForTest() {
+        // BuildIs methods are used like asserts.
+        return BuildIs.createdByThisVendor("AdoptOpenJDK")
+               && BuildIs.thisMajorVersion(8)
+               && BuildIs.moreRecentThanOrEqualToVersion("1.8.0_250+b20");
+    }
+
+    @Test
+    public void testTemplateExample() {
+        if(!rightEnvForTest()) return;
+        logger.info("Log message for the template test.");
+        String whatWeGot = "aaa";
+        String whatWeWant = "aaa";
+        Assert.assertEquals(whatWeGot, whatWeWant, "Print this message if those two strings don't match.");
+    }
+
+}

--- a/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/TestTemplate.java
+++ b/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/TestTemplate.java
@@ -26,11 +26,15 @@ public class TestTemplate {
 
     @Test
     public void testTemplateExample() {
-        if(!rightEnvForTest()) return;
-        logger.info("Log message for the template test.");
+        if(!rightEnvForTest()) {
+        	logger.info("Wrong environment for test. Skipped!");
+            return;
+        }
+        logger.info("Test template test starting.");
         String whatWeGot = "aaa";
         String whatWeWant = "aaa";
         Assert.assertEquals(whatWeGot, whatWeWant, "Print this message if those two strings don't match.");
+        logger.info("Test completed successfully.");
     }
 
 }

--- a/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/common/BuildIs.java
+++ b/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/common/BuildIs.java
@@ -147,7 +147,7 @@ public class BuildIs
         //First we turn it into a String that only has ints and dots.
         String formattedVersion = version;
         boolean hasBuildNumber = formattedVersion.contains("b") || formattedVersion.contains("+");
-        formattedVersion = formattedVersion.replaceAll("+", ".");
+        formattedVersion = formattedVersion.replaceAll("\\+", ".");
         formattedVersion = formattedVersion.replaceAll("-", ".");
         formattedVersion = formattedVersion.replaceAll("_", ".");
         formattedVersion = formattedVersion.replaceAll("b", ".");

--- a/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/common/BuildIs.java
+++ b/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/common/BuildIs.java
@@ -172,7 +172,7 @@ public class BuildIs
 	        ArrayList<String> formattedVersionArray = new ArrayList(formattedVersion.split("\\."));
 	        for (int x = 0; x < formattedVersionArray.size() ; ) {
 	        	if (formattedVersionArray.get(x).length() > 5) {
-	        	    formattedVersionArray.remove(x)
+	        	    formattedVersionArray.remove(x);
 	        	} else {
 	        	    x++;
 	        	}

--- a/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/common/BuildIs.java
+++ b/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/common/BuildIs.java
@@ -1,0 +1,171 @@
+package net.adoptopenjdk.test.build.common;
+
+import java.util.Map;
+
+public class BuildIs
+{
+    /**
+     * Returns whether the jdk build we're running 
+     * on was built by the vendor that matches the
+     * supplied string.
+     * 
+     * E.g. "AdoptOpenJDK"
+     */
+    public static boolean createdByThisVendor(String vendorName)
+    {
+        String lowercaseVendorName = vendorName.toLowerCase();
+        if (lowercaseVendorName.equals("adopt") || lowercaseVendorName.equals("adoptopenjdk")) {
+            return System.getProperty("java.vendor").equals("AdoptOpenJDK");
+        }
+
+        return System.getProperty("java.vendor").toLowerCase().equals(lowercaseVendorName);
+    }
+    
+    /**
+     * Returns true if we're using a Hotspot VM.
+     */
+    public static boolean usingAHotspotVM() {
+        //TODO: Figure out a better way of doing this. System properties don't seem to say 
+        //Hotspot anywhere except sun.management.compiler, which looks a bit "legacy" to me.
+        return !usingAnOpenJ9VM();
+    }
+     
+    /**
+     * Returns true if we're using an OpenJ9 VM.
+     */
+    public static boolean usingAnOpenJ9VM() {
+        return System.getProperty("java.vm.name").contains("OpenJ9");
+    }
+
+    /** 
+     * Takes a java.version value representing the oldest 
+     * acceptable version, and returns a boolean 
+     * indicating if this code is running on a JDK more 
+     * recent than (or equal to) the version supplied. 
+     * E.g. "1.8.0_275 or 11.0.2 or 11.0.2.1"
+     * Note: Omitting trailing characters defaults them to 0.
+     * (So 1.8.0 is treated as 1.8.0_0-b0)
+     * Also note: This method assumes all JDK11 builds
+     * are older than JDK8 builds, so compare major java
+     * versions separately if this concerns you.
+     */
+    public static boolean moreRecentThanOrEqualToVersion(String version)
+    {
+        int[] currentVersionArray = turnStringVersionIntoIntArray(System.getProperty("java.runtime.version"));
+        int[] usersVersionArray = turnStringVersionIntoIntArray(version);
+        
+        for (int x = 0 ; x < currentVersionArray.length ; x++ ) {
+            if (currentVersionArray[x] > usersVersionArray[x]) {
+                // The current build is newer than the supplied build version.
+                return true;
+            } else if (usersVersionArray[x] > currentVersionArray[x]) {
+                // The current build is older than the supplied build version.
+                return false;
+            }
+        }
+        
+        // The current build matches the supplied build version.
+        return true;
+    }
+
+    /**
+     * Takes an java.version value representing the most recent 
+     * acceptable version, and returns a boolean 
+     * indicating if this code is running on a JDK older
+     * than the version supplied: 
+     * E.g. "1.8.0_275 or 11.0.2 or 11.0.2.1"
+     * Note: Omitting trailing characters defaults them to 0.
+     * (So 1.8.0 is treated as 1.8.0_0-b0)
+     * Also note: This method assumes all JDK11 builds
+     * are older than JDK8 builds, so compare major java
+     * versions separately if this concerns you.
+     */
+    public static boolean olderThanVersion(String version)
+    {
+        int[] currentVersionArray = turnStringVersionIntoIntArray(System.getProperty("java.runtime.version"));
+        int[] usersVersionArray = turnStringVersionIntoIntArray(version);
+        
+        for (int x = 0 ; x < currentVersionArray.length ; x++ ) {
+            if (currentVersionArray[x] < usersVersionArray[x]) {
+                // The current build is newer than the supplied build version.
+                return true;
+            } else if (usersVersionArray[x] < currentVersionArray[x]) {
+                // The current build is older than the supplied build version.
+                return false;
+            }
+        }
+        
+        // The current build matches the supplied build version.
+        return false;
+    }
+
+    /**
+     * Returns whether the major version of the jdk 
+     * build we're running on matches the supplied 
+     * int (for jdk8, use 8).
+     */
+    public static boolean thisMajorVersion(int majorVersion)
+    {
+        int[] currentVersionArray = turnStringVersionIntoIntArray(System.getProperty("java.runtime.version"));
+        if(currentVersionArray[0] == majorVersion) return true;
+        return false;
+    }
+
+    /**
+     * Returns whether the major version of the jdk 
+     * build we're running on is above the supplied 
+     * int (for jdk8, use 8).
+     */
+    public static boolean aboveThisMajorVersion(int majorVersion)
+    {
+        int[] currentVersionArray = turnStringVersionIntoIntArray(System.getProperty("java.runtime.version"));
+        if(currentVersionArray[0] > majorVersion) return true;
+        return false;
+    }
+
+    /**
+     * Returns whether the major version of the jdk 
+     * build we're running on is below the supplied 
+     * int (for jdk8, use 8).
+     */
+    public static boolean belowThisMajorVersion(int majorVersion)
+    {
+        int[] currentVersionArray = turnStringVersionIntoIntArray(System.getProperty("java.runtime.version"));
+        if(currentVersionArray[0] < majorVersion) return true;
+        return false;
+    }
+    
+    /**
+     * Takes a runtime version string and returns it as an
+     * int array that we can easily compare to other versions.
+     * E.g. "1.8.0_275-b01" or "11.0.2+9" or "11.0.2.1+9"
+     * Note: Omitting trailing characters defaults them to 0.
+     * (So 1.8.0 and 1.8.potato are treated as 1.8.0_0-b0)
+     */
+    private static int[] turnStringVersionIntoIntArray(String version)
+    {
+        //First we turn it into a String that only has ints and dots.
+        String formattedVersion = version;
+        boolean hasBuildNumber = formattedVersion.contains("b") || formattedVersion.contains("+");
+        formattedVersion = formattedVersion.replaceAll("+", ".");
+        formattedVersion = formattedVersion.replaceAll("-", ".");
+        formattedVersion = formattedVersion.replaceAll("_", ".");
+        formattedVersion = formattedVersion.replaceAll("b", ".");
+        formattedVersion = formattedVersion.replaceAll("\\.\\.", ".");
+        if (formattedVersion.startsWith("1.")) formattedVersion = formattedVersion.substring(2);
+        
+        //Then we turn it into an array, adding any missing zeros.
+        int[] versionArray = {0,0,0,0,0};
+        String[] formattedVersionArray = formattedVersion.split("\\.");
+        for (int x = 0; x < formattedVersionArray.length ; x++ ) {
+            if ((formattedVersionArray[x].length() > 5) || (x == (versionArray.length - 1))) break;
+            versionArray[x] = Integer.parseInt(formattedVersionArray[x]);
+        }
+        
+        if (hasBuildNumber) {
+            versionArray[versionArray.length - 1] = Integer.parseInt(formattedVersionArray[formattedVersionArray.length - 1]);
+        }
+        
+        return versionArray;
+    }
+}

--- a/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/common/BuildIs.java
+++ b/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/common/BuildIs.java
@@ -171,6 +171,5 @@ public class BuildIs
     	} catch(Exception e) {
     	    throw new Exception("The BuildIs class has tried and failed to parse the java version string \"" + version + "\".", e);
     	}
-    	}
     }
 }

--- a/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/common/BuildIs.java
+++ b/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/common/BuildIs.java
@@ -169,7 +169,10 @@ public class BuildIs
 	        //any too-long numbers that are likely the build system putting the date into
 	        //the version string of nightlies.
 	        int[] returnVersionArray = {0,0,0,0,0};
-	        ArrayList<String> formattedVersionArray = new ArrayList(formattedVersion.split("\\."));
+	        ArrayList<String> formattedVersionArray = new ArrayList<String>();
+	        for (int x : formattedVersion.split("\\.")) {
+                formattedVersionArray.add(x);
+            }
 	        for (int x = 0; x < formattedVersionArray.size() ; ) {
 	        	if (formattedVersionArray.get(x).length() > 5) {
 	        	    formattedVersionArray.remove(x);

--- a/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/common/BuildIs.java
+++ b/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/common/BuildIs.java
@@ -169,7 +169,7 @@ public class BuildIs
 	        
 	        return versionArray;
     	} catch(Exception e) {
-    	    throw new Exception("The BuildIs class has tried and failed to parse the java version string \"" + version + "\".", e);
+    	    throw new Error("The BuildIs class has tried and failed to parse the java version string \"" + version + "\".", e);
     	}
     }
 }

--- a/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/common/BuildIs.java
+++ b/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/common/BuildIs.java
@@ -144,28 +144,33 @@ public class BuildIs
      */
     private static int[] turnStringVersionIntoIntArray(String version)
     {
-        //First we turn it into a String that only has ints and dots.
-        String formattedVersion = version;
-        boolean hasBuildNumber = formattedVersion.contains("b") || formattedVersion.contains("+");
-        formattedVersion = formattedVersion.replaceAll("\\+", ".");
-        formattedVersion = formattedVersion.replaceAll("-", ".");
-        formattedVersion = formattedVersion.replaceAll("_", ".");
-        formattedVersion = formattedVersion.replaceAll("b", ".");
-        formattedVersion = formattedVersion.replaceAll("\\.\\.", ".");
-        if (formattedVersion.startsWith("1.")) formattedVersion = formattedVersion.substring(2);
+    	try {
+            //First we turn it into a String that only has ints and dots.
+            String formattedVersion = version;
+            boolean hasBuildNumber = formattedVersion.contains("b") || formattedVersion.contains("+");
+	        formattedVersion = formattedVersion.replaceAll("\\+", ".");
+	        formattedVersion = formattedVersion.replaceAll("-", ".");
+	        formattedVersion = formattedVersion.replaceAll("_", ".");
+	        formattedVersion = formattedVersion.replaceAll("b", ".");
+	        formattedVersion = formattedVersion.replaceAll("\\.\\.", ".");
+	        if (formattedVersion.startsWith("1.")) formattedVersion = formattedVersion.substring(2);
         
-        //Then we turn it into an array, adding any missing zeros.
-        int[] versionArray = {0,0,0,0,0};
-        String[] formattedVersionArray = formattedVersion.split("\\.");
-        for (int x = 0; x < formattedVersionArray.length ; x++ ) {
-            if ((formattedVersionArray[x].length() > 5) || (x == (versionArray.length - 1))) break;
-            versionArray[x] = Integer.parseInt(formattedVersionArray[x]);
-        }
-        
-        if (hasBuildNumber) {
-            versionArray[versionArray.length - 1] = Integer.parseInt(formattedVersionArray[formattedVersionArray.length - 1]);
-        }
-        
-        return versionArray;
+	        //Then we turn it into an array, adding any missing zeros.
+	        int[] versionArray = {0,0,0,0,0};
+	        String[] formattedVersionArray = formattedVersion.split("\\.");
+	        for (int x = 0; x < formattedVersionArray.length ; x++ ) {
+	            if ((formattedVersionArray[x].length() > 5) || (x == (versionArray.length - 1))) break;
+	            versionArray[x] = Integer.parseInt(formattedVersionArray[x]);
+	        }
+	        
+	        if (hasBuildNumber) {
+	            versionArray[versionArray.length - 1] = Integer.parseInt(formattedVersionArray[formattedVersionArray.length - 1]);
+	        }
+	        
+	        return versionArray;
+    	} catch(Exception e) {
+    	    throw new Exception("The BuildIs class has tried and failed to parse the java version string \"" + version + "\".", e);
+    	}
+    	}
     }
 }

--- a/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/common/BuildIs.java
+++ b/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/common/BuildIs.java
@@ -170,7 +170,7 @@ public class BuildIs
 	        //the version string of nightlies.
 	        int[] returnVersionArray = {0,0,0,0,0};
 	        ArrayList<String> formattedVersionArray = new ArrayList<String>();
-	        for (int x : formattedVersion.split("\\.")) {
+	        for (String x : formattedVersion.split("\\.")) {
                 formattedVersionArray.add(x);
             }
 	        for (int x = 0; x < formattedVersionArray.size() ; ) {

--- a/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/cuda/CudaEnabledTest.java
+++ b/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/cuda/CudaEnabledTest.java
@@ -87,10 +87,7 @@ public class CudaEnabledTest {
         try {
             BufferedReader prtFileReader = new BufferedReader(new FileReader(prtFile));
             String oneLine = "";
-            int x = 0;
-            logger.info("Starting j9prt file read: " + prtFile);
             while ((oneLine = prtFileReader.readLine()) != null) {
-                logger.info("Line " + x + ": " + oneLine);
                 if(oneLine.contains("cudart")) {
                 	logger.info("Test completed successfully.");
                     return; //Success!

--- a/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/cuda/CudaEnabledTest.java
+++ b/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/cuda/CudaEnabledTest.java
@@ -63,7 +63,7 @@ public class CudaEnabledTest {
 
         prtLibDirectory = System.getProperty("java.home") + prtLibDirectory;
         File prtDirObject = new File(prtLibDirectory);
-        Assert.assertTrue(prtDirObject.exists(), "Can't find the predicted location of the j9prt lib file.");
+        Assert.assertTrue(prtDirObject.exists(), "Can't find the predicted location of the j9prt lib file. Expected location: " + prtLibDirectory);
         
         String[] prtLibDirectoryFiles = prtDirObject.list();
         File prtFile = null;

--- a/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/cuda/CudaEnabledTest.java
+++ b/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/cuda/CudaEnabledTest.java
@@ -1,6 +1,6 @@
 package net.adoptopenjdk.test.build.cuda;
 
-import java.io.BufferedReader
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;

--- a/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/cuda/CudaEnabledTest.java
+++ b/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/cuda/CudaEnabledTest.java
@@ -32,7 +32,10 @@ public class CudaEnabledTest {
 
     @Test
     public void testIfCudaIsEnabled() {
-        if(!rightEnvForTest()) return;
+        if(!rightEnvForTest()) {
+        	logger.info("Wrong environment for test. Skipped!");
+        	return;
+        }
         logger.info("Starting test to see if CUDA functionality is enabled in this build.");
         
         //Stage 1: Find the location of the j9prt lib file.
@@ -79,6 +82,7 @@ public class CudaEnabledTest {
             Scanner prtFileReader = new Scanner(prtFile);
             while (prtFileReader.hasNextLine()) {
                 if(prtFileReader.nextLine().contains("cudart")) {
+                	logger.info("Test completed successfully.");
                     return; //Success!
                 }
             }

--- a/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/cuda/CudaEnabledTest.java
+++ b/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/cuda/CudaEnabledTest.java
@@ -39,29 +39,32 @@ public class CudaEnabledTest {
         logger.info("Starting test to see if CUDA functionality is enabled in this build.");
         
         //Stage 1: Find the location of the j9prt lib file.
-        String prtLibDirectory = "";
+        String prtLibDirectory = System.getProperty("java.home");
+        String jreSubdir = "";
+        if((new File(prtLibDirectory + "/jre")).exists()) {
+        	jreSubdir = "/jre"
+        }
         if("Linux".contains(System.getProperty("os.name").split(" ")[0])) {
             if(BuildIs.thisMajorVersion(8)) {
-                prtLibDirectory = "/jre/lib/amd64/compressedrefs";
+                prtLibDirectory += jreSubdir + "/lib/amd64/compressedrefs";
             } else {
-                prtLibDirectory = "/lib/compressedrefs";
+                prtLibDirectory += "/lib/compressedrefs";
             }
         }
         //windows
         if("Windows".contains(System.getProperty("os.name").split(" ")[0])) {
             if(BuildIs.thisMajorVersion(8)) {
                 //jdk8 32: 
-                prtLibDirectory = "/jre/bin/compressedrefs";
-                if(!(new File(System.getProperty("java.home") + prtLibDirectory)).exists()) {
+                prtLibDirectory += jreSubdir + "/bin/compressedrefs";
+                if(!(new File(prtLibDirectory)).exists()) {
                     //In case of a 32-bit build, or a non-cr build.
-                    prtLibDirectory = "/jre/bin/default";
+                    prtLibDirectory = System.getProperty("java.home") + jreSubdir + "/bin/default";
                 }
             } else {
-                prtLibDirectory = "/bin/compressedrefs";
+                prtLibDirectory += "/bin/compressedrefs";
             }
         }
 
-        prtLibDirectory = System.getProperty("java.home") + prtLibDirectory;
         File prtDirObject = new File(prtLibDirectory);
         Assert.assertTrue(prtDirObject.exists(), "Can't find the predicted location of the j9prt lib file. Expected location: " + prtLibDirectory);
         

--- a/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/cuda/CudaEnabledTest.java
+++ b/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/cuda/CudaEnabledTest.java
@@ -72,12 +72,13 @@ public class CudaEnabledTest {
         File prtFile = null;
         for(int x = 0 ; x < prtLibDirectoryFiles.length ; x++) {
         	if(prtLibDirectoryFiles[x].contains("j9prt")) {
-        	    prtFile = new File(prtLibDirectory + prtLibDirectoryFiles[x]);
+        	    prtFile = new File(prtLibDirectory + "/" + prtLibDirectoryFiles[x]);
         	    break;
         	}
         }
         Assert.assertNotNull(prtFile,"Can't find the j9prt lib file in " + prtLibDirectory);
-        Assert.assertTrue(prtFile.canRead());
+        Assert.assertTrue(prtFile.exists(), "Found the prt file, but it doesn't exist. Tautology bug.");
+        Assert.assertTrue(prtFile.canRead(), "Found the prt file, but it can't be read. Likely a permissions bug.");
         
         //Stage 2: Iterate through the j9prt lib file to find "cudart".
         //If we find it, then cuda functionality is enabled on this build.

--- a/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/cuda/CudaEnabledTest.java
+++ b/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/cuda/CudaEnabledTest.java
@@ -1,0 +1,92 @@
+package net.adoptopenjdk.test.build.cuda;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.util.Scanner;
+import net.adoptopenjdk.test.build.common.BuildIs;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.testng.log4testng.Logger;
+
+/*
+ * Tests if the Cuda functionality is enabled in this build.
+ * Fit for OpenJ9 builds on Windows, xLinux and pLinux.
+ */
+@Test(groups={ "level.sanity" })
+public class CudaEnabledTest {
+
+    private static Logger logger = Logger.getLogger(CudaEnabledTest.class);
+
+    /**
+     * Returns true if, and only if, we're running on a build & platform this test
+     * is relevant to.
+     */
+    private boolean rightEnvForTest() {
+        String arch = System.getProperty("os.arch");
+        
+        return BuildIs.createdByThisVendor("AdoptOpenJDK")
+               && BuildIs.usingAnOpenJ9VM()
+               && "amd64, x86, ppc".contains(System.getProperty("os.arch"))
+               && "Windows, Linux".contains(System.getProperty("os.name").split(" ")[0]);
+    }
+
+    @Test
+    public void testIfCudaIsEnabled() {
+        if(!rightEnvForTest()) return;
+        logger.info("Starting test to see if CUDA functionality is enabled in this build.");
+        
+        //Stage 1: Find the location of the j9prt lib file.
+        String prtLibDirectory = "";
+        if("Linux".contains(System.getProperty("os.name").split(" ")[0])) {
+            if(BuildIs.thisMajorVersion(8)) {
+                prtLibDirectory = "/jre/lib/amd64/compressedrefs";
+            } else {
+                prtLibDirectory = "/lib/compressedrefs";
+            }
+        }
+        //windows
+        if("Windows".contains(System.getProperty("os.name").split(" ")[0])) {
+            if(BuildIs.thisMajorVersion(8)) {
+                //jdk8 32: 
+                prtLibDirectory = "/jre/bin/compressedrefs";
+                if(!(new File(System.getProperty("java.home") + prtLibDirectory)).exists()) {
+                    //In case of a 32-bit build, or a non-cr build.
+                    prtLibDirectory = "/jre/bin/default";
+                }
+            } else {
+                prtLibDirectory = "/bin/compressedrefs";
+            }
+        }
+
+        prtLibDirectory = System.getProperty("java.home") + prtLibDirectory;
+        File prtDirObject = new File(prtLibDirectory);
+        Assert.assertTrue(prtDirObject.exists(), "Can't find the predicted location of the j9prt lib file.");
+        
+        String[] prtLibDirectoryFiles = prtDirObject.list();
+        File prtFile = null;
+        for(int x = 0 ; x < prtLibDirectoryFiles.length ; x++) {
+        	if(prtLibDirectoryFiles[x].contains("j9prt")) {
+        	    prtFile = new File(prtLibDirectory + prtLibDirectoryFiles[x]);
+        	    break;
+        	}
+        }
+        Assert.assertNotNull(prtFile,"Can't find the j9prt lib file in " + prtLibDirectory);
+        Assert.assertTrue(prtFile.canRead());
+        
+        //Stage 2: Iterate through the j9prt lib file to find "cudart".
+        //If we find it, then cuda functionality is enabled on this build.
+        try {
+            Scanner prtFileReader = new Scanner(prtFile);
+            while (prtFileReader.hasNextLine()) {
+                if(prtFileReader.nextLine().contains("cudart")) {
+                    return; //Success!
+                }
+            }
+            prtFileReader.close();
+        } catch (FileNotFoundException e) {
+            Assert.fail("A file that exists could not be found. This should never happen.");
+        }
+        Assert.fail("Cuda should be enabled on this build, but we found no evidence that this was the case.");
+    }
+
+}

--- a/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/cuda/CudaEnabledTest.java
+++ b/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/cuda/CudaEnabledTest.java
@@ -42,7 +42,7 @@ public class CudaEnabledTest {
         String prtLibDirectory = System.getProperty("java.home");
         String jreSubdir = "";
         if((new File(prtLibDirectory + "/jre")).exists()) {
-        	jreSubdir = "/jre"
+        	jreSubdir = "/jre";
         }
         if("Linux".contains(System.getProperty("os.name").split(" ")[0])) {
             if(BuildIs.thisMajorVersion(8)) {

--- a/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/cuda/CudaEnabledTest.java
+++ b/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/cuda/CudaEnabledTest.java
@@ -86,10 +86,10 @@ public class CudaEnabledTest {
             Scanner prtFileReader = new Scanner(prtFile);
             String lineyLine = "";
             int x = 0;
-            System.out.println("Starting j9prt file read: " + prtFile.toString());
+            logger.info("Starting j9prt file read: " + prtFile.toString());
             while (prtFileReader.hasNextLine()) {
                 lineyLine = prtFileReader.nextLine();
-                System.out.println("Line " + x + ": " + lineyLine);
+                logger.info("Line " + x + ": " + lineyLine);
                 if(lineyLine.contains("cudart")) {
                 	logger.info("Test completed successfully.");
                     return; //Success!

--- a/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/cuda/CudaEnabledTest.java
+++ b/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/cuda/CudaEnabledTest.java
@@ -84,8 +84,12 @@ public class CudaEnabledTest {
         //If we find it, then cuda functionality is enabled on this build.
         try {
             Scanner prtFileReader = new Scanner(prtFile);
+            String lineyLine = "";
+            int x = 0;
             while (prtFileReader.hasNextLine()) {
-                if(prtFileReader.nextLine().contains("cudart")) {
+                lineyLine = prtFileReader.nextLine();
+                System.out.println("Line " + x + ": " + lineyLine);
+                if(lineyLine.contains("cudart")) {
                 	logger.info("Test completed successfully.");
                     return; //Success!
                 }

--- a/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/cuda/CudaEnabledTest.java
+++ b/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/cuda/CudaEnabledTest.java
@@ -86,6 +86,7 @@ public class CudaEnabledTest {
             Scanner prtFileReader = new Scanner(prtFile);
             String lineyLine = "";
             int x = 0;
+            System.out.println("Starting j9prt file read: " + prtFile.toString());
             while (prtFileReader.hasNextLine()) {
                 lineyLine = prtFileReader.nextLine();
                 System.out.println("Line " + x + ": " + lineyLine);

--- a/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/freetype/FreetypeAbsenceTest.java
+++ b/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/freetype/FreetypeAbsenceTest.java
@@ -26,7 +26,7 @@ public class FreetypeAbsenceTest {
     }
 
     @Test
-    public void testTemplateExample() {
+    public void testifFreetypeIsExcluded() {
         if(!rightEnvForTest()) {
         	logger.info("Wrong environment for test. Skipped!");
         	return;

--- a/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/freetype/FreetypeAbsenceTest.java
+++ b/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/freetype/FreetypeAbsenceTest.java
@@ -27,13 +27,17 @@ public class FreetypeAbsenceTest {
 
     @Test
     public void testTemplateExample() {
-        logger.info("Log message for the template test.");
-        if(!rightEnvForTest()) return;
+        if(!rightEnvForTest()) {
+        	logger.info("Wrong environment for test. Skipped!");
+        	return;
+        }
+        logger.info("Freetype Absence test starting.");
         if(BuildIs.thisMajorVersion(8)) {
             Assert.assertFalse((new File(System.getProperty("java.home") + "/jre/lib/amd64/libfreetype.so.6")).exists());
         } else {
             Assert.assertFalse((new File(System.getProperty("java.home") + "/lib/libfreetype.so")).exists());
         }
+        logger.info("Freetype Absence test completed successfully.");
     }
 
 }

--- a/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/freetype/FreetypeAbsenceTest.java
+++ b/functional/BuildTestsForSpecificVendors/src/net/adoptopenjdk/test/build/freetype/FreetypeAbsenceTest.java
@@ -1,0 +1,39 @@
+package net.adoptopenjdk.test.build.freetype;
+
+import java.io.File;
+import net.adoptopenjdk.test.build.common.BuildIs;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.testng.log4testng.Logger;
+
+/*
+ * Tests for the (intentional and correct) absence of a bundled Freetype
+ * library in this JDK.
+ */
+@Test(groups={ "level.sanity" })
+public class FreetypeAbsenceTest {
+
+    private static Logger logger = Logger.getLogger(FreetypeAbsenceTest.class);
+
+    /**
+     * Returns true if, and only if, we're running on a build & platform this test
+     * is relevant to.
+     */
+    private boolean rightEnvForTest() {
+        // BuildIs methods are used like asserts.
+        return BuildIs.createdByThisVendor("AdoptOpenJDK")
+               && "Linux".contains(System.getProperty("os.name").split(" ")[0]);
+    }
+
+    @Test
+    public void testTemplateExample() {
+        logger.info("Log message for the template test.");
+        if(!rightEnvForTest()) return;
+        if(BuildIs.thisMajorVersion(8)) {
+            Assert.assertFalse((new File(System.getProperty("java.home") + "/jre/lib/amd64/libfreetype.so.6")).exists());
+        } else {
+            Assert.assertFalse((new File(System.getProperty("java.home") + "/lib/libfreetype.so")).exists());
+        }
+    }
+
+}

--- a/functional/BuildTestsForSpecificVendors/testng.xml
+++ b/functional/BuildTestsForSpecificVendors/testng.xml
@@ -1,0 +1,23 @@
+<!--
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+-->
+
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
+<suite name="Build Tests For Specific Vendors" parallel="none" verbose="2">
+	<test name="BuildTestsForSpecificVendors">
+		<classes>
+			<class name="net.adoptopenjdk.test.build.cuda.CudaEnabledTest"/>
+			<class name="net.adoptopenjdk.test.build.freetype.FreetypeAbsenceTest"/>
+		</classes>
+	</test>
+</suite>


### PR DESCRIPTION
These tests ensure that any vendor-specific build changes or fixes
are present and functional in the created builds on relevant
platforms, versions, etc.

The freetype and cuda tests are included in this change, as
documented.

Signed-off-by: Adam Farley <adfarley@redhat.com>