### PR TITLE
Remove references to eclipse/openj9#11135

### DIFF
--- a/openjdk/ProblemList_openjdk16-openj9.txt
+++ b/openjdk/ProblemList_openjdk16-openj9.txt
@@ -127,7 +127,6 @@ java/lang/invoke/VarargsArrayTest.java	https://github.com/AdoptOpenJDK/openjdk-t
 java/lang/invoke/condy/CondyNestedTest.java https://github.com/eclipse/openj9/issues/4127 linux-ppc64le
 java/lang/invoke/condy/CondyNestedResolutionTest.java	https://github.com/eclipse/openj9/issues/7158	aix-all
 java/lang/invoke/lambda/LambdaStackTrace.java	https://github.com/eclipse/openj9/issues/3394	generic-all
-java/lang/invoke/lambda/superProtectedMethod/SuperMethodTest.java https://github.com/eclipse/openj9/issues/11359 generic-all
 java/lang/invoke/lookup/LookupClassTest.java    https://github.com/eclipse/openj9/issues/8570   generic-all
 java/lang/invoke/modules/Driver.java    https://github.com/eclipse/openj9/issues/8571   generic-all
 java/lang/invoke/modules/Driver1.java   https://github.com/eclipse/openj9/issues/8571   generic-all
@@ -150,9 +149,9 @@ jdk/modules/etc/DefaultModules.java	https://github.com/AdoptOpenJDK/openjdk-test
 jdk/modules/incubator/ImageModules.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
 vm/JniInvocationTest.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	macosx-all
 jdk/internal/loader/NativeLibraries/Main.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1920 generic-all
-java/lang/invoke/lambda/superProtectedMethod/SuperMethodTest.java https://github.com/eclipse/openj9/issues/11135 generic-all
-java/lang/invoke/MethodHandles/publicLookup/Driver.java https://github.com/eclipse/openj9/issues/11135 generic-all
-java/lang/invoke/MethodHandlesPermuteArgumentsTest.java https://github.com/eclipse/openj9/issues/11135 generic-all
+java/lang/invoke/lambda/superProtectedMethod/SuperMethodTest.java https://github.com/eclipse/openj9/issues/11783 generic-all
+java/lang/invoke/MethodHandles/publicLookup/Driver.java https://github.com/eclipse/openj9/issues/10648 generic-all
+java/lang/invoke/MethodHandlesPermuteArgumentsTest.java https://github.com/eclipse/openj9/issues/11822 generic-all
 java/lang/invoke/VarHandles/VarHandleTestExact.java https://github.com/eclipse/openj9/issues/11256 generic-all
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1920 windows-all
 ############################################################################


### PR DESCRIPTION
eclipse/openj9#11135 refers to an uber issue, which will be closed soon.
So, the references to eclipse/openj9#11135 have been replaced with
stand-alone trackers for the respective issues.

Also, a duplicate for `SuperMethodTest.java` has been removed.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>