### PR TITLE
Reinstate ChaCha20Poly1305ParamTest

### DIFF
--- a/openjdk/ProblemList_openjdk16-openj9.txt
+++ b/openjdk/ProblemList_openjdk16-openj9.txt
@@ -349,6 +349,4 @@ java/foreign/TestVarArgs.java https://github.com/eclipse/openj9/issues/11195 gen
 
 # com_sun_crypto
 
-com/sun/crypto/provider/Cipher/ChaCha20/ChaCha20Poly1305ParamTest.java https://github.com/eclipse/openj9/issues/11689 generic-all
-
 ############################################################################

--- a/openjdk/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/ProblemList_openjdk17-openj9.txt
@@ -366,6 +366,4 @@ java/foreign/TestVarHandleCombinators.java https://github.com/eclipse/openj9/iss
 
 # com_sun_crypto
 
-com/sun/crypto/provider/Cipher/ChaCha20/ChaCha20Poly1305ParamTest.java https://github.com/eclipse/openj9/issues/11689 generic-all
-
 ############################################################################


### PR DESCRIPTION
Issue https://github.com/eclipse/openj9/issues/11689

Only jdk16 is fixed so far but jdk17 will be fixed shortly. I expect this could be merged anyway as it's more important in the short term to ensure it's fixed for jdk16. Neither version runs green atm anyway.