### PR TITLE
Stop using --strip on tar commands

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -319,12 +319,16 @@ getBinaryOpenjdk()
 				if [ -d "$SDKDIR/openjdkbinary/j2sdk-image/jre" ]; then
 					extract_dir="./j2sdk-image/jre"
 				fi
-				echo "unzip $jar_name in $extract_dir..."
+				echo "Uncompressing $jar_name over $extract_dir..."
 				if [[ $jar_name == *zip || $jar_name == *jar ]]; then
 					unzip -q $jar_name -d $extract_dir
 				else
-					# some debug-image tar has parent folder. --strip 1 is used to remove it
-					gzip -cd $jar_name | tar xof - -C $extract_dir --strip 1
+					# some debug-image tar has parent folder ... strip it
+					if tar --version 2>&1 | grep GNU 2>&1; then
+						gzip -cd $jar_name | tar xof - -C $extract_dir --strip 1
+					else
+						mkdir dir.$$ && cd dir.$$ && gzip -cd ../$jar_name | tar xof - && cd * && tar cf - . | (cd ../../$extract_dir && tar xpf -) && cd ../.. && rm -rf dir.$$
+					fi
 				fi
 			else
 				if [ -d "$SDKDIR/openjdkbinary/tmp" ]; then
@@ -332,7 +336,7 @@ getBinaryOpenjdk()
 				else
 					mkdir $SDKDIR/openjdkbinary/tmp
 				fi
-				echo "unzip file: $jar_name ..."
+				echo "Uncompressing file: $jar_name ..."
 				if [[ $jar_name == *zip || $jar_name == *jar ]]; then
 					unzip -q $jar_name -d ./tmp
 				elif [[ $jar_name == *.pax* ]]; then


### PR DESCRIPTION
Needs a bit more testing (testing on machine [-1](https://ci.adoptopenjdk.net/view/Failing%20Test%20Jobs/job/Test_openjdk11_j9_sanity.functional_ppc64_aix/66/) and [-2](https://ci.adoptopenjdk.net/view/Failing%20Test%20Jobs/job/Test_openjdk11_j9_sanity.functional_ppc64_aix/67/)), and this won't work of the top level contains anything that starts with a `.` but otherwise, this should remove another GNU-ism from the repository and prevent https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1758 from happening in the future.

Have also changed `unzip` to `Uncompress` since that message keeps confusing me when it's `tar.gz` file :-)

Signed-off-by: Stewart X Addison <sxa@redhat.com>