### PR TITLE
Convert iteration based STF load test playlist targets to time-based  

### DIFF
--- a/system/daaLoadTest/playlist.xml
+++ b/system/daaLoadTest/playlist.xml
@@ -19,12 +19,12 @@
 	</test>
 	<!--  The following tests are specific to openj9 only -->
 	<test>
-		<testCaseName>DaaLoadTest_daa1</testCaseName>
+		<testCaseName>DaaLoadTest_daa1_5m</testCaseName>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test-args=$(Q)workload=daa1$(Q) -test=DaaLoadTest; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test-args=$(Q)workload=daa1,timeLimit=5m$(Q) -test=DaaLoadTest; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -38,12 +38,12 @@
 		</impls>
 	</test>
 	<test>
-		<testCaseName>DaaLoadTest_daa2</testCaseName>
+		<testCaseName>DaaLoadTest_daa2_5m</testCaseName>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test-args=$(Q)workload=daa2$(Q)  -test=DaaLoadTest; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test-args=$(Q)workload=daa2,timeLimit=5m$(Q) -test=DaaLoadTest; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -57,12 +57,12 @@
 		</impls>
 	</test>
 	<test>
-		<testCaseName>DaaLoadTest_daa3</testCaseName>
+		<testCaseName>DaaLoadTest_daa3_5m</testCaseName>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test-args=$(Q)workload=daa3$(Q) -test=DaaLoadTest; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test-args=$(Q)workload=daa3,timeLimit=5m$(Q) -test=DaaLoadTest; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -76,12 +76,12 @@
 		</impls>
 	</test>
 	<test>
-		<testCaseName>DaaLoadTest_all</testCaseName>
+		<testCaseName>DaaLoadTest_all_5m</testCaseName>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=DaaLoadTest; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=DaaLoadTest -test-args=$(Q)workload=daaAll,timeLimit=5m$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -95,11 +95,11 @@
 		</impls>
 	</test>
 	<test>
-		<testCaseName>DaaLoadTest_daa1_ConcurrentScavenge</testCaseName>
+		<testCaseName>DaaLoadTest_daa1_CS_5m</testCaseName>
 		<variations>
 			<variation>-Xgcpolicy:gencon -Xgc:concurrentScavenge</variation>
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test-args=$(Q)workload=daa1$(Q) -test=DaaLoadTest; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test-args=$(Q)workload=daa1,timeLimit=5m$(Q) -test=DaaLoadTest; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -114,11 +114,11 @@
 		<platformRequirements>bits.64,^arch.arm</platformRequirements>
 	</test>
 	<test>
-		<testCaseName>DaaLoadTest_daa2_ConcurrentScavenge</testCaseName>
+		<testCaseName>DaaLoadTest_daa2_CS_5m</testCaseName>
 		<variations>
 			<variation>-Xgcpolicy:gencon -Xgc:concurrentScavenge</variation>
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test-args=$(Q)workload=daa2$(Q) -test=DaaLoadTest; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test-args=$(Q)workload=daa2,timeLimit=5m$(Q) -test=DaaLoadTest; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -133,11 +133,11 @@
 		<platformRequirements>bits.64,^arch.arm</platformRequirements>
 	</test>
 	<test>
-		<testCaseName>DaaLoadTest_daa3_ConcurrentScavenge</testCaseName>
+		<testCaseName>DaaLoadTest_daa3_CS_5m</testCaseName>
 		<variations>
 			<variation>-Xgcpolicy:gencon -Xgc:concurrentScavenge</variation>
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test-args=$(Q)workload=daa3$(Q) -test=DaaLoadTest; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test-args=$(Q)workload=daa3,timeLimit=5m$(Q) -test=DaaLoadTest; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -152,11 +152,11 @@
 		<platformRequirements>bits.64,^arch.arm</platformRequirements>
 	</test>
 	<test>
