### PR TITLE
Ensure the coverage for mixedref SDK in system tests

### DIFF
--- a/system/daaLoadTest/playlist.xml
+++ b/system/daaLoadTest/playlist.xml
@@ -21,7 +21,8 @@
 	<test>
 		<testCaseName>DaaLoadTest_daa1</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test-args=$(Q)workload=daa1$(Q) -test=DaaLoadTest; \
 	$(TEST_STATUS)</command>
@@ -39,7 +40,8 @@
 	<test>
 		<testCaseName>DaaLoadTest_daa2</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test-args=$(Q)workload=daa2$(Q)  -test=DaaLoadTest; \
 	$(TEST_STATUS)</command>
@@ -57,7 +59,8 @@
 	<test>
 		<testCaseName>DaaLoadTest_daa3</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test-args=$(Q)workload=daa3$(Q) -test=DaaLoadTest; \
 	$(TEST_STATUS)</command>
@@ -75,7 +78,8 @@
 	<test>
 		<testCaseName>DaaLoadTest_all</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=DaaLoadTest; \
 	$(TEST_STATUS)</command>
@@ -173,7 +177,6 @@
 			<variation>Mode103</variation>
 			<variation>Mode104</variation>
 			<variation>Mode107</variation>
-			<variation>Mode110</variation>
 			<variation>Mode112</variation>
 			<variation>Mode113</variation>
 			<variation>Mode121</variation>
@@ -190,7 +193,6 @@
 			<variation>Mode556</variation>
 			<variation>Mode557</variation>
 			<variation>Mode607</variation>
-			<variation>Mode610</variation>
 			<variation>Mode614</variation>
 			<variation>Mode615</variation>
 			<variation>Mode687</variation>
@@ -223,7 +225,6 @@
 			<variation>Mode103</variation>
 			<variation>Mode104</variation>
 			<variation>Mode107</variation>
-			<variation>Mode110</variation>
 			<variation>Mode112</variation>
 			<variation>Mode113</variation>
 			<variation>Mode121</variation>
@@ -240,7 +241,6 @@
 			<variation>Mode556</variation>
 			<variation>Mode557</variation>
 			<variation>Mode607</variation>
-			<variation>Mode610</variation>
 			<variation>Mode614</variation>
 			<variation>Mode615</variation>
 			<variation>Mode687</variation>
@@ -273,7 +273,6 @@
 			<variation>Mode103</variation>
 			<variation>Mode104</variation>
 			<variation>Mode107</variation>
-			<variation>Mode110</variation>
 			<variation>Mode112</variation>
 			<variation>Mode113</variation>
 			<variation>Mode121</variation>
@@ -290,7 +289,6 @@
 			<variation>Mode556</variation>
 			<variation>Mode557</variation>
 			<variation>Mode607</variation>
-			<variation>Mode610</variation>
 			<variation>Mode614</variation>
 			<variation>Mode615</variation>
 			<variation>Mode687</variation>
@@ -323,7 +321,6 @@
 			<variation>Mode103</variation>
 			<variation>Mode104</variation>
 			<variation>Mode107</variation>
-			<variation>Mode110</variation>
 			<variation>Mode112</variation>
 			<variation>Mode113</variation>
 			<variation>Mode121</variation>
@@ -340,7 +337,6 @@
 			<variation>Mode556</variation>
 			<variation>Mode557</variation>
 			<variation>Mode607</variation>
-			<variation>Mode610</variation>
 			<variation>Mode614</variation>
 			<variation>Mode615</variation>
 			<variation>Mode687</variation>

--- a/system/jlm/playlist.xml
+++ b/system/jlm/playlist.xml
@@ -25,7 +25,8 @@
 	<test>
 		<testCaseName>TestJlmLocal</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=TestJlmLocal; \
 	$(TEST_STATUS)</command>
@@ -41,7 +42,8 @@
 	<test>
 		<testCaseName>TestJlmRemoteClassAuth</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=TestJlmRemoteClassAuth; \
 	$(TEST_STATUS)</command>
