### PR TITLE
Add Xvfb wait time to avoid 10second getDisplayName timeout

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -560,7 +560,8 @@ def runTest( ) {
 					makeTest("${RUNTEST_CMD}")
 				}
 				else if (env.SPEC.startsWith('linux')) {
-					wrap([$class: 'Xvfb', autoDisplayName: true]) {
+					// Add an additional 10 second timeout due to issue: https://github.com/AdoptOpenJDK/openjdk-build/issues/2368#issuecomment-756683888
+					wrap([$class: 'Xvfb', autoDisplayName: true, timeout:10]) {
 						def DISPLAY = sh (
 							script: 'ps -f  | grep \'[X]vfb\' | awk \'{print \$9}\'',
 							returnStdout: true


### PR DESCRIPTION
Fixes issue: https://github.com/AdoptOpenJDK/openjdk-build/issues/2368

Xvfb 1.1.3 has an internal hardcoded getDisplayName() timeout of 10seconds. This is just a bit too small to allow for the Xvfb process startup and display name acquisition. On a typical good run I see the time taken of the order of 4seconds. This PR adds an additional Xvfb startup wait time of 10seconds, so the total timeout will now be Xvfb_waittime+getDisplayName()_timeout = (10+10) = 20seconds.

Xvfb waittime: https://github.com/jenkinsci/xvfb-plugin/blob/c8a89302e42663e3cb03fd564ac2b675e6a07892/src/main/java/org/jenkinsci/plugins/xvfb/Xvfb.java#L592
Xvffb getDisplayName() timeout: https://github.com/jenkinsci/xvfb-plugin/blob/b7fc94a7b2d45aa99bf3db804457e9d23276d9bd/src/main/java/org/jenkinsci/plugins/xvfb/AutoDisplayNameFilterStream.java#L50

Signed-off-by: Andrew Leonard <anleonar@redhat.com>