### PR TITLE
Create ProblemList for JDK17

### DIFF
--- a/openjdk/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/ProblemList_openjdk17-openj9.txt
@@ -1,0 +1,370 @@
+############################################################################
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+############################################################################
+
+# To determine required OS exclusion string see http://hg.openjdk.java.net/code-tools/jtreg/file/6f00c63c0a98/src/share/classes/com/sun/javatest/regtest/config/OS.java
+
+############################################################################
+
+# jdk_awt
+
+############################################################################
+
+# jdk_beans
+
+############################################################################
+
+# jdk_lang
+
+java/lang/Class/GetModuleTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
+#java/lang/Class/GetPackageBootLoaderChildLayer.java is also excluded for the issue https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267
+java/lang/Class/GetPackageBootLoaderChildLayer.java	https://github.com/eclipse/openj9/issues/5274	generic-all
+java/lang/Class/forName/NonJavaNames.sh	https://github.com/eclipse/openj9/issues/5225	generic-all
+java/lang/ClassLoader/Assert.java	https://github.com/eclipse/openj9/issues/6668	macosx-x64
+java/lang/ClassLoader/EndorsedDirs.java	https://github.com/eclipse/openj9/issues/3055	generic-all
+java/lang/ClassLoader/ExtDirs.java	https://github.com/eclipse/openj9/issues/3055	generic-all
+java/lang/ClassLoader/LibraryPathProperty.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
+java/lang/ClassLoader/RecursiveSystemLoader.java	https://github.com/eclipse/openj9/issues/3178	generic-all
+java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	generic-all
+java/lang/Enum/ConstantDirectoryOptimalCapacity.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
+java/lang/ModuleLayer/BasicLayerTest.java	https://github.com/eclipse/openj9/issues/6462	generic-all
+java/lang/ProcessBuilder/SkipTest.java https://github.com/eclipse/openj9/issues/4124 windows-all
+java/lang/StackTraceElement/PublicConstructor.java	https://github.com/eclipse/openj9/issues/6659	generic-all
+java/lang/StackTraceElement/SerialTest.java	https://github.com/eclipse/openj9/issues/6659	generic-all
+java/lang/StackWalker/Basic.java		https://github.com/eclipse/openj9/issues/6698	generic-all
+java/lang/StackWalker/DumpStackTest.java	https://github.com/eclipse/openj9/issues/6680	generic-all
+java/lang/StackWalker/EmbeddedStackWalkTest.java	https://github.com/eclipse/openj9/issues/3941	generic-all
+java/lang/StackWalker/LocalsAndOperands.java#id0  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
+java/lang/StackWalker/LocalsAndOperands.java#id1  https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
+java/lang/StackWalker/ReflectionFrames.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
+java/lang/StackWalker/VerifyStackTrace.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1273	generic-all
+java/lang/String/CaseConvertSameInstance.java	https://github.com/eclipse/openj9/issues/6672	generic-all
+java/lang/String/CaseInsensitiveComparator.java	https://github.com/eclipse/openj9/issues/6665	generic-all
+java/lang/String/CompactString/IndexOf.java		https://github.com/eclipse/openj9/issues/6673	generic-all
+java/lang/String/concat/CompactStringsInitialCoder.java	https://github.com/eclipse/openj9/issues/9656	generic-all
+java/lang/String/concat/ImplicitStringConcat.java	https://github.com/eclipse/openj9/issues/9656	generic-all
+java/lang/String/concat/ImplicitStringConcatArgCount.java	https://github.com/eclipse/openj9/issues/9656	generic-all
+java/lang/String/concat/ImplicitStringConcatAssignLHS.java	https://github.com/eclipse/openj9/issues/9656	generic-all
+java/lang/String/concat/ImplicitStringConcatBoundaries.java	https://github.com/eclipse/openj9/issues/9656	generic-all
+java/lang/String/concat/ImplicitStringConcatMany.java	https://github.com/eclipse/openj9/issues/9656	generic-all
+java/lang/String/concat/ImplicitStringConcatManyLongs.java	https://github.com/eclipse/openj9/issues/9656	generic-all
+java/lang/String/concat/ImplicitStringConcatOrder.java	https://github.com/eclipse/openj9/issues/9656	generic-all
+java/lang/String/concat/ImplicitStringConcatShapes.java	https://github.com/eclipse/openj9/issues/9656	generic-all
+java/lang/String/concat/StringConcatFactoryInvariants.java	https://github.com/eclipse/openj9/issues/9656	generic-all
+java/lang/String/concat/StringConcatFactoryRepeatedConstants.java	https://github.com/eclipse/openj9/issues/9656	generic-all
+java/lang/String/concat/WithSecurityManager.java	https://github.com/eclipse/openj9/issues/9656	generic-all
+java/lang/String/EqualsIgnoreCase.java	https://github.com/eclipse/openj9/issues/6666	generic-all
+java/lang/String/StringRepeat.java	https://github.com/eclipse/openj9/issues/6667	generic-all
+java/lang/String/UnicodeCasingTest.java https://github.com/eclipse/openj9/issues/4597 linux-s390x
+java/lang/String/nativeEncoding/StringPlatformChars.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	generic-all
+java/lang/StringBuilder/HugeCapacity.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
+java/lang/System/Logger/custom/CustomLoggerTest.java	https://github.com/eclipse/openj9/issues/6674	generic-all
+java/lang/System/Logger/default/DefaultLoggerTest.java	https://github.com/eclipse/openj9/issues/6674	generic-all
+java/lang/System/LoggerFinder/BaseLoggerFinderTest/BaseLoggerFinderTest.java	https://github.com/eclipse/openj9/issues/6674	generic-all
+java/lang/System/LoggerFinder/DefaultLoggerFinderTest/DefaultLoggerFinderTest.java	https://github.com/eclipse/openj9/issues/6674	generic-all
+java/lang/System/LoggerFinder/internal/BaseDefaultLoggerFinderTest/BaseDefaultLoggerFinderTest.java	https://github.com/eclipse/openj9/issues/6674	generic-all
+java/lang/System/LoggerFinder/internal/BaseLoggerBridgeTest/BaseLoggerBridgeTest.java	https://github.com/eclipse/openj9/issues/6674	generic-all
+java/lang/System/LoggerFinder/internal/LoggerBridgeTest/LoggerBridgeTest.java	https://github.com/eclipse/openj9/issues/6674	generic-all
+java/lang/System/LoggerFinder/internal/LoggerFinderLoaderTest/LoggerFinderLoaderTest.java	https://github.com/eclipse/openj9/issues/6674	generic-all
+java/lang/System/LoggerFinder/internal/backend/LoggerFinderBackendTest.java	https://github.com/eclipse/openj9/issues/6674	generic-all
+java/lang/System/LoggerFinder/jdk/DefaultLoggerBridgeTest/DefaultLoggerBridgeTest.java	https://github.com/eclipse/openj9/issues/6674	generic-all
+java/lang/System/LoggerFinder/modules/JDKLoggerForImageTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
+java/lang/System/LoggerFinder/modules/LoggerInImageTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
+java/lang/System/LoggerFinder/modules/NamedLoggerForImageTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
+java/lang/System/LoggerFinder/modules/UnnamedLoggerForImageTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
+java/lang/Thread/UncaughtExceptions.sh	https://github.com/eclipse/openj9/issues/6690	generic-all
+java/lang/ThreadGroup/SetMaxPriority.java	https://github.com/eclipse/openj9/issues/6691	generic-all
+java/lang/Throwable/SuppressedExceptions.java	https://github.com/eclipse/openj9/issues/6692	generic-all
+java/lang/annotation/AnnotationsInheritanceOrderRedefinitionTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
+java/lang/annotation/loaderLeak/Main.java	https://github.com/eclipse/openj9/issues/6701	generic-all
+java/lang/invoke/AccessControlTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1285	generic-all
+java/lang/invoke/ArrayConstructorTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
+java/lang/invoke/CallerSensitiveAccess.java	https://github.com/eclipse/openj9/issues/6768	generic-all
+java/lang/invoke/ClassSpecializerTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
+java/lang/invoke/DefineClassTest.java		https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
+java/lang/invoke/defineHiddenClass/BasicTest.java	https://github.com/eclipse/openj9/issues/10345	generic-all
+java/lang/invoke/defineHiddenClass/LambdaNestedInnerTest.java	https://github.com/eclipse/openj9/issues/10345	generic-all
+java/lang/invoke/defineHiddenClass/SelfReferenceDescriptor.java	https://github.com/eclipse/openj9/issues/10345	generic-all
+java/lang/invoke/defineHiddenClass/TypeDescriptorTest.java	https://github.com/eclipse/openj9/issues/10345	generic-all
+java/lang/invoke/defineHiddenClass/UnloadingTest.java	https://github.com/eclipse/openj9/issues/10345	generic-all
+java/lang/reflect/AccessibleObject/HiddenClassTest.java	https://github.com/eclipse/openj9/issues/10345	generic-all
+java/lang/invoke/DropLookupModeTest.java    https://github.com/eclipse/openj9/issues/8570   generic-all
+java/lang/invoke/ExplicitCastArgumentsTest.java		https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
+java/lang/invoke/FindAccessTest.java		https://github.com/eclipse/openj9/issues/6868	generic-all
+java/lang/invoke/LFCaching/LFMultiThreadCachingTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
+java/lang/invoke/LFCaching/LFSingleThreadCachingTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
+java/lang/invoke/LambdaFormTest.java		https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
+java/lang/invoke/LoopCombinatorTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
+java/lang/invoke/MethodHandles/privateLookupIn/Driver.java https://github.com/eclipse/openj9/issues/8571 generic-all
+java/lang/invoke/MethodHandlesGeneralTest.java	https://github.com/eclipse/openj9/issues/7043	generic-all
+java/lang/invoke/MethodHandlesInsertArgumentsTest.java	https://github.com/eclipse/openj9/issues/7057	generic-all
+java/lang/invoke/PrivateInterfaceCall.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
+java/lang/invoke/PrivateInvokeTest.java	https://github.com/eclipse/openj9/issues/7071	generic-all
+java/lang/invoke/RevealDirectTest.java	https://github.com/eclipse/openj9/issues/8268	generic-all
+java/lang/invoke/SpecialInterfaceCall.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
+java/lang/invoke/SpreadCollectTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
+java/lang/invoke/TryFinallyTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
+java/lang/invoke/VarHandle/AccessMode/OptimalMapSize.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
+java/lang/invoke/VarHandles/VarHandleTestAccessModeMethodNames.java	https://github.com/eclipse/openj9/issues/3181	generic-all
+java/lang/invoke/VarHandles/VarHandleTestByteArrayAsChar.java https://github.com/eclipse/openj9/issues/4924 generic-all
+java/lang/invoke/VarHandles/VarHandleTestByteArrayAsDouble.java https://github.com/eclipse/openj9/issues/4924 generic-all
+java/lang/invoke/VarHandles/VarHandleTestByteArrayAsFloat.java https://github.com/eclipse/openj9/issues/4924 generic-all
+java/lang/invoke/VarHandles/VarHandleTestByteArrayAsInt.java https://github.com/eclipse/openj9/issues/4924 generic-all
+java/lang/invoke/VarHandles/VarHandleTestByteArrayAsLong.java https://github.com/eclipse/openj9/issues/4924 generic-all
+java/lang/invoke/VarHandles/VarHandleTestByteArrayAsShort.java https://github.com/eclipse/openj9/issues/4924 generic-all
+java/lang/invoke/VarargsArrayTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
+java/lang/invoke/condy/CondyNestedTest.java https://github.com/eclipse/openj9/issues/4127 linux-ppc64le
+java/lang/invoke/condy/CondyNestedResolutionTest.java	https://github.com/eclipse/openj9/issues/7158	aix-all
+java/lang/invoke/lambda/LambdaReceiver.java https://github.com/eclipse/openj9/issues/11359 generic-all
+java/lang/invoke/lambda/LambdaReceiverBridge.java https://github.com/eclipse/openj9/issues/11359 generic-all
+java/lang/invoke/lambda/LambdaStackTrace.java	https://github.com/eclipse/openj9/issues/3394	generic-all
+java/lang/invoke/lambda/superProtectedMethod/InheritedProtectedMethod.java https://github.com/eclipse/openj9/issues/11359 generic-all
+java/lang/invoke/lambda/superProtectedMethod/SuperMethodTest.java https://github.com/eclipse/openj9/issues/11359 generic-all
+java/lang/invoke/lookup/LookupClassTest.java    https://github.com/eclipse/openj9/issues/8570   generic-all
+java/lang/invoke/modules/Driver.java    https://github.com/eclipse/openj9/issues/8571   generic-all
+java/lang/invoke/modules/Driver1.java   https://github.com/eclipse/openj9/issues/8571   generic-all
+java/lang/ref/CleanerTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
+java/lang/ref/EarlyTimeout.java	https://github.com/eclipse/openj9/issues/7225	generic-all
+java/lang/ref/FinalizeOverride.java	https://github.com/eclipse/openj9/issues/9651	generic-all
+java/lang/ref/FinalizerHistogramTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
+java/lang/ref/NullQueue.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
+java/lang/ref/OOMEInReferenceHandler.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
+java/lang/ref/ReachabilityFenceTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
+java/lang/reflect/AccessibleObject/ModuleSetAccessibleTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
+java/lang/reflect/AccessibleObject/TrySetAccessibleTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
+java/lang/reflect/DefaultMethodMembers/FilterNotMostSpecific.java	https://github.com/eclipse/openj9/issues/7623	generic-all
+java/lang/reflect/Nestmates/TestReflectionAPI.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
+java/lang/reflect/Proxy/ProxyForMethodHandle.java	https://github.com/eclipse/openj9/issues/7741	generic-all
+java/lang/reflect/Proxy/ProxyLayerTest.java	https://github.com/eclipse/openj9/issues/7775	generic-all
+java/lang/reflect/PublicMethods/PublicMethodsTest.java	https://github.com/eclipse/openj9/issues/7897	generic-all
+java/lang/reflect/exeCallerAccessTest/CallerAccessTest.java https://github.com/AdoptOpenJDK/openjdk-build/issues/248 generic-all
+jdk/modules/etc/DefaultModules.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
+jdk/modules/incubator/ImageModules.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
+vm/JniInvocationTest.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	macosx-all
+jdk/internal/loader/NativeLibraries/Main.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1920 generic-all
+java/lang/invoke/lambda/superProtectedMethod/SuperMethodTest.java https://github.com/eclipse/openj9/issues/11135 generic-all
+java/lang/invoke/MethodHandles/publicLookup/Driver.java https://github.com/eclipse/openj9/issues/11135 generic-all
+java/lang/invoke/MethodHandlesPermuteArgumentsTest.java https://github.com/eclipse/openj9/issues/11135 generic-all
+java/lang/invoke/MethodHandles/TestDropReturn.java https://github.com/eclipse/openj9/issues/11135 generic-all
+java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java https://github.com/eclipse/openj9/issues/11135 generic-all
+java/lang/invoke/VarHandles/VarHandleTestExact.java https://github.com/eclipse/openj9/issues/11256 generic-all
+java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1920 windows-all
+############################################################################
+
+# jdk_internal
+jdk/internal/loader/NativeLibraries/Main.java  https://github.com/eclipse/openj9/issues/9018  generic-all
+
+############################################################################
+
+# jdk_management
+
+sun/management/HotspotClassLoadingMBean/GetClassInitializationTime.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/932 generic-all
+sun/management/HotspotClassLoadingMBean/GetClassLoadingTime.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/932 generic-all
+sun/management/HotspotClassLoadingMBean/GetInitializedClassCount.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/932 generic-all
+sun/management/HotspotClassLoadingMBean/GetLoadedClassSize.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/932 generic-all
+sun/management/HotspotClassLoadingMBean/GetMethodDataSize.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/932 generic-all
+sun/management/HotspotClassLoadingMBean/GetUnloadedClassSize.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/932 generic-all
+sun/management/HotspotRuntimeMBean/GetSafepointCount.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/932 generic-all
+sun/management/HotspotRuntimeMBean/GetSafepointSyncTime.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/932 generic-all
+sun/management/HotspotRuntimeMBean/GetTotalSafepointTime.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/932 generic-all
+sun/management/HotspotThreadMBean/GetInternalThreads.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/932 generic-all
+
+############################################################################
+
+# jdk_jmx
+
+############################################################################
+
+# jdk_math
+
+
+############################################################################
+
+# jdk_net
+
+java/net/Inet4Address/PingThis.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1127	aix-all
+java/net/MulticastSocket/Promiscuous.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699 linux-s390x
+java/net/MulticastSocket/PromiscuousIPv6.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699	linux-s390x
+java/net/MulticastSocket/SetLoopbackMode.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699 linux-s390x
+java/net/MulticastSocket/Test.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699 linux-s390x
+java/net/Socket/asyncClose/AsyncClose.java https://github.com/eclipse/openj9/issues/4560 generic-all
+java/net/SocketPermission/SocketPermissionTest.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1650 aix-all
+java/net/httpclient/websocket/BlowupOutputQueue.java https://github.com/eclipse/openj9/issues/4298 macosx-all
+java/net/httpclient/websocket/PendingBinaryPingClose.java https://github.com/eclipse/openj9/issues/4298 macosx-all
+java/net/httpclient/websocket/PendingBinaryPongClose.java https://github.com/eclipse/openj9/issues/4298 macosx-all
+java/net/httpclient/websocket/PendingPingBinaryClose.java https://github.com/eclipse/openj9/issues/4298 macosx-all
+java/net/httpclient/websocket/PendingPingTextClose.java https://github.com/eclipse/openj9/issues/4298 macosx-all
+java/net/httpclient/websocket/PendingPongBinaryClose.java https://github.com/eclipse/openj9/issues/4298 macosx-all
+java/net/httpclient/websocket/PendingPongTextClose.java https://github.com/eclipse/openj9/issues/4298 macosx-all
+java/net/httpclient/websocket/PendingTextPingClose.java https://github.com/eclipse/openj9/issues/4298 macosx-all
+java/net/httpclient/websocket/PendingTextPongClose.java https://github.com/eclipse/openj9/issues/4298 macosx-all
+
+############################################################################
+
+# jdk_io
+
+java/io/CharArrayReader/OverflowInRead.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1500	generic-all
+java/io/FileInputStream/UnreferencedFISClosesFd.java  https://github.com/eclipse/openj9/issues/3543 generic-all
+java/io/FileOutputStream/UnreferencedFOSClosesFd.java https://github.com/eclipse/openj9/issues/3543 generic-all
+
+############################################################################
+
+# jdk_jdi
+
+############################################################################
+
+# jdk_nio
+
+java/nio/Buffer/DirectBufferAllocTest.java https://github.com/eclipse/openj9/issues/4473 generic-all
+java/nio/Buffer/LimitDirectMemory.java	https://github.com/eclipse/openj9/issues/8063	generic-all
+java/nio/Buffer/LimitDirectMemoryNegativeTest.java	https://github.com/eclipse/openj9/issues/8065	generic-all
+java/nio/MappedByteBuffer/MapSyncFail.java https://github.com/eclipse/openj9/issues/6831 generic-all
+java/nio/channels/AsyncCloseAndInterrupt.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1173	linux-all,aix-all
+java/nio/channels/AsynchronousFileChannel/Basic.java https://bugs.openjdk.java.net/browse/JDK-7052549 windows-all
+java/nio/channels/AsynchronousSocketChannel/Basic.java	https://bugs.openjdk.java.net/browse/JDK-7052549	windows-all
+java/nio/channels/DatagramChannel/AfterDisconnect.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1650 aix-all
+java/nio/channels/DatagramChannel/ChangingAddress.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1650 aix-all
+#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/AdoptOpenJDK/openjdk-tests/issues/1016
+#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699 linux-s390x
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267 macosx-all,linux-s390x
+#java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue	https://github.com/eclipse/openj9/issues/6669
+java/nio/channels/DatagramChannel/Promiscuous.java              https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699    linux-s390x,macosx-all
+java/nio/channels/DatagramChannel/PromiscuousIPv6.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699    linux-s390x
+java/nio/channels/SocketChannel/AdaptSocket.java https://github.com/eclipse/openj9/issues/4317 macosx-all
+java/nio/file/Files/CopyAndMove.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/795 macosx-all
+jdk/nio/zipfs/ZipFSTester.java https://github.com/eclipse/openj9/issues/4679 linux-x64,macosx-all
+
+############################################################################
+
+# jdk_rmi
+
+java/rmi/activation/Activatable/checkAnnotations/CheckAnnotations https://github.com/eclipse/openj9/issues/6749 windows-all
+java/rmi/dgc/dgcAckFailure/DGCAckFailure.java	https://github.com/eclipse/openj9/issues/3347	generic-all
+java/rmi/dgc/retryDirtyCalls/RetryDirtyCalls.java	https://github.com/eclipse/openj9/issues/7592	generic-all
+java/rmi/server/RMISocketFactory/useSocketFactory/unicast/TCPEndpointReadBug.java	https://github.com/eclipse/openj9/issues/8515	generic-all
+java/rmi/server/RemoteServer/AddrInUse.java		https://github.com/eclipse/openj9/issues/3377	generic-all
+java/rmi/server/UnicastRemoteObject/serialFilter/FilterUROTest.java	https://github.com/eclipse/openj9/issues/3347	generic-all
+java/rmi/server/UnicastRemoteObject/unexportObject/UnexportLeak.java https://github.com/eclipse/openj9/issues/4094 generic-all
+java/rmi/server/UnicastServerRef/serialFilter/FilterUSRTest.java	https://github.com/eclipse/openj9/issues/3347	generic-all
+
+############################################################################
+
+# jdk_security
+
+security/infra/java/security/cert/CertPathValidator/certification/LuxTrustCA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074	generic-all
+security/infra/java/security/cert/CertPathValidator/certification/BuypassCA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074	generic-all
+security/infra/java/security/cert/CertPathValidator/certification/QuoVadisCA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074	generic-all
+############################################################################
+
+# jdk_sound
+
+############################################################################
+
+# jdk_swing
+
+############################################################################
+
+# jdk_text
+
+############################################################################
+
+# jdk_time
+
+############################################################################
+
+# jdk_tools
+
+############################################################################
+
+# jdk_jdi
+
+############################################################################
+
+# jdk_util
+
+java/util/Arrays/TimSortStackSize2.java	https://github.com/eclipse/openj9/issues/7086	generic-all
+java/util/Arrays/largeMemory/ParallelPrefix.java https://github.com/eclipse/openj9/issues/4100 linux-ppc64le
+java/util/BitSet/stream/BitSetStreamTest.java https://github.com/eclipse/openj9/issues/4720 linux-all
+java/util/Spliterator/SpliteratorCollisions.java	https://github.com/eclipse/openj9/issues/7090	generic-all
+java/util/concurrent/ArrayBlockingQueue/WhiteBox.java 	https://github.com/eclipse/openj9/issues/5988 	macosx-all
+java/util/concurrent/forkjoin/FJExceptionTableLeak.java	https://github.com/eclipse/openj9/issues/3209	generic-all
+java/util/concurrent/locks/Lock/TimedAcquireLeak.java	https://github.com/eclipse/openj9/issues/7125	macosx-all,linux-all,aix-all
+java/util/concurrent/TimeUnit/Basic.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1665 windows-all
+java/util/logging/CheckZombieLockTest.java	https://bugs.openjdk.java.net/browse/JDK-8148972	macosx-all,linux-all
+java/util/logging/TestLoggerWeakRefLeak.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
+java/util/logging/LogManager/TestLoggerNames.java https://github.com/eclipse/openj9/issues/4561 generic-all
+java/util/stream/boottest/java.base/java/util/stream/NodeTest.java https://github.com/eclipse/openj9/issues/4129 macosx-all
+java/util/stream/test/org/openjdk/tests/java/util/SplittableRandomTest.java https://github.com/eclipse/openj9/issues/4613 generic-all
+java/util/stream/test/org/openjdk/tests/java/util/stream/ToArrayOpTest.java	https://github.com/eclipse/openj9/issues/3447	generic-all
+java/util/WeakHashMap/GCDuringIteration.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
+java/util/zip/ZipFile/TestCleaner.java	https://github.com/eclipse/openj9/issues/8872 	generic-all
+
+############################################################################
+
+# svc_tools
+
+############################################################################
+
+# jdk_other
+
+jdk/internal/misc/VM/GetNanoTimeAdjustment.java		https://github.com/eclipse/openj9/issues/7184		generic-all
+jdk/internal/misc/VM/RuntimeArguments.java		https://github.com/eclipse/openj9/issues/7186		generic-all
+jdk/internal/reflect/CallerSensitive/CheckCSMs.java	https://github.com/eclipse/openj9/issues/7245		generic-all
+jdk/internal/reflect/constantPool/ConstantPoolTest.java	https://github.com/eclipse/openj9/issues/7249		generic-all
+
+sun/misc/SunMiscSignalTest.java		https://github.com/eclipse/openj9/issues/7264		generic-all
+sun/net/www/protocol/file/DirPermissionDenied.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/749 windows-all
+sun/nio/ch/TestMaxCachedBufferSize.java		https://github.com/eclipse/openj9/issues/5328		generic-all
+
+vm/verifier/VerifyProtectedConstructor.java	https://github.com/eclipse/openj9/issues/7336	generic-all
+############################################################################
+
+# jdk_foreign
+java/foreign/TestArrays.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1701 generic-all
+java/foreign/TestLayouts.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1701 generic-all
+java/foreign/TestLayoutPaths.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1701	generic-all
+java/foreign/TestByteBuffer.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1702	generic-all
+java/foreign/TestLayoutConstants.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1702	generic-all
+java/foreign/TestNative.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1920 generic-all
+java/foreign/TestSharedAccess.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestSpliterator.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestByteBuffer.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestHandshake.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestCleaner.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/stackwalk/TestStackWalk.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/valist/VaListTest.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/StdLibTest.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestAdaptVarHandles.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestAddressHandle.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestDowncall.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestIllegalLink.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestIntrinsics.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestMemoryAccess.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestMemoryAccessStatics.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestMemoryAlignment.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestMemoryCopy.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestMemoryHandleAsUnsigned.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestMismatch.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestNativeScope.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestNulls.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestRebase.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestSegments.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestSlices.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestTypeAccess.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestUpcall.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestUpcallHighArity.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestUpcallStubs.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestVarArgs.java https://github.com/eclipse/openj9/issues/11027 generic-all
+java/foreign/TestVarHandleCombinators.java https://github.com/eclipse/openj9/issues/11027 generic-all
+
+############################################################################