@@ -56,7 +58,8 @@
 	<test>
 		<testCaseName>TestJlmRemoteClassNoAuth</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=TestJlmRemoteClassNoAuth; \
 	$(TEST_STATUS)</command>
@@ -72,7 +75,8 @@
 	<test>
 		<testCaseName>TestJlmRemoteMemoryAuth</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=TestJlmRemoteMemoryAuth; \
 	$(TEST_STATUS)</command>
@@ -87,7 +91,8 @@
 	<test>
 		<testCaseName>TestJlmRemoteMemoryNoAuth</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=TestJlmRemoteMemoryNoAuth; \
 	$(TEST_STATUS)</command>
@@ -103,7 +108,8 @@
 	<test>
 		<testCaseName>TestJlmRemoteNotifierProxyAuth</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=TestJlmRemoteNotifierProxyAuth; \
 	$(TEST_STATUS)</command>
@@ -120,7 +126,8 @@
 	<test>
 		<testCaseName>TestJlmRemoteThreadAuth</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=TestJlmRemoteThreadAuth; \
 	$(TEST_STATUS)</command>
@@ -135,7 +142,8 @@
 	<test>
 		<testCaseName>TestJlmRemoteThreadNoAuth</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=TestJlmRemoteThreadNoAuth; \
 	$(TEST_STATUS)</command>
@@ -150,7 +158,8 @@
 	<test>
 		<testCaseName>TestIBMJlmLocal</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=TestIBMJlmLocal; \
 	$(TEST_STATUS)</command>
@@ -171,7 +180,8 @@
 	<test>
 		<testCaseName>TestIBMJlmRemoteClassAuth</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=TestIBMJlmRemoteClassAuth; \
 	$(TEST_STATUS)</command>
@@ -195,7 +205,8 @@
 	<test>
 		<testCaseName>TestIBMJlmRemoteClassAuth_SE80</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=TestIBMJlmRemoteClassAuth; \
 	$(TEST_STATUS)</command>
@@ -217,7 +228,8 @@
 	<test>
 		<testCaseName>TestIBMJlmRemoteClassAuth_SE80_Linux</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=TestIBMJlmRemoteClassAuth; \
 	$(TEST_STATUS)</command>
@@ -240,7 +252,8 @@
 	<test>
 		<testCaseName>TestIBMJlmRemoteClassNoAuth</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=TestIBMJlmRemoteClassNoAuth; \
 	$(TEST_STATUS)</command>
@@ -261,7 +274,8 @@
 	<test>
 		<testCaseName>TestIBMJlmRemoteClassNoAuth_SE80</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=TestIBMJlmRemoteClassNoAuth; \
 	$(TEST_STATUS)</command>
@@ -283,7 +297,8 @@
 	<test>
 		<testCaseName>TestIBMJlmRemoteClassNoAuth_SE80_Linux</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=TestIBMJlmRemoteClassNoAuth; \
 	$(TEST_STATUS)</command>
@@ -308,7 +323,8 @@
 	<test>
 		<testCaseName>TestIBMJlmRemoteMemoryAuth</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=TestIBMJlmRemoteMemoryAuth; \
 	$(TEST_STATUS)</command>
@@ -332,7 +348,8 @@
 	<test>
 		<testCaseName>TestIBMJlmRemoteMemoryAuth_SE80</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=TestIBMJlmRemoteMemoryAuth; \
 	$(TEST_STATUS)</command>
@@ -354,7 +371,8 @@
 	<test>
 		<testCaseName>TestIBMJlmRemoteMemoryAuth_SE80_Linux</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=TestIBMJlmRemoteMemoryAuth; \
 	$(TEST_STATUS)</command>
@@ -377,7 +395,8 @@
 	<test>
 		<testCaseName>TestIBMJlmRemoteMemoryNoAuth</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=TestIBMJlmRemoteMemoryNoAuth; \
 	$(TEST_STATUS)</command>
@@ -398,7 +417,8 @@
 	<test>
 		<testCaseName>TestIBMJlmRemoteMemoryNoAuth_SE80</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=TestIBMJlmRemoteMemoryNoAuth; \
 	$(TEST_STATUS)</command>
