### PR TITLE
Revert "Add add-exports to HCRLateAttachWorkload_previewEnabled"

### DIFF
--- a/system/otherLoadTest/playlist.xml
+++ b/system/otherLoadTest/playlist.xml
@@ -244,7 +244,7 @@
 			<variation>Mode650</variation>
 			<variation>Mode1000</variation>
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -debug-generation=$(Q)true$(Q) -java-debug-args=$(Q)--enable-preview --add-exports java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED$(Q) -java-args=$(Q)--enable-preview --add-exports java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED$(Q) -test=HCRLateAttachWorkload; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -debug-generation=$(Q)true$(Q) -java-debug-args=$(Q)--enable-preview$(Q) -java-args=$(Q)--enable-preview$(Q) -test=HCRLateAttachWorkload; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>


### PR DESCRIPTION
Reverts AdoptOpenJDK/openjdk-tests#2182

Related: Related: https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/397