### PR TITLE
Update OpenJ9 JDK17 exclude list

### DIFF
--- a/openjdk/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/ProblemList_openjdk17-openj9.txt
@@ -127,7 +127,6 @@ java/lang/invoke/VarargsArrayTest.java	https://github.com/AdoptOpenJDK/openjdk-t
 java/lang/invoke/condy/CondyNestedTest.java https://github.com/eclipse/openj9/issues/4127 linux-ppc64le
 java/lang/invoke/condy/CondyNestedResolutionTest.java	https://github.com/eclipse/openj9/issues/7158	aix-all
 java/lang/invoke/lambda/LambdaStackTrace.java	https://github.com/eclipse/openj9/issues/3394	generic-all
-java/lang/invoke/lambda/superProtectedMethod/SuperMethodTest.java https://github.com/eclipse/openj9/issues/11359 generic-all
 java/lang/invoke/lookup/LookupClassTest.java    https://github.com/eclipse/openj9/issues/8570   generic-all
 java/lang/invoke/modules/Driver.java    https://github.com/eclipse/openj9/issues/8571   generic-all
 java/lang/invoke/modules/Driver1.java   https://github.com/eclipse/openj9/issues/8571   generic-all
@@ -150,10 +149,10 @@ jdk/modules/etc/DefaultModules.java	https://github.com/AdoptOpenJDK/openjdk-test
 jdk/modules/incubator/ImageModules.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
 vm/JniInvocationTest.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/248	macosx-all
 jdk/internal/loader/NativeLibraries/Main.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1920 generic-all
-java/lang/invoke/lambda/superProtectedMethod/SuperMethodTest.java https://github.com/eclipse/openj9/issues/11135 generic-all
-java/lang/invoke/MethodHandles/publicLookup/Driver.java https://github.com/eclipse/openj9/issues/11135 generic-all
-java/lang/invoke/MethodHandlesPermuteArgumentsTest.java https://github.com/eclipse/openj9/issues/11135 generic-all
 java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java https://github.com/eclipse/openj9/issues/11135 generic-all
+java/lang/invoke/lambda/superProtectedMethod/SuperMethodTest.java https://github.com/eclipse/openj9/issues/11783 generic-all
+java/lang/invoke/MethodHandles/publicLookup/Driver.java https://github.com/eclipse/openj9/issues/10648 generic-all
+java/lang/invoke/MethodHandlesPermuteArgumentsTest.java https://github.com/eclipse/openj9/issues/11822 generic-all
 java/lang/invoke/VarHandles/VarHandleTestExact.java https://github.com/eclipse/openj9/issues/11256 generic-all
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1920 windows-all
 ############################################################################

--- a/openjdk/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/ProblemList_openjdk17-openj9.txt
@@ -109,7 +109,6 @@ java/lang/invoke/LoopCombinatorTest.java	https://github.com/AdoptOpenJDK/openjdk
 java/lang/invoke/MethodHandles/classData/ClassDataTest.java https://github.com/eclipse/openj9/issues/11366 generic-all
 java/lang/invoke/MethodHandles/privateLookupIn/Driver.java https://github.com/eclipse/openj9/issues/8571 generic-all
 java/lang/invoke/MethodHandlesGeneralTest.java	https://github.com/eclipse/openj9/issues/7043	generic-all
-java/lang/invoke/MethodHandlesInsertArgumentsTest.java	https://github.com/eclipse/openj9/issues/7057	generic-all
 java/lang/invoke/PrivateInterfaceCall.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/invoke/PrivateInvokeTest.java	https://github.com/eclipse/openj9/issues/7071	generic-all
 java/lang/invoke/RevealDirectTest.java	https://github.com/eclipse/openj9/issues/8268	generic-all
@@ -127,10 +126,7 @@ java/lang/invoke/VarHandles/VarHandleTestByteArrayAsShort.java https://github.co
 java/lang/invoke/VarargsArrayTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all
 java/lang/invoke/condy/CondyNestedTest.java https://github.com/eclipse/openj9/issues/4127 linux-ppc64le
 java/lang/invoke/condy/CondyNestedResolutionTest.java	https://github.com/eclipse/openj9/issues/7158	aix-all
-java/lang/invoke/lambda/LambdaReceiver.java https://github.com/eclipse/openj9/issues/11359 generic-all
-java/lang/invoke/lambda/LambdaReceiverBridge.java https://github.com/eclipse/openj9/issues/11359 generic-all
 java/lang/invoke/lambda/LambdaStackTrace.java	https://github.com/eclipse/openj9/issues/3394	generic-all
-java/lang/invoke/lambda/superProtectedMethod/InheritedProtectedMethod.java https://github.com/eclipse/openj9/issues/11359 generic-all
 java/lang/invoke/lambda/superProtectedMethod/SuperMethodTest.java https://github.com/eclipse/openj9/issues/11359 generic-all
 java/lang/invoke/lookup/LookupClassTest.java    https://github.com/eclipse/openj9/issues/8570   generic-all
 java/lang/invoke/modules/Driver.java    https://github.com/eclipse/openj9/issues/8571   generic-all

--- a/openjdk/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/ProblemList_openjdk17-openj9.txt
@@ -153,7 +153,6 @@ jdk/internal/loader/NativeLibraries/Main.java https://github.com/AdoptOpenJDK/op
 java/lang/invoke/lambda/superProtectedMethod/SuperMethodTest.java https://github.com/eclipse/openj9/issues/11135 generic-all
 java/lang/invoke/MethodHandles/publicLookup/Driver.java https://github.com/eclipse/openj9/issues/11135 generic-all
 java/lang/invoke/MethodHandlesPermuteArgumentsTest.java https://github.com/eclipse/openj9/issues/11135 generic-all
-java/lang/invoke/MethodHandles/TestDropReturn.java https://github.com/eclipse/openj9/issues/11135 generic-all
 java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java https://github.com/eclipse/openj9/issues/11135 generic-all
 java/lang/invoke/VarHandles/VarHandleTestExact.java https://github.com/eclipse/openj9/issues/11256 generic-all
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1920 windows-all


### PR DESCRIPTION
The following PRs are applied to the OpenJ9 JDK17 exclude list:
- #2188
- #2192 
- ~#2193~
- #2215

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>