@@ -420,7 +440,8 @@
 	<test>
 		<testCaseName>TestIBMJlmRemoteMemoryNoAuth_SE80_Linux</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=TestIBMJlmRemoteMemoryNoAuth; \
 	$(TEST_STATUS)</command>

--- a/system/lambdaLoadTest/playlist.xml
+++ b/system/lambdaLoadTest/playlist.xml
@@ -22,7 +22,8 @@
 	<test>
 		<testCaseName>LambdaLoadTest_Hotspot</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=LambdaLoadTest; \
 	$(TEST_STATUS)</command>
@@ -39,7 +40,8 @@
 	<test>
 		<testCaseName>LambdaLoadTest_OpenJ9_NonLinux</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=LambdaLoadTest; \
 	$(TEST_STATUS)</command>
@@ -58,7 +60,8 @@
 	<test>
 		<testCaseName>LambdaLoadTest_OpenJ9_Linux_CompressedRefs</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=LambdaLoadTest; \
 	$(TEST_STATUS)</command>
@@ -80,7 +83,8 @@
 			<comment>AdoptOpenJDK/openjdk-systemtest/issues/63</comment>
 		</disabled>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=JdiTest; \
 	$(TEST_STATUS)</command>
@@ -118,7 +122,6 @@
 			<variation>Mode103</variation>
 			<variation>Mode104</variation>
 			<variation>Mode107</variation>
-			<variation>Mode110</variation>
 			<variation>Mode112</variation>
 			<variation>Mode113</variation>
 			<variation>Mode121</variation>
@@ -135,7 +138,6 @@
 			<variation>Mode556</variation>
 			<variation>Mode557</variation>
 			<variation>Mode607</variation>
-			<variation>Mode610</variation>
 			<variation>Mode614</variation>
 			<variation>Mode615</variation>
 			<variation>Mode687</variation>
@@ -169,7 +171,6 @@
 			<variation>Mode103</variation>
 			<variation>Mode104</variation>
 			<variation>Mode107</variation>
-			<variation>Mode110</variation>
 			<variation>Mode112</variation>
 			<variation>Mode113</variation>
 			<variation>Mode121</variation>
@@ -186,7 +187,6 @@
 			<variation>Mode556</variation>
 			<variation>Mode557</variation>
 			<variation>Mode607</variation>
-			<variation>Mode610</variation>
 			<variation>Mode614</variation>
 			<variation>Mode615</variation>
 			<variation>Mode687</variation>

--- a/system/mathLoadTest/playlist.xml
+++ b/system/mathLoadTest/playlist.xml
@@ -20,7 +20,8 @@
 	<test>
 		<testCaseName>MathLoadTest_all</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MathLoadTest; \
 	$(TEST_STATUS)</command>
@@ -34,7 +35,8 @@
 	<test>
 		<testCaseName>MathLoadTest_autosimd</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test-args=$(Q)workload=autoSimd$(Q) -test=MathLoadTest; \
 	$(TEST_STATUS)</command>
@@ -48,7 +50,8 @@
 	<test>
 		<testCaseName>MathLoadTest_bigdecimal</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MathLoadTest -test-args=$(Q)workload=bigDecimal$(Q); \
 	$(TEST_STATUS)</command>
@@ -127,7 +130,6 @@
 			<variation>Mode103</variation>
 			<variation>Mode104</variation>
 			<variation>Mode107</variation>
-			<variation>Mode110</variation>
 			<variation>Mode112</variation>
 			<variation>Mode113</variation>
 			<variation>Mode121</variation>
@@ -144,7 +146,6 @@
 			<variation>Mode556</variation>
 			<variation>Mode557</variation>
 			<variation>Mode607</variation>
-			<variation>Mode610</variation>
 			<variation>Mode614</variation>
 			<variation>Mode615</variation>
 			<variation>Mode687</variation>
@@ -177,7 +178,6 @@
 			<variation>Mode103</variation>
 			<variation>Mode104</variation>
 			<variation>Mode107</variation>
-			<variation>Mode110</variation>
 			<variation>Mode112</variation>
 			<variation>Mode113</variation>
 			<variation>Mode121</variation>
