### PR TITLE
Perm exclude java/lang/StringBuilder/HugeCapacity.java

### DIFF
--- a/openjdk/ProblemList_openjdk16-openj9.txt
+++ b/openjdk/ProblemList_openjdk16-openj9.txt
@@ -67,6 +67,7 @@ java/lang/String/EqualsIgnoreCase.java	https://github.com/eclipse/openj9/issues/
 java/lang/String/StringRepeat.java	https://github.com/eclipse/openj9/issues/6667	generic-all
 java/lang/String/UnicodeCasingTest.java https://github.com/eclipse/openj9/issues/4597 linux-s390x
 java/lang/String/nativeEncoding/StringPlatformChars.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	generic-all
+java/lang/StringBuilder/HugeCapacity.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/System/Logger/custom/CustomLoggerTest.java	https://github.com/eclipse/openj9/issues/6674	generic-all
 java/lang/System/Logger/default/DefaultLoggerTest.java	https://github.com/eclipse/openj9/issues/6674	generic-all
 java/lang/System/LoggerFinder/BaseLoggerFinderTest/BaseLoggerFinderTest.java	https://github.com/eclipse/openj9/issues/6674	generic-all


### PR DESCRIPTION
The test is not compatible with OpenJ9.
a) It requires `-XX:+CompactStrings` to be the default.
b) It assumes `new byte[Integer.MAX_VALUE]` throws OOM, but OpenJ9
supports this.

The test exists prior to Java 16, but contains `@ignore` so doesn't run.
From Java 16 it contains `@requires (sun.arch.data.model == "64" &
os.maxMemory >= 6G)`.

Issue https://github.com/eclipse/openj9/issues/10582

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>