-		<testCaseName>DaaLoadTest_all_ConcurrentScavenge</testCaseName>
+		<testCaseName>DaaLoadTest_all_CS_5m</testCaseName>
 		<variations>
 			<variation>-Xgcpolicy:gencon -Xgc:concurrentScavenge</variation>
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=DaaLoadTest; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=DaaLoadTest -test-args=$(Q)workload=daaAll,timeLimit=5m$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -171,7 +171,7 @@
 		<platformRequirements>bits.64,^arch.arm</platformRequirements>
 	</test>
 	<test>
-		<testCaseName>DaaLoadTest_daa1_special</testCaseName>
+		<testCaseName>DaaLoadTest_daa1_special_5m</testCaseName>
 		<variations>
 			<variation>Mode101</variation>
 			<variation>Mode103</variation>
@@ -205,7 +205,7 @@
 			<variation>-Xgcpolicy:gencon -Xgc:dynamicBreadthFirstScanOrdering</variation>
 			<!--Note: -Xint modes Mode108, Mode109, Mode109-CS, Mode159, Mode159-CS, Mode550 should be run manually -->
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test-args=$(Q)workload=daa1$(Q) -test=DaaLoadTest; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test-args=$(Q)workload=daa1,timeLimit=5m$(Q) -test=DaaLoadTest; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -219,7 +219,7 @@
 		</impls>
 	</test>
 	<test>
-		<testCaseName>DaaLoadTest_daa2_special</testCaseName>
+		<testCaseName>DaaLoadTest_daa2_special_5m</testCaseName>
 		<variations>
 			<variation>Mode101</variation>
 			<variation>Mode103</variation>
@@ -253,7 +253,7 @@
 			<variation>-Xgcpolicy:gencon -Xgc:dynamicBreadthFirstScanOrdering</variation>
 			<!--Note: -Xint modes Mode108, Mode109, Mode109-CS, Mode159, Mode159-CS, Mode550 should be run manually -->
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test-args=$(Q)workload=daa2$(Q) -test=DaaLoadTest; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test-args=$(Q)workload=daa2,timeLimit=5m$(Q) -test=DaaLoadTest; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -267,7 +267,7 @@
 		</impls>
 	</test>
 	<test>
-		<testCaseName>DaaLoadTest_daa3_special</testCaseName>
+		<testCaseName>DaaLoadTest_daa3_special_5m</testCaseName>
 		<variations>
 			<variation>Mode101</variation>
 			<variation>Mode103</variation>
@@ -301,7 +301,7 @@
 			<variation>-Xgcpolicy:gencon -Xgc:dynamicBreadthFirstScanOrdering</variation>
 			<!--Note: -Xint modes Mode108, Mode109, Mode109-CS, Mode159, Mode159-CS, Mode550 should be run manually -->
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test-args=$(Q)workload=daa3$(Q) -test=DaaLoadTest; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test-args=$(Q)workload=daa3,timeLimit=5m$(Q) -test=DaaLoadTest; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -315,7 +315,7 @@
 		</impls>
 	</test>
 	<test>
-		<testCaseName>DaaLoadTest_all_special</testCaseName>
+		<testCaseName>DaaLoadTest_all_special_5m</testCaseName>
 		<variations>
 			<variation>Mode101</variation>
 			<variation>Mode103</variation>
@@ -349,7 +349,7 @@
 			<variation>-Xgcpolicy:gencon -Xgc:dynamicBreadthFirstScanOrdering</variation>
 			<!--Note: -Xint modes Mode108, Mode109, Mode109-CS, Mode159, Mode159-CS, Mode550 should be run manually -->
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=DaaLoadTest; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=DaaLoadTest -test-args=$(Q)workload=daaAll,timeLimit=5m$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>

--- a/system/lambdaLoadTest/playlist.xml
+++ b/system/lambdaLoadTest/playlist.xml
@@ -20,13 +20,13 @@
 	<!-- Exclude LambdaLoad test on Linux x64 non-compressedrefs sdks for OpenJ9 builds only,
 		Reason: https://github.com/eclipse/openj9/issues/2209)-->
 	<test>