@@ -194,7 +194,6 @@
 			<variation>Mode556</variation>
 			<variation>Mode557</variation>
 			<variation>Mode607</variation>
-			<variation>Mode610</variation>
 			<variation>Mode614</variation>
 			<variation>Mode615</variation>
 			<variation>Mode687</variation>
@@ -231,7 +230,6 @@
 			<variation>Mode103</variation>
 			<variation>Mode104</variation>
 			<variation>Mode107</variation>
-			<variation>Mode110</variation>
 			<variation>Mode112</variation>
 			<variation>Mode113</variation>
 			<variation>Mode121</variation>
@@ -248,7 +246,6 @@
 			<variation>Mode556</variation>
 			<variation>Mode557</variation>
 			<variation>Mode607</variation>
-			<variation>Mode610</variation>
 			<variation>Mode614</variation>
 			<variation>Mode615</variation>
 			<variation>Mode687</variation>

--- a/system/mauveLoadTest/playlist.xml
+++ b/system/mauveLoadTest/playlist.xml
@@ -21,7 +21,8 @@
 	<test>
 		<testCaseName>MauveSingleThrdLoad_J9</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MauveSingleThrdLoad; \
 	$(TEST_STATUS)</command>
@@ -40,7 +41,8 @@
 	<test>
 		<testCaseName>MauveSingleThrdLoad_HS</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MauveSingleThrdLoad; \
 	$(TEST_STATUS)</command>
@@ -58,7 +60,8 @@
 	<test>
 		<testCaseName>MauveSingleInvocLoad_J9</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MauveSingleInvocLoad; \
 	$(TEST_STATUS)</command>
@@ -77,7 +80,8 @@
 	<test>
 		<testCaseName>MauveSingleInvocLoad_HS</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MauveSingleInvocLoad; \
 	$(TEST_STATUS)</command>
@@ -94,7 +98,8 @@
 	<test>
 		<testCaseName>MauveMultiThrdLoad</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MauveMultiThrdLoad; \
 	$(TEST_STATUS)</command>
@@ -179,7 +184,6 @@
 			<variation>Mode103</variation>
 			<variation>Mode104</variation>
 			<variation>Mode107</variation>
-			<variation>Mode110</variation>
 			<variation>Mode112</variation>
 			<variation>Mode113</variation>
 			<variation>Mode121</variation>
@@ -195,7 +199,6 @@
 			<variation>Mode556</variation>
 			<variation>Mode557</variation>
 			<variation>Mode607</variation>
-			<variation>Mode610</variation>
 			<variation>Mode614</variation>
 			<variation>Mode615</variation>
 			<variation>Mode687</variation>
@@ -233,7 +236,6 @@
 			<variation>Mode103</variation>
 			<variation>Mode104</variation>
 			<variation>Mode107</variation>
-			<variation>Mode110</variation>
 			<variation>Mode112</variation>
 			<variation>Mode113</variation>
 			<variation>Mode121</variation>
@@ -249,7 +251,6 @@
 			<variation>Mode556</variation>
 			<variation>Mode557</variation>
 			<variation>Mode607</variation>
-			<variation>Mode610</variation>
 			<variation>Mode614</variation>
 			<variation>Mode615</variation>
 			<variation>Mode687</variation>
@@ -284,7 +285,6 @@
 			<variation>Mode103</variation>
 			<variation>Mode104</variation>
 			<variation>Mode107</variation>
-			<variation>Mode110</variation>
 			<variation>Mode112</variation>
 			<variation>Mode113</variation>
 			<variation>Mode121</variation>
@@ -300,7 +300,6 @@
 			<variation>Mode556</variation>
 			<variation>Mode557</variation>
 			<variation>Mode607</variation>
-			<variation>Mode610</variation>
 			<variation>Mode614</variation>
 			<variation>Mode615</variation>
 			<variation>Mode687</variation>

--- a/system/modularity/playlist.xml
+++ b/system/modularity/playlist.xml
@@ -26,7 +26,8 @@
 	<test>
 		<testCaseName>CpMp_CpMp</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=CpMpTest -test-args=$(Q)variant=CpMp$(Q); \
 	$(TEST_STATUS)</command>
