### PR TITLE
Add a custom playlist target to run system tests

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -539,7 +539,11 @@ def runTest( ) {
 
 			TARGET = "${params.TARGET}";
 			if (TARGET.contains('custom') && CUSTOM_TARGET!='') {
-				CUSTOM_OPTION = "${TARGET.toUpperCase()}_TARGET='${CUSTOM_TARGET}'"
+				if (TARGET == 'system_custom') {
+					env.SYSTEM_CUSTOM_TARGET=CUSTOM_TARGET
+				} else {
+					CUSTOM_OPTION = "${TARGET.toUpperCase()}_TARGET='${CUSTOM_TARGET}'"
+				}
 			}
 			if (!TARGET.startsWith('-f')) {
 				TARGET="_${params.TARGET}"

--- a/system/otherLoadTest/playlist.xml
+++ b/system/otherLoadTest/playlist.xml
@@ -18,6 +18,20 @@
 		</groups>
 	</test>
 	<test>
+		<testCaseName>system_custom</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) $(CUSTOM_TARGET);\
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>special</level>
+		</levels>
+		<groups>
+			<group>system</group>
+		</groups>
+	</test>
+	<test>
 		<testCaseName>MiniMix_5m</testCaseName>
 		<variations>
 			<variation>Mode150</variation>

--- a/system/systemtest.mk
+++ b/system/systemtest.mk
@@ -53,3 +53,6 @@ perl $(SYSTEMTEST_RESROOT)$(D)stf$(D)stf.core$(D)scripts$(D)stf.pl \
 	-java-args=$(SQ)$(JVM_OPTIONS)$(SQ) \
 	-results-root=$(REPORTDIR)
 endef
+
+# Default test to be run for system_custom in regular system test builds 
+CUSTOM_TARGET ?= -test=ClassloadingLoadTest


### PR DESCRIPTION
Resolves https://github.com/AdoptOpenJDK/openjdk-tests/issues/2212

- Adds `system_custom` playlist target which enables running of individual STF system tests in Grinders 
- Updates JenkinsfileBase logic for `system_custom` target to allow stf tests with extra options to work 

To run stf system tests using `system_custom` in a Grinder, please ensure the following is set: 

```
1) BUILD_LIST=system
2) TARGET=system_custom
3) CUSTOM_TARGET=-test=<stf_test_class_name>
     - Optionally, if test requires arguments, CUSTOM_TARGET=-test=<stf_test_class_name>  -test-args="x=a,y=b"
```

Note, `<stf_test_class_name>` should be the name of the STF class to run, e.g. [CassLoadingLoadTest](https://github.com/AdoptOpenJDK/openjdk-systemtest/blob/master/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/ClassloadingLoadTest.java); not a [playlist target](https://github.com/AdoptOpenJDK/openjdk-tests/blob/517467de209aae47db938d4d2b58f45727912322/system/otherLoadTest/playlist.xml#L57). 

Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>