-		<testCaseName>LambdaLoadTest_Hotspot</testCaseName>
+		<testCaseName>LambdaLoadTest_HS_5m</testCaseName>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
 			<variation>Mode1000</variation>
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=LambdaLoadTest; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=LambdaLoadTest -test-args=$(Q)timeLimit=5m$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -39,12 +39,12 @@
 		</impls>
 	</test>
 	<test>
-		<testCaseName>LambdaLoadTest_OpenJ9_NonLinux</testCaseName>
+		<testCaseName>LambdaLoadTest_J9_NonLinux_5m</testCaseName>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=LambdaLoadTest; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=LambdaLoadTest -test-args=$(Q)timeLimit=5m$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -59,12 +59,12 @@
 		<platformRequirements>^os.linux</platformRequirements>
 	</test>
 	<test>
-		<testCaseName>LambdaLoadTest_OpenJ9_Linux_CompressedRefs</testCaseName>
+		<testCaseName>LambdaLoadTest_J9_Linux_CompRef_5m</testCaseName>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=LambdaLoadTest; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=LambdaLoadTest -test-args=$(Q)timeLimit=5m$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -99,11 +99,11 @@
 	</test>
 	<!-- Temporarily excluding this test from linux ppc64le xl and linux x64 xl, ref: https://github.com/eclipse/openj9/issues/6475 -->
 	<test>
-		<testCaseName>LambdaLoadTest_ConcurrentScavenge</testCaseName>
+		<testCaseName>LambdaLoadTest_CS_5m</testCaseName>
 		<variations>
 			<variation>-Xgcpolicy:gencon -Xgc:concurrentScavenge</variation>
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=LambdaLoadTest; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=LambdaLoadTest -test-args=$(Q)timeLimit=5m$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -118,7 +118,7 @@
 		<platformRequirements>bits.64,^arch.arm,^spec.linux_ppc-64_le,^spec.linux_x86-64</platformRequirements>
 	</test>
 	<test>
-		<testCaseName>LambdaLoadTest_OpenJ9_NonLinux_special</testCaseName>
+		<testCaseName>LambdaLoadTest_special_J9_NonLinux_5m</testCaseName>
 		<variations>
 			<variation>Mode101</variation>
 			<variation>Mode103</variation>
@@ -152,7 +152,7 @@
 			<variation>-Xgcpolicy:gencon -Xgc:dynamicBreadthFirstScanOrdering</variation>
 			<!--Note: -Xint modes Mode108, Mode109, Mode109-CS, Mode159, Mode159-CS, Mode550 should be run manually -->
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=LambdaLoadTest; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=LambdaLoadTest -test-args=$(Q)timeLimit=5m$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -167,7 +167,7 @@
 		<platformRequirements>^os.linux</platformRequirements>
 	</test>
 	<test>
-		<testCaseName>LambdaLoadTest_OpenJ9_Linux_CompressedRefs_special</testCaseName>
+		<testCaseName>LambdaLoadTest_J9_special_Linux_CompRef_5m</testCaseName>
 		<variations>
 			<variation>Mode101</variation>
 			<variation>Mode103</variation>
@@ -201,7 +201,7 @@
 			<variation>-Xgcpolicy:gencon -Xgc:dynamicBreadthFirstScanOrdering</variation>
 			<!--Note: -Xint modes Mode108, Mode109, Mode109-CS, Mode159, Mode159-CS, Mode550 should be run manually -->
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=LambdaLoadTest; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=LambdaLoadTest -test-args=$(Q)timeLimit=5m$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>