@@ -43,7 +44,8 @@
 	<test>
 		<testCaseName>CpMp_MP</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=CpMpTest -test-args=$(Q)variant=Mp$(Q); \
 	$(TEST_STATUS)</command>
@@ -60,7 +62,8 @@
 	<test>
 		<testCaseName>CpMp2</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=CpMpTest2; \
 	$(TEST_STATUS)</command>
@@ -77,7 +80,8 @@
 	<test>
 		<testCaseName>CpMp3</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=CpMpTest3; \
 	$(TEST_STATUS)</command>
@@ -94,7 +98,8 @@
 	<test>
 		<testCaseName>CpMpModJar</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=CpMpModJar; \
 	$(TEST_STATUS)</command>
@@ -111,7 +116,8 @@
 	<test>
 		<testCaseName>CpMpModJar2</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=CpMpModJar2; \
 	$(TEST_STATUS)</command>
@@ -128,7 +134,8 @@
 	<test>
 		<testCaseName>CpMpModJar3</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=CpMpModJar3; \
 	$(TEST_STATUS)</command>
@@ -145,7 +152,8 @@
 	<test>
 		<testCaseName>InternalAPIs</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=InternalAPIs; \
 	$(TEST_STATUS)</command>
@@ -162,7 +170,8 @@
 	<test>
 		<testCaseName>AutoMod1</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=AutoModTest -test-args=$(Q)variant=AutoMod1$(Q); \
 	$(TEST_STATUS)</command>
@@ -179,7 +188,8 @@
 	<test>
 		<testCaseName>AutoMod2</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=AutoModTest -test-args=$(Q)variant=AutoMod2$(Q); \
 	$(TEST_STATUS)</command>
@@ -196,7 +206,8 @@
 	<test>
 		<testCaseName>AutoMod_Impl1</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=AutoModTest -test-args=$(Q)variant=Impl1$(Q); \
 	$(TEST_STATUS)</command>
@@ -213,7 +224,8 @@
 	<test>
 		<testCaseName>AutoMod_Impl2</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=AutoModTest -test-args=$(Q)variant=Impl2$(Q); \
 	$(TEST_STATUS)</command>
@@ -230,7 +242,8 @@
 	<test>
 		<testCaseName>AutoMod_Impl3</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=AutoModTest -test-args=$(Q)variant=Impl3$(Q); \
 	$(TEST_STATUS)</command>
@@ -251,7 +264,8 @@
 			<comment>https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/200</comment>
 		</disabled>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=ExplMod; \
 	$(TEST_STATUS)</command>
@@ -270,7 +284,8 @@
 	<test>
 		<testCaseName>SLTest</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=SLTest; \
 	$(TEST_STATUS)</command>
@@ -289,7 +304,8 @@
 	<test>
 		<testCaseName>PatMod_PlatMod</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=PatModTest -test-args=$(Q)variant=PlatMod$(Q); \
 	$(TEST_STATUS)</command>
@@ -307,7 +323,8 @@
 	<test>
 		<testCaseName>PatMod_AppMod</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=PatModTest -test-args=$(Q)variant=AppMod$(Q); \
 	$(TEST_STATUS)</command>
@@ -324,7 +341,8 @@
 	<test>
 		<testCaseName>PatMod_Unex</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=PatModTest -test-args=$(Q)variant=Unex$(Q); \
 	$(TEST_STATUS)</command>
@@ -341,7 +359,8 @@
 	<test>
 		<testCaseName>PatMod_Adv</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=PatModTest -test-args=$(Q)variant=Adv$(Q); \
 	$(TEST_STATUS)</command>
@@ -361,7 +380,8 @@
 	<test>
 		<testCaseName>PatModImg_PlatMod</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=PatModImgTest -test-args=$(Q)variant=PlatMod$(Q); \
 	$(TEST_STATUS)</command>
@@ -380,7 +400,8 @@
 	<test>
 		<testCaseName>PatModImg_AppMod</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=PatModImgTest -test-args=$(Q)variant=AppMod$(Q); \
 	$(TEST_STATUS)</command>