--- a/openjdk/ProblemList_openjdk17.txt
+++ b/openjdk/ProblemList_openjdk17.txt
@@ -1,0 +1,185 @@
+############################################################################
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#############################################################################
+
+# jdk_awt
+
+############################################################################
+
+# jdk_beans
+
+############################################################################
+
+# jdk_lang
+java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	generic-all
+java/lang/String/nativeEncoding/StringPlatformChars.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	generic-all
+vm/JniInvocationTest.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	macosx-all
+java/lang/reflect/exeCallerAccessTest/CallerAccessTest.java https://github.com/AdoptOpenJDK/openjdk-build/issues/248 generic-all
+java/lang/System/LoggerFinder/modules/JDKLoggerForImageTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
+java/lang/System/LoggerFinder/modules/LoggerInImageTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
+java/lang/System/LoggerFinder/modules/NamedLoggerForImageTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
+java/lang/System/LoggerFinder/modules/UnnamedLoggerForImageTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
+jdk/modules/etc/DefaultModules.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
+jdk/modules/incubator/ImageModules.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
+java/lang/Class/GetPackageBootLoaderChildLayer.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
+#java/lang/String/StringRepeat.java https://bugs.openjdk.java.net/browse/JDK-8221400
+java/lang/String/StringRepeat.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1272 windows-all
+java/lang/invoke/VarHandles/VarHandleTestAccessBoolean.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1118	linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessByte.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1118	linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessChar.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1118	linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessDouble.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1118	linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessFloat.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1118	linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessInt.java		https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1118	linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessLong.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1118  linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessShort.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1118  linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessString.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1118  linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestByteArrayAsDouble.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1118	linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestByteArrayAsFloat.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1118	linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessBoolean.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1118  linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessByte.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1118  linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessChar.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1118  linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessDouble.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1118  linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessFloat.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1118  linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessInt.java		https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1118  linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessLong.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1118  linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessShort.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1118  linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1118	linux-aarch64
+jdk/internal/loader/NativeLibraries/Main.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1920 generic-all
+java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1920 windows-all
+############################################################################
+
+# jdk_management
+
+############################################################################
+
+# jdk_jmx
+
+############################################################################
+
+# jdk_math
+
+############################################################################
+
+# jdk_other
+
+############################################################################
+
+# jdk_net
+java/net/Inet4Address/PingThis.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1127	aix-all
+java/net/InetAddress/BadDottedIPAddress.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/593	linux-all
+java/net/InetAddress/CachedUnknownHostName.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/593	linux-all
+java/net/InetAddress/IPv4Formats.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/593	linux-all
+java/net/MulticastSocket/PromiscuousIPv6.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699	linux-s390x
+java/net/SocketPermission/SocketPermissionCollection.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/593	linux-all
+java/net/SocketPermission/SocketPermissionTest.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1650 aix-all
+java/net/SocketPermission/Wildcard.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/593	linux-all
+java/net/Socks/SocksV4Test.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/593	linux-all
+java/net/URL/OpenStream.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/593	linux-all
+java/net/httpclient/ConnectExceptionTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/593	linux-all
+java/net/httpclient/AsFileDownloadTest.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/893	linux-all
+java/net/httpclient/StreamingBody.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/893	linux-all
+java/net/httpclient/http2/ContinuationFrameTest.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/893	linux-all
+java/net/httpclient/SpecialHeadersTest.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/893	linux-all
+java/net/httpclient/http2/BadHeadersTest.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/893	linux-all
+java/net/httpclient/DigestEchoClientSSL.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/893	linux-all
+java/net/httpclient/ResponseBodyBeforeError.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/893	linux-all
+java/net/httpclient/ResponsePublisher.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/893	linux-all
+java/net/MulticastSocket/Promiscuous.java               https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699    linux-s390x
+java/net/MulticastSocket/SetLoopbackMode.java     https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699    linux-s390x
+java/net/MulticastSocket/Test.java                             https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699    linux-s390x
+#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/AdoptOpenJDK/openjdk-tests/issues/1016
+#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699 linux-s390x
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267 macosx-all,linux-s390x
+#java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue	https://github.com/AdoptOpenJDK/openjdk-tests/issues/602
+java/nio/channels/DatagramChannel/Promiscuous.java              https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699    linux-s390x,macosx-all
+############################################################################
+
+# jdk_io
+
+############################################################################
+
+# jdk_jdi
+
+############################################################################
+
+# jdk_nio
+java/nio/channels/spi/SelectorProvider/inheritedChannel/InheritedChannelTest.java https://github.com/AdoptOpenJDK/openjdk-build/issues/248	generic-all
+java/nio/file/attribute/BasicFileAttributeView/UnixSocketFile.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/593	linux-all
+java/nio/channels/AsyncCloseAndInterrupt.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1597	linux-all,aix-all
+java/nio/charset/spi/CharsetProviderBasicTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/593	linux-all
+java/nio/channels/DatagramChannel/AfterDisconnect.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1650 aix-all
+java/nio/channels/DatagramChannel/ChangingAddress.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1650 aix-all
+java/nio/channels/DatagramChannel/ConnectExceptions.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/593	linux-all
+java/nio/channels/DatagramChannel/SendExceptions.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/593	linux-all
+java/nio/file/Files/InterruptCopy.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/593	linux-all
+java/nio/channels/AsynchronousFileChannel/Basic.java https://bugs.openjdk.java.net/browse/JDK-7052549 windows-all
+java/nio/channels/AsynchronousSocketChannel/Basic.java	https://bugs.openjdk.java.net/browse/JDK-7052549	windows-all
+jdk/nio/zipfs/ZipFSTester.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/602 macosx-all,linux-ppc64le
+java/nio/file/Files/CopyAndMove.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
+java/nio/channels/DatagramChannel/PromiscuousIPv6.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699    linux-s390x
+############################################################################ 
+
+# jdk_rmi
+############################################################################
+
+# jdk_security
+
+security/infra/java/security/cert/CertPathValidator/certification/LuxTrustCA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074	generic-all
+security/infra/java/security/cert/CertPathValidator/certification/BuypassCA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074	generic-all
+security/infra/java/security/cert/CertPathValidator/certification/QuoVadisCA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2074	generic-all
+############################################################################
+
+# jdk_sound
+
+############################################################################
+
+# jdk_swing
+
+############################################################################
+
+# jdk_text
+
+############################################################################
+
+# jdk_time
+
+############################################################################
+
+# jdk_tools
+
+############################################################################
+
+# jdk_jdi
+
+############################################################################
+
+# jdk_util
+java/util/concurrent/locks/Lock/TimedAcquireLeak.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
+java/util/logging/TestLoggerWeakRefLeak.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
+java/util/concurrent/tck/JSR166TestCase.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1272 windows-all
+############################################################################
+
+# svc_tools
+
+############################################################################
+
+# jdk_other
+############################################################################
+
+# jdk_foreign
+java/foreign/TestArrays.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1701 generic-all
+java/foreign/TestLayouts.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1701 generic-all
+java/foreign/TestLayoutPaths.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1701	generic-all
+java/foreign/TestNative.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1920 generic-all
+
+############################################################################


### PR DESCRIPTION
Copied from `ProblemList_openjdk16`, otherwise `ProblemList_openjdk11` is used by default.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>