--- a/system/mathLoadTest/playlist.xml
+++ b/system/mathLoadTest/playlist.xml
@@ -18,13 +18,13 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>MathLoadTest_all</testCaseName>
+		<testCaseName>MathLoadTest_all_5m</testCaseName>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
 			<variation>Mode1000</variation>
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MathLoadTest; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MathLoadTest -test-args=$(Q)workload=math,timeLimit=5m$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -34,13 +34,13 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>MathLoadTest_autosimd</testCaseName>
+		<testCaseName>MathLoadTest_autosimd_5m</testCaseName>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
 			<variation>Mode1000</variation>
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test-args=$(Q)workload=autoSimd$(Q) -test=MathLoadTest; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test-args=$(Q)workload=autoSimd,timeLimit=5m$(Q) -test=MathLoadTest; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -50,13 +50,13 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>MathLoadTest_bigdecimal</testCaseName>
+		<testCaseName>MathLoadTest_bigdecimal_5m</testCaseName>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
 			<variation>Mode1000</variation>
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MathLoadTest -test-args=$(Q)workload=bigDecimal$(Q); \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MathLoadTest -test-args=$(Q)timeLimit=5m,workload=bigDecimal$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -66,11 +66,11 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>MathLoadTest_all_ConcurrentScavenge</testCaseName>
+		<testCaseName>MathLoadTest_all_CS_5m</testCaseName>
 		<variations>
 			<variation>-Xgcpolicy:gencon -Xgc:concurrentScavenge</variation>
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MathLoadTest; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MathLoadTest -test-args=$(Q)workload=math,timeLimit=5m$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -85,11 +85,11 @@
 		<platformRequirements>bits.64,^arch.arm</platformRequirements>
 	</test>
 	<test>
-		<testCaseName>MathLoadTest_autosimd_ConcurrentScavenge</testCaseName>
+		<testCaseName>MathLoadTest_autosimd_CS_5m</testCaseName>
 		<variations>
 			<variation>-Xgcpolicy:gencon -Xgc:concurrentScavenge</variation>
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test-args=$(Q)workload=autoSimd$(Q) -test=MathLoadTest; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test-args=$(Q)timeLimit=5m,workload=autoSimd$(Q) -test=MathLoadTest; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -104,11 +104,11 @@
 		<platformRequirements>bits.64,^arch.arm</platformRequirements>
 	</test>
 	<test>
-		<testCaseName>MathLoadTest_bigdecimal_ConcurrentScavenge</testCaseName>
+		<testCaseName>MathLoadTest_bigdecimal_CS_5m</testCaseName>
 		<variations>
 			<variation>-Xgcpolicy:gencon -Xgc:concurrentScavenge</variation>
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MathLoadTest -test-args=$(Q)workload=bigDecimal$(Q); \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MathLoadTest -test-args=$(Q)timeLimit=5m,workload=bigDecimal$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -123,7 +123,7 @@
 		<platformRequirements>bits.64,^arch.arm</platformRequirements>
 	</test>
 	<test>
-		<testCaseName>MathLoadTest_all_special</testCaseName>
+		<testCaseName>MathLoadTest_all_special_5m</testCaseName>
 		<disabled>
 			<comment>rtc 139897</comment>
 			<variation>Mode554</variation>
@@ -161,7 +161,7 @@
 			<variation>-Xgcpolicy:gencon -Xgc:dynamicBreadthFirstScanOrdering</variation>
 			<!--Note: -Xint modes Mode108, Mode109, Mode109-CS, Mode159, Mode159-CS, Mode550 should be run manually -->
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MathLoadTest; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MathLoadTest -test-args=$(Q)workload=math,timeLimit=5m$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -175,7 +175,7 @@
 		</impls>
 	</test>
 	<test>
-		<testCaseName>MathLoadTest_autosimd_special</testCaseName>
+		<testCaseName>MathLoadTest_autosimd_special_5m</testCaseName>
 		<variations>
 			<variation>Mode101</variation>
 			<variation>Mode103</variation>