@@ -399,7 +420,8 @@
 	<test>
 		<testCaseName>PatModImg_Unex</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=PatModImgTest -test-args=$(Q)variant=Unex$(Q); \
 	$(TEST_STATUS)</command>
@@ -418,7 +440,8 @@
 	<test>
 		<testCaseName>PatModImg_Adv</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=PatModImgTest -test-args=$(Q)variant=Adv$(Q); \
 	$(TEST_STATUS)</command>
@@ -436,7 +459,8 @@
 	<test>
 		<testCaseName>UpgModPath_Exp</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=UpgModPathTest -test-args=$(Q)variant=Exp$(Q); \
 	$(TEST_STATUS)</command>
@@ -454,7 +478,8 @@
 	<test>
 		<testCaseName>UpgModPath_ExpImg</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=UpgModPathTest -test-args=$(Q)variant=ExpImg$(Q); \
 	$(TEST_STATUS)</command>
@@ -472,7 +497,8 @@
 	<test>
 		<testCaseName>UpgModPath_Jar</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=UpgModPathTest -test-args=$(Q)variant=Jar$(Q); \
 	$(TEST_STATUS)</command>
@@ -490,7 +516,8 @@
 	<test>
 		<testCaseName>UpgModPath_JarImg</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=UpgModPathTest -test-args=$(Q)variant=JarImg$(Q); \
 	$(TEST_STATUS)</command>
@@ -510,7 +537,8 @@
 	<test>
 		<testCaseName>Jlink_ReqMod</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=JlinkTest -test-args=$(Q)variant=ReqdMod$(Q); \
 	$(TEST_STATUS)</command>
@@ -530,7 +558,8 @@
 	<test>
 		<testCaseName>Jlink_AddMLimitM</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=JlinkTest -test-args=$(Q)variant=AddMLimitM$(Q); \
 	$(TEST_STATUS)</command>
@@ -549,7 +578,8 @@
 	<test>
 		<testCaseName>CpMpJlink</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=CpMpJlinkTest; \
 	$(TEST_STATUS)</command>
@@ -568,7 +598,8 @@
 	<test>
 		<testCaseName>Jlink_GenOpt</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=JlinkPluginTest -test-args=$(Q)variant=GenOpt$(Q); \
 	$(TEST_STATUS)</command>
@@ -586,7 +617,8 @@
 	<test>
 		<testCaseName>LayersTest</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=LayersTest -test-args=$(Q)heapsize=10m$(Q); \
 	$(TEST_STATUS)</command>
@@ -607,7 +639,8 @@
 	<test>
 		<testCaseName>CLTest</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=CLTest -test-args=$(Q)variant=CLTest$(Q); \
 	$(TEST_STATUS)</command>
@@ -625,7 +658,8 @@
 	<test>
 		<testCaseName>CLTestImg</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=CLTestImage -test-args=$(Q)variant=Img$(Q); \
 	$(TEST_STATUS)</command>
@@ -643,7 +677,8 @@
 	<test>
 		<testCaseName>CLLoad</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=CLLoadTest; \
 	$(TEST_STATUS)</command>
@@ -663,7 +698,8 @@
 			<comment>https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/197</comment>
 		</disabled>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=CLStressLayers; \
 	$(TEST_STATUS)</command>
@@ -683,7 +719,8 @@
 			<comment>https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/197</comment>
 		</disabled>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=CLStressCRI; \
 	$(TEST_STATUS)</command>

--- a/system/otherLoadTest/playlist.xml
+++ b/system/otherLoadTest/playlist.xml
@@ -20,7 +20,8 @@
 	<test>
 		<testCaseName>MiniMix_5min</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MixedLoadTest -test-args=$(Q)timeLimit=5m$(Q);\
 	$(TEST_STATUS)</command>
@@ -34,7 +35,8 @@
 	<test>
 		<testCaseName>ClassLoadingTest</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=ClassloadingLoadTest; \
 	$(TEST_STATUS)</command>
