### PR TITLE
Re-enable tests fixed by ibmruntimes/openj9-openjdk-jdk16#9 

### DIFF
--- a/openjdk/ProblemList_openjdk16-openj9.txt
+++ b/openjdk/ProblemList_openjdk16-openj9.txt
@@ -153,7 +153,6 @@ jdk/internal/loader/NativeLibraries/Main.java https://github.com/AdoptOpenJDK/op
 java/lang/invoke/lambda/superProtectedMethod/SuperMethodTest.java https://github.com/eclipse/openj9/issues/11135 generic-all
 java/lang/invoke/MethodHandles/publicLookup/Driver.java https://github.com/eclipse/openj9/issues/11135 generic-all
 java/lang/invoke/MethodHandlesPermuteArgumentsTest.java https://github.com/eclipse/openj9/issues/11135 generic-all
-java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java https://github.com/eclipse/openj9/issues/11135 generic-all
 java/lang/invoke/VarHandles/VarHandleTestExact.java https://github.com/eclipse/openj9/issues/11256 generic-all
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1920 windows-all
 ############################################################################
@@ -327,11 +326,7 @@ vm/verifier/VerifyProtectedConstructor.java	https://github.com/eclipse/openj9/is
 ############################################################################
 
 # jdk_foreign
-java/foreign/TestArrays.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1701 generic-all
-java/foreign/TestLayouts.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1701 generic-all
-java/foreign/TestLayoutPaths.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1701	generic-all
 java/foreign/TestByteBuffer.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1702	generic-all
-java/foreign/TestLayoutConstants.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1702	generic-all
 java/foreign/TestNative.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1920 generic-all
 java/foreign/TestSharedAccess.java https://github.com/eclipse/openj9/issues/11027 generic-all
 java/foreign/TestSpliterator.java https://github.com/eclipse/openj9/issues/11027 generic-all
@@ -341,27 +336,12 @@ java/foreign/TestCleaner.java https://github.com/eclipse/openj9/issues/11027 gen
 java/foreign/stackwalk/TestStackWalk.java https://github.com/eclipse/openj9/issues/11027 generic-all
 java/foreign/valist/VaListTest.java https://github.com/eclipse/openj9/issues/11027 generic-all
 java/foreign/StdLibTest.java https://github.com/eclipse/openj9/issues/11027 generic-all
-java/foreign/TestAdaptVarHandles.java https://github.com/eclipse/openj9/issues/11027 generic-all
-java/foreign/TestAddressHandle.java https://github.com/eclipse/openj9/issues/11027 generic-all
 java/foreign/TestDowncall.java https://github.com/eclipse/openj9/issues/11027 generic-all
-java/foreign/TestIllegalLink.java https://github.com/eclipse/openj9/issues/11027 generic-all
 java/foreign/TestIntrinsics.java https://github.com/eclipse/openj9/issues/11027 generic-all
-java/foreign/TestMemoryAccess.java https://github.com/eclipse/openj9/issues/11027 generic-all
-java/foreign/TestMemoryAccessStatics.java https://github.com/eclipse/openj9/issues/11027 generic-all
-java/foreign/TestMemoryAlignment.java https://github.com/eclipse/openj9/issues/11027 generic-all
-java/foreign/TestMemoryCopy.java https://github.com/eclipse/openj9/issues/11027 generic-all
-java/foreign/TestMemoryHandleAsUnsigned.java https://github.com/eclipse/openj9/issues/11027 generic-all
-java/foreign/TestMismatch.java https://github.com/eclipse/openj9/issues/11027 generic-all
 java/foreign/TestNativeScope.java https://github.com/eclipse/openj9/issues/11027 generic-all
-java/foreign/TestNulls.java https://github.com/eclipse/openj9/issues/11027 generic-all
-java/foreign/TestRebase.java https://github.com/eclipse/openj9/issues/11027 generic-all
-java/foreign/TestSegments.java https://github.com/eclipse/openj9/issues/11027 generic-all
-java/foreign/TestSlices.java https://github.com/eclipse/openj9/issues/11027 generic-all
-java/foreign/TestTypeAccess.java https://github.com/eclipse/openj9/issues/11027 generic-all
 java/foreign/TestUpcall.java https://github.com/eclipse/openj9/issues/11027 generic-all
 java/foreign/TestUpcallHighArity.java https://github.com/eclipse/openj9/issues/11027 generic-all
 java/foreign/TestUpcallStubs.java https://github.com/eclipse/openj9/issues/11027 generic-all
 java/foreign/TestVarArgs.java https://github.com/eclipse/openj9/issues/11027 generic-all