@@ -209,7 +209,7 @@
 			<variation>-Xgcpolicy:gencon -Xgc:dynamicBreadthFirstScanOrdering</variation>
 			<!--Note: -Xint modes Mode108, Mode109, Mode109-CS, Mode159, Mode159-CS, Mode550 should be run manually -->
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test-args=$(Q)workload=autoSimd$(Q) -test=MathLoadTest; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test-args=$(Q)timeLimit=5m,workload=autoSimd$(Q) -test=MathLoadTest; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -223,7 +223,7 @@
 		</impls>
 	</test>
 	<test>
-		<testCaseName>MathLoadTest_bigdecimal_special</testCaseName>
+		<testCaseName>MathLoadTest_bigdecimal_special_5m</testCaseName>
 		<disabled>
 			<comment>https://github.com/eclipse/openj9/issues/9104</comment>
 			<variation>Mode614</variation>
@@ -261,7 +261,7 @@
 			<variation>-Xgcpolicy:gencon -Xgc:dynamicBreadthFirstScanOrdering</variation>
 			<!--Note: -Xint modes Mode108, Mode109, Mode109-CS, Mode159, Mode159-CS, Mode550 should be run manually -->
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MathLoadTest -test-args=$(Q)workload=bigDecimal$(Q); \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MathLoadTest -test-args=$(Q)timeLimit=5m,workload=bigDecimal$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>

--- a/system/mauveLoadTest/playlist.xml
+++ b/system/mauveLoadTest/playlist.xml
@@ -19,12 +19,12 @@
 	</test>
 	<!-- Disabled from OpenJ9 on osx due to : https://github.com/eclipse/openj9/issues/4091 -->
 	<test>
-		<testCaseName>MauveSingleThrdLoad_J9</testCaseName>
+		<testCaseName>MauveSingleThrdLoad_J9_5m</testCaseName>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MauveSingleThrdLoad; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MauveSingleThrdLoad -test-args=$(Q)timeLimit=5m$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -39,13 +39,13 @@
 		<platformRequirements>^os.osx</platformRequirements>
 	</test>
 	<test>
-		<testCaseName>MauveSingleThrdLoad_HS</testCaseName>
+		<testCaseName>MauveSingleThrdLoad_HS_5m</testCaseName>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
 			<variation>Mode1000</variation>
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MauveSingleThrdLoad; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MauveSingleThrdLoad -test-args=$(Q)timeLimit=5m$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -59,12 +59,12 @@
 	</test>
 	<!-- Disabled from OpenJ9 on osx due to : https://github.com/eclipse/openj9/issues/4091 -->
 	<test>
-		<testCaseName>MauveSingleInvocLoad_J9</testCaseName>
+		<testCaseName>MauveSingleInvocLoad_J9_5m</testCaseName>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MauveSingleInvocLoad; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MauveSingleInvocLoad -test-args=$(Q)timeLimit=5m$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -79,13 +79,13 @@
 		<platformRequirements>^os.osx</platformRequirements>
 	</test>
 	<test>
-		<testCaseName>MauveSingleInvocLoad_HS</testCaseName>
+		<testCaseName>MauveSingleInvocLoad_HS_5m</testCaseName>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
 			<variation>Mode1000</variation>
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MauveSingleInvocLoad; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MauveSingleInvocLoad -test-args=$(Q)timeLimit=5m$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -98,13 +98,13 @@
 		</impls>
 	</test>
 	<test>
-		<testCaseName>MauveMultiThrdLoad</testCaseName>
+		<testCaseName>MauveMultiThrdLoad_5m</testCaseName>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
 			<variation>Mode1000</variation>
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MauveMultiThrdLoad; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MauveMultiThrdLoad -test-args=$(Q)timeLimit=5m$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -114,14 +114,14 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>MauveSingleThrdLoad_CS</testCaseName>
+		<testCaseName>MauveSingleThrdLoad_CS_5m</testCaseName>
 		<disabled>
 			<comment>AdoptOpenJDK/openjdk-systemtest/issues/75</comment>
 		</disabled>
 		<variations>
 			<variation>-Xgcpolicy:gencon -Xgc:concurrentScavenge</variation>
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MauveSingleThrdLoad; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MauveSingleThrdLoad -test-args=$(Q)timeLimit=5m$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -136,14 +136,14 @@
 		<platformRequirements>bits.64,^arch.arm</platformRequirements>
 	</test>
 	<test>