@@ -52,7 +54,6 @@
 			<variation>Mode103</variation>
 			<variation>Mode104</variation>
 			<variation>Mode107</variation>
-			<variation>Mode110</variation>
 			<variation>Mode112</variation>
 			<variation>Mode113</variation>
 			<variation>Mode121</variation>
@@ -69,7 +70,6 @@
 			<variation>Mode556</variation>
 			<variation>Mode557</variation>
 			<variation>Mode607</variation>
-			<variation>Mode610</variation>
 			<variation>Mode614</variation>
 			<variation>Mode615</variation>
 			<variation>Mode687</variation>
@@ -98,7 +98,8 @@
 	<test>
 		<testCaseName>ConcurrentLoadTest</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=ConcurrentLoadTest; \
 	$(TEST_STATUS)</command>
@@ -113,7 +114,8 @@
 	<test>
 		<testCaseName>DirectByteBufferLoadTest</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=DirectByteBufferLoadTest; \
 	$(TEST_STATUS)</command>
@@ -128,7 +130,8 @@
 	<test>
 		<testCaseName>LangLoadTest</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=LangLoadTest; \
 	$(TEST_STATUS)</command>
@@ -142,7 +145,8 @@
 	<test>
 		<testCaseName>LockingLoadTest</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=LockingLoadTest; \
 	$(TEST_STATUS)</command>
@@ -158,7 +162,8 @@
 	<test>
 		<testCaseName>NioLoadTest</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=NioLoadTest; \
 	$(TEST_STATUS)</command>
@@ -171,28 +176,10 @@
 		<platformRequirements>^arch.arm,^os.zos</platformRequirements>
 	</test>
 	<test>
-		<testCaseName>NioLoadTest_special</testCaseName>
-		<variations>
-			<variation>Mode110</variation>
-		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=NioLoadTest; \
-	$(TEST_STATUS)</command>
-		<levels>
-			<level>special</level>
-		</levels>
-		<groups>
-			<group>system</group>
-		</groups>
-		<impls>
-			<impl>openj9</impl>
-			<impl>ibm</impl>
-		</impls>
-		<platformRequirements>^arch.arm</platformRequirements>
-	</test>
-	<test>
 		<testCaseName>UtilLoadTest</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=UtilLoadTest; \
 	$(TEST_STATUS)</command>
@@ -206,7 +193,8 @@
 	<test>
 		<testCaseName>HCRLateAttachWorkload</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=HCRLateAttachWorkload; \
 	$(TEST_STATUS)</command>
@@ -223,7 +211,8 @@
 	<test>
 		<testCaseName>HCRLateAttachWorkload_previewEnabled</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -debug-generation=$(Q)true$(Q) -java-debug-args=$(Q)--enable-preview$(Q) -java-args=$(Q)--enable-preview$(Q) -test=HCRLateAttachWorkload; \
 	$(TEST_STATUS)</command>
@@ -240,7 +229,8 @@
 	<test>
 		<testCaseName>HeapHogLoadTest</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -java-args=$(Q)$(JVM_OPTIONS) -Xdisableexcessivegc$(Q) -test=HeapHogLoadTest; \
 	$(TEST_STATUS)</command>
@@ -258,7 +248,8 @@
 	<test>
 		<testCaseName>ObjectTreeLoadTest</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -java-args=$(Q)$(JVM_OPTIONS) -Xnoclassgc$(Q) -test=ObjectTreeLoadTest; \
 	$(TEST_STATUS)</command>
@@ -297,7 +288,8 @@
 	<test>
 		<testCaseName>MixedLoadTest</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MixedLoadTest; \
 	$(TEST_STATUS)</command>

--- a/system/sharedClasses/playlist.xml
+++ b/system/sharedClasses/playlist.xml
@@ -25,7 +25,8 @@
 	<test>
 		<testCaseName>SharedClassesAPI</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
 		</variations>
 		<command>if [[ ! $(Q)$(PLATFORM)$(Q) == *$(Q)win$(Q)* ]] ; then export original_umask_val=`umask` $(AND_IF_SUCCESS) umask 0002 $(AND_IF_SUCCESS) echo umask set to `umask`; fi; \
 	$(SYSTEMTEST_CMD_TEMPLATE) -test=SharedClassesAPI; \
