### PR TITLE
Remove _5m from ParallelStreamsLoadTest targets

### DIFF
--- a/system/lambdaLoadTest/playlist.xml
+++ b/system/lambdaLoadTest/playlist.xml
@@ -123,7 +123,7 @@
 		</impls>
 	</test>
 	<test>
-		<testCaseName>ParallelStreamsLoadTest_HS_5m</testCaseName>
+		<testCaseName>ParallelStreamsLoadTest_HS</testCaseName>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
@@ -142,7 +142,7 @@
 		</impls>
 	</test>
 	<test>
-		<testCaseName>ParallelStreamsLoadTest_J9_5m</testCaseName>
+		<testCaseName>ParallelStreamsLoadTest_J9</testCaseName>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
@@ -161,7 +161,7 @@
 		</impls>
 	</test>
 	<test>
-		<testCaseName>ParallelStreamsLoadTest_CS_5m</testCaseName>
+		<testCaseName>ParallelStreamsLoadTest_CS</testCaseName>
 		<variations>
 			<variation>-Xgcpolicy:gencon -Xgc:concurrentScavenge</variation>
 		</variations>
@@ -180,7 +180,7 @@
 		<platformRequirements>bits.64</platformRequirements>
 	</test>
 	<test>
-		<testCaseName>ParallelStreamsLoadTest_special_J9_5m</testCaseName>
+		<testCaseName>ParallelStreamsLoadTest_special_J9</testCaseName>
 		<variations>
 			<variation>Mode101</variation>
 			<variation>Mode103</variation>


### PR DESCRIPTION
Signed-off-by: Simon Rushton <srushton@redhat.com>