-		<testCaseName>MauveSingleInvocLoad_CS</testCaseName>
+		<testCaseName>MauveSingleInvocLoad_CS_5m</testCaseName>
 		<disabled>
 			<comment>AdoptOpenJDK/openjdk-systemtest/issues/78</comment>
 		</disabled>
 		<variations>
 			<variation>-Xgcpolicy:gencon -Xgc:concurrentScavenge</variation>
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MauveSingleInvocLoad; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MauveSingleInvocLoad -test-args=$(Q)timeLimit=5m$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -158,14 +158,14 @@
 		<platformRequirements>bits.64,^arch.arm</platformRequirements>
 	</test>
 	<test>
-		<testCaseName>MauveMultiThrdLoad_CS</testCaseName>
+		<testCaseName>MauveMultiThrdLoad_CS_5m</testCaseName>
 		<disabled>
 			<comment>AdoptOpenJDK/openjdk-systemtest/issues/64</comment>
 		</disabled>
 		<variations>
 			<variation>-Xgcpolicy:gencon -Xgc:concurrentScavenge</variation>
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MauveMultiThrdLoad; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MauveMultiThrdLoad -test-args=$(Q)timeLimit=5m$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -181,7 +181,7 @@
 	</test>
 	<!-- The above tests are to be run using concurrentScavenge on z/OS, z/Linux, x/Linux and x/Windows using 64-bit OpenJ9 SDK -->
 	<test>
-		<testCaseName>MauveMultiThrdLoad_special</testCaseName>
+		<testCaseName>MauveMultiThrdLoad_special_5m</testCaseName>
 		<variations>
 			<variation>Mode101</variation>
 			<variation>Mode103</variation>
@@ -213,7 +213,7 @@
 			<variation>-Xgcpolicy:gencon -Xgc:dynamicBreadthFirstScanOrdering</variation>
 			<!--Note: -Xint modes Mode108, Mode109, Mode550 should be run manually -->
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MauveMultiThrdLoadTrc; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MauveMultiThrdLoadTrc -test-args=$(Q)timeLimit=5m$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -230,7 +230,7 @@
 		</subsets>
 	</test>
 	<test>
-		<testCaseName>MauveSingleThrdLoad_special</testCaseName>
+		<testCaseName>MauveSingleThrdLoad_special_5m</testCaseName>
 		<disabled>
 			<comment>https://github.com/eclipse/openj9/issues/3771</comment>
 		</disabled>
@@ -265,7 +265,7 @@
 			<variation>-Xgcpolicy:gencon -Xgc:dynamicBreadthFirstScanOrdering</variation>
 			<!--Note: -Xint modes Mode108, Mode109, Mode550 should be run manually -->
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MauveSingleThrdLoadTrc; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MauveSingleThrdLoadTrc -test-args=$(Q)timeLimit=5m$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -282,7 +282,7 @@
 		</subsets>
 	</test>
 	<test>
-		<testCaseName>MauveSingleInvocLoad_special</testCaseName>
+		<testCaseName>MauveSingleInvocLoad_special_5m</testCaseName>
 		<variations>
 			<variation>Mode101</variation>
 			<variation>Mode103</variation>
@@ -314,7 +314,7 @@
 			<variation>-Xgcpolicy:gencon -Xgc:dynamicBreadthFirstScanOrdering</variation>
 			<!--Note: -Xint modes Mode108, Mode109, Mode550 should be run manually -->
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MauveSingleInvocLoad; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MauveSingleInvocLoad -test-args=$(Q)timeLimit=5m$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>