@@ -45,7 +46,8 @@
 	<test>
 		<testCaseName>SharedClassesWorkload</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=SharedClassesWorkload; \
 	$(TEST_STATUS)</command>
@@ -63,7 +65,8 @@
 	<test>
 		<testCaseName>SC_Softmx_Increase</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=SharedClassesWorkloadTest_Softmx_Increase; \
 	$(TEST_STATUS)</command>
@@ -81,7 +84,8 @@
 	<test>
 		<testCaseName>SC_Softmx_UpDown</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=SharedClassesWorkloadTest_Softmx_IncreaseDecrease; \
 	$(TEST_STATUS)</command>
@@ -100,7 +104,8 @@
 	<test>
 		<testCaseName>SC_Softmx_JitAot</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=SharedClassesWorkloadTest_Softmx_Increase_JitAot; \
 	$(TEST_STATUS)</command>
@@ -119,7 +124,8 @@
 	<test>
 		<testCaseName>SC_Softmx_JitAot_Linux</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=SharedClassesWorkloadTest_Softmx_Increase_JitAot; \
 	$(TEST_STATUS)</command>
@@ -138,7 +144,8 @@
 	<test>
 		<testCaseName>SharedClasses.SCM01.SingleCL</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=SharedClasses -test-args=$(Q)sharedClassMode=SCM01,sharedClassTest=SingleCL$(Q); \
 	$(TEST_STATUS)</command>
@@ -156,7 +163,8 @@
 	<test>
 		<testCaseName>SharedClasses.SCM01.MultiCL</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=SharedClasses -test-args=$(Q)sharedClassMode=SCM01,sharedClassTest=MultiCL$(Q); \
 	$(TEST_STATUS)</command>
@@ -174,7 +182,8 @@
 	<test>
 		<testCaseName>SharedClasses.SCM01.MultiThread</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=SharedClasses -test-args=$(Q)sharedClassMode=SCM01,sharedClassTest=MultiThread$(Q); \
 	$(TEST_STATUS)</command>
@@ -192,7 +201,8 @@
 	<test>
 		<testCaseName>SharedClasses.SCM01.MultiThreadMultiCL</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=SharedClasses -test-args=$(Q)sharedClassMode=SCM01,sharedClassTest=MultiThreadMultiCL$(Q); \
 	$(TEST_STATUS)</command>
@@ -210,7 +220,8 @@
 	<test>
 		<testCaseName>SharedClasses.SCM23.SingleCL</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=SharedClasses -test-args=$(Q)sharedClassMode=SCM23,sharedClassTest=SingleCL$(Q); \
 	$(TEST_STATUS)</command>
@@ -228,7 +239,8 @@
 	<test>
 		<testCaseName>SharedClasses.SCM23.MultiCL</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=SharedClasses -test-args=$(Q)sharedClassMode=SCM23,sharedClassTest=MultiCL$(Q); \
 	$(TEST_STATUS)</command>
@@ -246,7 +258,8 @@
 	<test>
 		<testCaseName>SharedClasses.SCM23.MultiThread</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=SharedClasses -test-args=$(Q)sharedClassMode=SCM23,sharedClassTest=MultiThread$(Q); \
 	$(TEST_STATUS)</command>
@@ -264,7 +277,8 @@
 	<test>
 		<testCaseName>SharedClasses.SCM23.MultiThreadMultiCL</testCaseName>
 		<variations>
-			<variation>NoOptions</variation>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=SharedClasses -test-args=$(Q)sharedClassMode=SCM23,sharedClassTest=MultiThreadMultiCL$(Q); \
 	$(TEST_STATUS)</command>


### PR DESCRIPTION
- for tests for all JVM, add Mode150 and Mode650
- for tests for openj9/ibm only, add Mode110 and Mode610
- remove Mode110 and Mode610 in special tests if above modes are added in sanity/extended

Related: https://github.com/eclipse/openj9/issues/9231

Signed-off-by: lanxia <lan_xia@ca.ibm.com>