### PR TITLE
Enable jdk_security4 & exclude java/lang/ProcessBuilder/Basic

### DIFF
--- a/openjdk/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/ProblemList_openjdk11-openj9.txt
@@ -38,8 +38,8 @@ java/lang/ClassLoader/RecursiveSystemLoader.java	https://github.com/eclipse/open
 java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	generic-all
 java/lang/Enum/ConstantDirectoryOptimalCapacity.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/ModuleLayer/BasicLayerTest.java	https://github.com/eclipse/openj9/issues/6462	generic-all
-java/lang/ProcessBuilder/Basic.java#id0		https://github.com/eclipse/openj9/issues/9032	linux-aarch64,aix-all
-java/lang/ProcessBuilder/Basic.java#id1		https://github.com/eclipse/openj9/issues/9032	linux-aarch64
+java/lang/ProcessBuilder/Basic.java#id0		https://github.com/eclipse/openj9/issues/9032	linux-aarch64,aix-all,linux-ppc64le
+java/lang/ProcessBuilder/Basic.java#id1		https://github.com/eclipse/openj9/issues/9032	linux-aarch64,linux-ppc64le
 java/lang/ProcessBuilder/SkipTest.java https://github.com/eclipse/openj9/issues/4124 windows-all
 java/lang/StackTraceElement/PublicConstructor.java	https://github.com/eclipse/openj9/issues/6659	generic-all
 java/lang/StackTraceElement/SerialTest.java	https://github.com/eclipse/openj9/issues/6659	generic-all

--- a/openjdk/ProblemList_openjdk15-openj9.txt
+++ b/openjdk/ProblemList_openjdk15-openj9.txt
@@ -38,6 +38,7 @@ java/lang/ClassLoader/RecursiveSystemLoader.java	https://github.com/eclipse/open
 java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	generic-all
 java/lang/Enum/ConstantDirectoryOptimalCapacity.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/ModuleLayer/BasicLayerTest.java	https://github.com/eclipse/openj9/issues/6462	generic-all
+java/lang/ProcessBuilder/Basic.java		https://github.com/eclipse/openj9/issues/10921	linux-ppc64le
 java/lang/ProcessBuilder/SkipTest.java https://github.com/eclipse/openj9/issues/4124 windows-all
 java/lang/StackTraceElement/PublicConstructor.java	https://github.com/eclipse/openj9/issues/6659	generic-all
 java/lang/StackTraceElement/SerialTest.java	https://github.com/eclipse/openj9/issues/6659	generic-all

--- a/openjdk/ProblemList_openjdk16-openj9.txt
+++ b/openjdk/ProblemList_openjdk16-openj9.txt
@@ -38,6 +38,7 @@ java/lang/ClassLoader/RecursiveSystemLoader.java	https://github.com/eclipse/open
 java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	generic-all
 java/lang/Enum/ConstantDirectoryOptimalCapacity.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/ModuleLayer/BasicLayerTest.java	https://github.com/eclipse/openj9/issues/6462	generic-all
+java/lang/ProcessBuilder/Basic.java		https://github.com/eclipse/openj9/issues/10921	linux-ppc64le
 java/lang/ProcessBuilder/SkipTest.java https://github.com/eclipse/openj9/issues/4124 windows-all
 java/lang/StackTraceElement/PublicConstructor.java	https://github.com/eclipse/openj9/issues/6659	generic-all
 java/lang/StackTraceElement/SerialTest.java	https://github.com/eclipse/openj9/issues/6659	generic-all
@@ -105,6 +106,7 @@ java/lang/invoke/LFCaching/LFMultiThreadCachingTest.java	https://github.com/Adop
 java/lang/invoke/LFCaching/LFSingleThreadCachingTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/invoke/LambdaFormTest.java		https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/invoke/LoopCombinatorTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
+java/lang/invoke/MethodHandles/classData/ClassDataTest.java https://github.com/eclipse/openj9/issues/11366 generic-all
 java/lang/invoke/MethodHandles/privateLookupIn/Driver.java https://github.com/eclipse/openj9/issues/8571 generic-all
 java/lang/invoke/MethodHandlesGeneralTest.java	https://github.com/eclipse/openj9/issues/7043	generic-all
 java/lang/invoke/MethodHandlesInsertArgumentsTest.java	https://github.com/eclipse/openj9/issues/7057	generic-all

