### PR TITLE
Re-enable tests fixed by openj9#7119 and openj9#11699

### DIFF
--- a/openjdk/ProblemList_openjdk16-openj9.txt
+++ b/openjdk/ProblemList_openjdk16-openj9.txt
@@ -109,7 +109,6 @@ java/lang/invoke/LoopCombinatorTest.java	https://github.com/AdoptOpenJDK/openjdk
 java/lang/invoke/MethodHandles/classData/ClassDataTest.java https://github.com/eclipse/openj9/issues/11366 generic-all
 java/lang/invoke/MethodHandles/privateLookupIn/Driver.java https://github.com/eclipse/openj9/issues/8571 generic-all
 java/lang/invoke/MethodHandlesGeneralTest.java	https://github.com/eclipse/openj9/issues/7043	generic-all
-java/lang/invoke/MethodHandlesInsertArgumentsTest.java	https://github.com/eclipse/openj9/issues/7057	generic-all
 java/lang/invoke/PrivateInterfaceCall.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/invoke/PrivateInvokeTest.java	https://github.com/eclipse/openj9/issues/7071	generic-all
 java/lang/invoke/RevealDirectTest.java	https://github.com/eclipse/openj9/issues/8268	generic-all

--- a/openjdk/ProblemList_openjdk16-openj9.txt
+++ b/openjdk/ProblemList_openjdk16-openj9.txt
@@ -127,10 +127,7 @@ java/lang/invoke/VarHandles/VarHandleTestByteArrayAsShort.java https://github.co
 java/lang/invoke/VarargsArrayTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/invoke/condy/CondyNestedTest.java https://github.com/eclipse/openj9/issues/4127 linux-ppc64le
 java/lang/invoke/condy/CondyNestedResolutionTest.java	https://github.com/eclipse/openj9/issues/7158	aix-all
-java/lang/invoke/lambda/LambdaReceiver.java https://github.com/eclipse/openj9/issues/11359 generic-all
-java/lang/invoke/lambda/LambdaReceiverBridge.java https://github.com/eclipse/openj9/issues/11359 generic-all
 java/lang/invoke/lambda/LambdaStackTrace.java	https://github.com/eclipse/openj9/issues/3394	generic-all
-java/lang/invoke/lambda/superProtectedMethod/InheritedProtectedMethod.java https://github.com/eclipse/openj9/issues/11359 generic-all
 java/lang/invoke/lambda/superProtectedMethod/SuperMethodTest.java https://github.com/eclipse/openj9/issues/11359 generic-all
 java/lang/invoke/lookup/LookupClassTest.java    https://github.com/eclipse/openj9/issues/8570   generic-all
 java/lang/invoke/modules/Driver.java    https://github.com/eclipse/openj9/issues/8571   generic-all


### PR DESCRIPTION
Re-enable tests fixed by 
- eclipse/openj9#7119 
- eclipse/openj9#11699

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>