### PR TITLE
Exclude sanity.openjdk java/lang/invoke tests

### DIFF
--- a/openjdk/ProblemList_openjdk16-openj9.txt
+++ b/openjdk/ProblemList_openjdk16-openj9.txt
@@ -125,7 +125,11 @@ java/lang/invoke/VarHandles/VarHandleTestByteArrayAsShort.java https://github.co
 java/lang/invoke/VarargsArrayTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/invoke/condy/CondyNestedTest.java https://github.com/eclipse/openj9/issues/4127 linux-ppc64le
 java/lang/invoke/condy/CondyNestedResolutionTest.java	https://github.com/eclipse/openj9/issues/7158	aix-all
+java/lang/invoke/lambda/LambdaReceiver.java https://github.com/eclipse/openj9/issues/11359 generic-all
+java/lang/invoke/lambda/LambdaReceiverBridge.java https://github.com/eclipse/openj9/issues/11359 generic-all
 java/lang/invoke/lambda/LambdaStackTrace.java	https://github.com/eclipse/openj9/issues/3394	generic-all
+java/lang/invoke/lambda/superProtectedMethod/InheritedProtectedMethod.java https://github.com/eclipse/openj9/issues/11359 generic-all
+java/lang/invoke/lambda/superProtectedMethod/SuperMethodTest.java https://github.com/eclipse/openj9/issues/11359 generic-all
 java/lang/invoke/lookup/LookupClassTest.java    https://github.com/eclipse/openj9/issues/8570   generic-all
 java/lang/invoke/modules/Driver.java    https://github.com/eclipse/openj9/issues/8571   generic-all
 java/lang/invoke/modules/Driver1.java   https://github.com/eclipse/openj9/issues/8571   generic-all


### PR DESCRIPTION
Excluded following tests:
```
java/lang/invoke/lambda/LambdaReceiver.java
java/lang/invoke/lambda/LambdaReceiverBridge.java
java/lang/invoke/lambda/superProtectedMethod/InheritedProtectedMethod.java
java/lang/invoke/lambda/superProtectedMethod/SuperMethodTest.java
```
These tests will be fixed via https://github.com/eclipse/openj9/issues/7352, excluding it for now.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>