--- a/system/otherLoadTest/playlist.xml
+++ b/system/otherLoadTest/playlist.xml
@@ -18,7 +18,7 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>MiniMix_5min</testCaseName>
+		<testCaseName>MiniMix_5m</testCaseName>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
@@ -37,7 +37,7 @@
 		</subsets>
 	</test>
 	<test>
-		<testCaseName>MiniMix_5min_jdk8</testCaseName>
+		<testCaseName>MiniMix_jdk8_5m</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -54,13 +54,13 @@
 		</subsets>
 	</test>
 	<test>
-		<testCaseName>ClassLoadingTest</testCaseName>
+		<testCaseName>ClassLoadingTest_5m</testCaseName>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
 			<variation>Mode1000</variation>
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=ClassloadingLoadTest; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=ClassloadingLoadTest -test-args=$(Q)timeLimit=5m$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -70,7 +70,7 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>ClassLoadingTest_special</testCaseName>
+		<testCaseName>ClassLoadingTest_special_5m</testCaseName>
 		<variations>
 			<variation>Mode101</variation>
 			<variation>Mode103</variation>
@@ -104,7 +104,7 @@
 			<variation>-Xgcpolicy:gencon -Xgc:dynamicBreadthFirstScanOrdering</variation>
 			<!--Note: -Xint modes Mode108, Mode109, Mode109-CS, Mode159, Mode159-CS, Mode550 should be run manually -->
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=ClassloadingLoadTest; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=ClassloadingLoadTest -test-args=$(Q)timeLimit=5m$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -118,13 +118,13 @@
 		</impls>
 	</test>
 	<test>
-		<testCaseName>ConcurrentLoadTest</testCaseName>
+		<testCaseName>ConcurrentLoadTest_5m</testCaseName>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
 			<variation>Mode1000</variation>
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=ConcurrentLoadTest; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=ConcurrentLoadTest -test-args=$(Q)timeLimit=5m$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -135,13 +135,13 @@
 	</test>
 	<!-- Temporarily excluded from z/Os due to : jdk11-zos/issues/571-->
 	<test>
-		<testCaseName>DirectByteBufferLoadTest</testCaseName>
+		<testCaseName>DBBLoadTest_5m</testCaseName>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
 			<variation>Mode1000</variation>
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=DirectByteBufferLoadTest; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=DirectByteBufferLoadTest -test-args=$(Q)timeLimit=5m$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -152,13 +152,13 @@
 		<platformRequirements>^os.zos</platformRequirements>
 	</test>
 	<test>
-		<testCaseName>LangLoadTest</testCaseName>
+		<testCaseName>LangLoadTest_5m</testCaseName>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
 			<variation>Mode1000</variation>
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=LangLoadTest; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=LangLoadTest -test-args=$(Q)timeLimit=5m$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -186,13 +186,13 @@
 	<!-- Temporarily exclude from Linux aarch64 for: https://github.com/eclipse/openj9/issues/3065 -->
 	<!-- Temporarily excluded from z/Os due to : jdk11-zos/issues/342-->
 	<test>
-		<testCaseName>NioLoadTest</testCaseName>
+		<testCaseName>NioLoadTest_5m</testCaseName>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
 			<variation>Mode1000</variation>
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=NioLoadTest; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=NioLoadTest -test-args=$(Q)timeLimit=5m$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -203,13 +203,13 @@
 		<platformRequirements>^arch.arm,^os.zos</platformRequirements>
 	</test>
 	<test>
-		<testCaseName>UtilLoadTest</testCaseName>
+		<testCaseName>UtilLoadTest_5m</testCaseName>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
 			<variation>Mode1000</variation>
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=UtilLoadTest; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=UtilLoadTest -test-args=$(Q)timeLimit=5m$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -257,12 +257,12 @@
 		</subsets>
 	</test>
 	<test>
