### PR TITLE
Add add-exports to HCRLateAttachWorkload_previewEnabled

### DIFF
--- a/system/otherLoadTest/playlist.xml
+++ b/system/otherLoadTest/playlist.xml
@@ -244,7 +244,7 @@
 			<variation>Mode650</variation>
 			<variation>Mode1000</variation>
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -debug-generation=$(Q)true$(Q) -java-debug-args=$(Q)--enable-preview$(Q) -java-args=$(Q)--enable-preview$(Q) -test=HCRLateAttachWorkload; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -debug-generation=$(Q)true$(Q) -java-debug-args=$(Q)--enable-preview --add-exports java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED$(Q) -java-args=$(Q)--enable-preview --add-exports java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED$(Q) -test=HCRLateAttachWorkload; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>


### PR DESCRIPTION
- Add add-exports to HCRLateAttachWorkload_previewEnabled
- Related Issue: https://github.com/eclipse/openj9/issues/11642
- Need to merge with PR (https://github.com/AdoptOpenJDK/openjdk-systemtest/pull/399) together.

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>