-java/foreign/TestVarHandleCombinators.java https://github.com/eclipse/openj9/issues/11027 generic-all
 
 ############################################################################

--- a/openjdk/ProblemList_openjdk16-openj9.txt
+++ b/openjdk/ProblemList_openjdk16-openj9.txt
@@ -326,22 +326,25 @@ vm/verifier/VerifyProtectedConstructor.java	https://github.com/eclipse/openj9/is
 ############################################################################
 
 # jdk_foreign
-java/foreign/TestByteBuffer.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1702	generic-all
-java/foreign/TestNative.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1920 generic-all
+
+# Foreign-Memory Access API, Third Incubator, JEP393 Failures
+java/foreign/TestByteBuffer.java https://github.com/eclipse/openj9/issues/11027 generic-all
 java/foreign/TestSharedAccess.java https://github.com/eclipse/openj9/issues/11027 generic-all
 java/foreign/TestSpliterator.java https://github.com/eclipse/openj9/issues/11027 generic-all
-java/foreign/TestByteBuffer.java https://github.com/eclipse/openj9/issues/11027 generic-all
 java/foreign/TestHandshake.java https://github.com/eclipse/openj9/issues/11027 generic-all
 java/foreign/TestCleaner.java https://github.com/eclipse/openj9/issues/11027 generic-all
-java/foreign/stackwalk/TestStackWalk.java https://github.com/eclipse/openj9/issues/11027 generic-all
-java/foreign/valist/VaListTest.java https://github.com/eclipse/openj9/issues/11027 generic-all
-java/foreign/StdLibTest.java https://github.com/eclipse/openj9/issues/11027 generic-all
-java/foreign/TestDowncall.java https://github.com/eclipse/openj9/issues/11027 generic-all
-java/foreign/TestIntrinsics.java https://github.com/eclipse/openj9/issues/11027 generic-all
 java/foreign/TestNativeScope.java https://github.com/eclipse/openj9/issues/11027 generic-all
-java/foreign/TestUpcall.java https://github.com/eclipse/openj9/issues/11027 generic-all
-java/foreign/TestUpcallHighArity.java https://github.com/eclipse/openj9/issues/11027 generic-all
-java/foreign/TestUpcallStubs.java https://github.com/eclipse/openj9/issues/11027 generic-all
-java/foreign/TestVarArgs.java https://github.com/eclipse/openj9/issues/11027 generic-all
+
+# Foreign Linker API, JEP389, Failures
+java/foreign/TestNative.java https://github.com/eclipse/openj9/issues/11195 generic-all
+java/foreign/stackwalk/TestStackWalk.java https://github.com/eclipse/openj9/issues/11195 generic-all
+java/foreign/valist/VaListTest.java https://github.com/eclipse/openj9/issues/11195 generic-all
+java/foreign/StdLibTest.java https://github.com/eclipse/openj9/issues/11195 generic-all
+java/foreign/TestDowncall.java https://github.com/eclipse/openj9/issues/11195 generic-all
+java/foreign/TestIntrinsics.java https://github.com/eclipse/openj9/issues/11195 generic-all
+java/foreign/TestUpcall.java https://github.com/eclipse/openj9/issues/11195 generic-all
+java/foreign/TestUpcallHighArity.java https://github.com/eclipse/openj9/issues/11195 generic-all
+java/foreign/TestUpcallStubs.java https://github.com/eclipse/openj9/issues/11195 generic-all
+java/foreign/TestVarArgs.java https://github.com/eclipse/openj9/issues/11195 generic-all
 
 ############################################################################


### PR DESCRIPTION
- Re-enable tests fixed by ibmruntimes/openj9-openjdk-jdk16#9.
- JEP389 and JEP393 failures have been:
    - sorted correctly; and
    - linked to the correct issue.
- Also, a duplicate for `TestByteBuffer.java` has been removed.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>