-		<testCaseName>HeapHogLoadTest</testCaseName>
+		<testCaseName>HeapHogLoadTest_5m</testCaseName>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -java-args=$(Q)$(JVM_OPTIONS) -Xdisableexcessivegc$(Q) -test=HeapHogLoadTest; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -java-args=$(Q)$(JVM_OPTIONS) -Xdisableexcessivegc$(Q) -test=HeapHogLoadTest -test-args=$(Q)timeLimit=5m$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -276,12 +276,12 @@
 		</impls>
 	</test>
 	<test>
-		<testCaseName>ObjectTreeLoadTest</testCaseName>
+		<testCaseName>ObjectTreeLoadTest_5m</testCaseName>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -java-args=$(Q)$(JVM_OPTIONS) -Xnoclassgc$(Q) -test=ObjectTreeLoadTest; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -java-args=$(Q)$(JVM_OPTIONS) -Xnoclassgc$(Q) -test=ObjectTreeLoadTest -test-args=$(Q)timeLimit=5m$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -296,11 +296,11 @@
 	</test>
 	<!-- The tests below are added to test concurrent scavenge on z/OS, z/Linux, x/Linux and x/Windows using 64-bit OpenJ9 SDK -->
 	<test>
-		<testCaseName>ClassLoadingTest_ConcurrentScavenge</testCaseName>
+		<testCaseName>ClassLoadingTest_CS_5m</testCaseName>
 		<variations>
 			<variation>-Xgcpolicy:gencon -Xgc:concurrentScavenge</variation>
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=ClassloadingLoadTest; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=ClassloadingLoadTest -test-args=$(Q)timeLimit=5m$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -313,25 +313,5 @@
 			<impl>ibm</impl>
 		</impls>
 		<platformRequirements>bits.64,^arch.arm</platformRequirements>
-	</test>
-	<!-- Temporarily excluded from z/Os due to : jdk11-zos/issues/342-->
-	<test>
-		<testCaseName>MixedLoadTest</testCaseName>
-		<variations>
-			<variation>Mode110</variation>
-			<variation>Mode610</variation>
-		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MixedLoadTest; \
-	$(TEST_STATUS)</command>
-		<levels>
-			<level>extended</level>
-		</levels>
-		<groups>
-			<group>system</group>
-		</groups>
-		<impls>
-			<impl>ibm</impl>
-		</impls>
-		<platformRequirements>^os.zos</platformRequirements>
 	</test>
 </playlist>


### PR DESCRIPTION
- Convert iteration based STF load tests to time-based tests. 
- Related to https://github.com/AdoptOpenJDK/openjdk-tests/issues/2104

Note 1: The following System tests have **not** been converted to time-based in this pass, as they are not really load tests:
1) LockingLoadTest (Not really a load test; it runs a minimix load and runs lock contention tests). 
2) HCRLateAttachWorkload (Not a load test It launches process 'A' with a mini-mix load and then runs process 'B' that attaches an agent to 'A' and runs various unit tests repeatedly).  
3) JDITest (Not a load test; it starts and monitors various relevant attaching or listening processes). 
3) All tests under jlm (Not really load tests. They do stuff like launching sub-process A with a load, while launching sub-process B that issues JLM based commands to test JLM API).  
4) All tests under sharedClasses (Not really load tests. These tests run a mini-mix load in a sub-process and runs various sharedclasses chache verification tests, softmx tests, etc). 
5) All tests under modularity (not really load tests; these tests are mostly for unit-testing various modularity features).  

Note 2: This PR contains deletion of the old `MixedLoadTest` target, as we now have the time-based equivalent of this target (e.g. MiniMix_5m) that was added in an [earlier PR](https://github.com/AdoptOpenJDK/openjdk-tests/pull/2107/files). 

FYI @pshipton 

Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>