--- a/openjdk/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/ProblemList_openjdk17-openj9.txt
@@ -38,6 +38,7 @@ java/lang/ClassLoader/RecursiveSystemLoader.java	https://github.com/eclipse/open
 java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	generic-all
 java/lang/Enum/ConstantDirectoryOptimalCapacity.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/ModuleLayer/BasicLayerTest.java	https://github.com/eclipse/openj9/issues/6462	generic-all
+java/lang/ProcessBuilder/Basic.java		https://github.com/eclipse/openj9/issues/10921	linux-ppc64le
 java/lang/ProcessBuilder/SkipTest.java https://github.com/eclipse/openj9/issues/4124 windows-all
 java/lang/StackTraceElement/PublicConstructor.java	https://github.com/eclipse/openj9/issues/6659	generic-all
 java/lang/StackTraceElement/SerialTest.java	https://github.com/eclipse/openj9/issues/6659	generic-all
@@ -105,6 +106,7 @@ java/lang/invoke/LFCaching/LFMultiThreadCachingTest.java	https://github.com/Adop
 java/lang/invoke/LFCaching/LFSingleThreadCachingTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/invoke/LambdaFormTest.java		https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/invoke/LoopCombinatorTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
+java/lang/invoke/MethodHandles/classData/ClassDataTest.java https://github.com/eclipse/openj9/issues/11366 generic-all
 java/lang/invoke/MethodHandles/privateLookupIn/Driver.java https://github.com/eclipse/openj9/issues/8571 generic-all
 java/lang/invoke/MethodHandlesGeneralTest.java	https://github.com/eclipse/openj9/issues/7043	generic-all
 java/lang/invoke/MethodHandlesInsertArgumentsTest.java	https://github.com/eclipse/openj9/issues/7057	generic-all

--- a/openjdk/ProblemList_openjdk8-openj9.txt
+++ b/openjdk/ProblemList_openjdk8-openj9.txt
@@ -27,7 +27,7 @@ java/lang/Class/forName/arrayClass/ExceedMaxDim.java	https://github.com/eclipse/
 java/lang/ClassLoader/Assert.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/982	aix-all
 java/lang/ClassLoader/forNameLeak/ClassForNameLeak.java		https://github.com/eclipse/openj9/issues/7122	generic-all
 java/lang/Math/HypotTests.java	https://github.com/eclipse/openj9/issues/1128	generic-all
-java/lang/ProcessBuilder/Basic.java		https://github.com/AdoptOpenJDK/openjdk-tests/issues/1397	aix-all
+java/lang/ProcessBuilder/Basic.java		https://github.com/AdoptOpenJDK/openjdk-tests/issues/1397	aix-all,linux-ppc64le
 java/lang/Runtime/loadLibrary/LoadLibraryTest.java	https://github.com/eclipse/openj9/issues/8287	macosx-all
 java/lang/Runtime/shutdown/ShutdownInterruptedMain.java		https://github.com/eclipse/openj9/issues/1128	generic-all
 java/lang/SecurityManager/CheckPackageAccess.java		https://github.com/eclipse/openj9/issues/1128	generic-all

--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -771,10 +771,6 @@
 		<levels>
 			<level>extended</level>
 		</levels>
-		<!-- temporarily disable on openj9 due to https://github.com/eclipse/openj9/issues/10757 -->
-		<impls>
-			<impl>hotspot</impl>
-		</impls>
 		<groups>
 			<group>openjdk</group>
 		</groups>


### PR DESCRIPTION
Re-enable `jdk_security4` for `OpenJ9`;
Excluding `java/lang/ProcessBuilder/Basic.java` for `JDK 15/16/17` to match earlier versions;
Also exclude `java/lang/invoke/MethodHandles/classData/ClassDataTest.java`.

Note: assuming https://github.com/eclipse/openj9/pull/11664 is accepted to close https://github.com/eclipse/openj9/issues/11268

Signed-off-by: Jason Feng <fengj@ca.ibm.com>