### PR TITLE
Add certain directories trigger for PR/push testing

### DIFF
--- a/.github/workflows/directoriesFilesChangePR.yml
+++ b/.github/workflows/directoriesFilesChangePR.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           git config --list
           python3 ./.github/workflows/getBuildLists.py ${{ needs.getChangeLocation.outputs.location }}
-  testChangeBasedBuildListWithHotspot:
+  testChangeBasedBuildListWithHotspotAndOpenj9:
     runs-on: ${{ matrix.os }}
     needs: getBuildLists
     if: ${{!contains( fromJson(needs.getBuildLists.outputs.buildLists), 'skip')}}
@@ -46,63 +46,19 @@ jobs:
         os: [ubuntu-16.04, macos-10.15, windows-2016]
         version: [8, 15]
         build_list: ${{ fromJson(needs.getBuildLists.outputs.buildLists) }}
+        impl: [hotspot, openj9]
     steps:
       - uses: actions/checkout@v2
       - uses: AdoptOpenJDK/install-jdk@v1
         with:
           version: ${{ matrix.version }}
           source: 'nightly'
+          impl: ${{ matrix.impl }}
       - name: Extract branch and repo name
         shell: bash
         run: |
-          if ${{ github.event_name == 'pull_request' }}; then
-            echo "::set-output name=branch::$(echo ${GITHUB_HEAD_REF})"
-            echo "::set-output name=repo::$(echo ${{ github.event.pull_request.head.repo.full_name }})"
-          else
-            echo "::set-output name=branch::$(echo ${GITHUB_REF#refs/heads/})"
-            echo "::set-output name=repo::$(echo ${{ github.repository }})"
-          fi
-        id: extract_branch
-      - name: AQA
-        uses: AdoptOpenJDK/run-aqa@v1
-        with:
-          build_list: ${{ matrix.build_list }}
-          target: '_sanity.${{ matrix.build_list }}'
-          jdksource: 'install-jdk'
-          version: ${{ matrix.version }}
-          openjdk_testRepo: '${{ steps.extract_branch.outputs.repo }}:${{ steps.extract_branch.outputs.branch }}'
-      - uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: output_changed_based_build_list
-          path: ./**/output_*/
-  testChangeBasedBuildListWithOpenj9:
-    runs-on: ${{ matrix.os }}
-    needs: getBuildLists
-    if: ${{!contains( fromJson(needs.getBuildLists.outputs.buildLists), 'skip')}}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-16.04, macos-10.15, windows-2016]
-        version: [8, 15]
-        build_list: ${{ fromJson(needs.getBuildLists.outputs.buildLists) }}
-    steps:
-      - uses: actions/checkout@v2
-      - uses: AdoptOpenJDK/install-jdk@v1
-        with:
-          version: ${{ matrix.version }}
-          source: 'nightly'
-          impl: 'openj9'
-      - name: Extract branch name
-        shell: bash
-        run: |
-          if ${{ github.event_name == 'pull_request' }}; then
-            echo "::set-output name=branch::$(echo ${GITHUB_HEAD_REF})"
-            echo "::set-output name=repo::$(echo ${{ github.event.pull_request.head.repo.full_name }})"
-          else
-            echo "::set-output name=branch::$(echo ${GITHUB_REF#refs/heads/})"
-            echo "::set-output name=repo::$(echo ${{ github.repository }})"
-          fi
+          echo "::set-output name=branch::$(echo ${GITHUB_HEAD_REF})"
+          echo "::set-output name=repo::$(echo ${{ github.event.pull_request.head.repo.full_name }})"
         id: extract_branch
       - name: AQA
         uses: AdoptOpenJDK/run-aqa@v1

--- a/.github/workflows/directoriesFilesChangePR.yml
+++ b/.github/workflows/directoriesFilesChangePR.yml
@@ -1,0 +1,129 @@
+name: 'Directories/Files Change Test PR'
+on:
+  pull_request:
+    types: [ready_for_review]
+    paths-ignore:
+      - '.gitignore'
+      - '*.md'
+      - 'doc/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/*.yml'
+      - 'buildenv/**'
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+    paths-ignore:
+      - '.gitignore'
+      - '*.md'
+      - 'doc/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/*.yml'
+      - 'buildenv/**'
+jobs:
+  getChangeLocation:
+    runs-on: ubuntu-latest
+    outputs:
+      location: ${{ steps.get_location.outputs.location }}
+    steps:
+      - uses: jitterbit/get-changed-files@v1
+        id: get_change
+        with:
+          format: space-delimited
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: echo locations
+        id: get_location
+        run: |
+          echo "::set-output name=location::$(echo ${{ steps.get_change.outputs.all }})"
+  getBuildLists:
+    runs-on: ubuntu-latest
+    needs: getChangeLocation
+    outputs:
+      buildLists: ${{ steps.locations_parse.outputs.build_lists }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: parse locations
+        id: locations_parse
+        run: |
+          git config --list
+          python3 ./.github/workflows/getBuildLists.py ${{ needs.getChangeLocation.outputs.location }}
+  testChangeBasedBuildListWithHotspot:
+    runs-on: ${{ matrix.os }}
+    needs: getBuildLists
+    if: ${{!contains( fromJson(needs.getBuildLists.outputs.buildLists), 'skip')}}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-16.04, macos-10.15, windows-2016]
+        version: [8, 15]
+        build_list: ${{ fromJson(needs.getBuildLists.outputs.buildLists) }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: AdoptOpenJDK/install-jdk@v1
+        with:
+          version: ${{ matrix.version }}
+          source: 'nightly'
+      - name: Extract branch and repo name
+        shell: bash
+        run: |
+          if ${{ github.event_name == 'pull_request' }}; then
+            echo "::set-output name=branch::$(echo ${GITHUB_HEAD_REF})"
+            echo "::set-output name=repo::$(echo ${{ github.event.pull_request.head.repo.full_name }})"
+          else
+            echo "::set-output name=branch::$(echo ${GITHUB_REF#refs/heads/})"
+            echo "::set-output name=repo::$(echo ${{ github.repository }})"
+          fi
+        id: extract_branch
+      - name: AQA
+        uses: AdoptOpenJDK/run-aqa@v1
+        with:
+          build_list: ${{ matrix.build_list }}
+          target: '_jdk_custom'
+          jdksource: 'install-jdk'
+          version: ${{ matrix.version }}
+          openjdk_testRepo: '${{ steps.extract_branch.outputs.repo }}:${{ steps.extract_branch.outputs.branch }}'
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: output_changed_based_build_list
+          path: ./**/output_*/
+  testChangeBasedBuildListWithOpenj9:
+    runs-on: ${{ matrix.os }}
+    needs: getBuildLists
+    if: ${{!contains( fromJson(needs.getBuildLists.outputs.buildLists), 'skip')}}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-16.04, macos-10.15, windows-2016]
+        version: [8, 15]
+        build_list: ${{ fromJson(needs.getBuildLists.outputs.buildLists) }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: AdoptOpenJDK/install-jdk@v1
+        with:
+          version: ${{ matrix.version }}
+          source: 'nightly'
+          impl: 'openj9'
+      - name: Extract branch name
+        shell: bash
+        run: |
+          if ${{ github.event_name == 'pull_request' }}; then
+            echo "::set-output name=branch::$(echo ${GITHUB_HEAD_REF})"
+            echo "::set-output name=repo::$(echo ${{ github.event.pull_request.head.repo.full_name }})"
+          else
+            echo "::set-output name=branch::$(echo ${GITHUB_REF#refs/heads/})"
+            echo "::set-output name=repo::$(echo ${{ github.repository }})"
+          fi
+        id: extract_branch
+      - name: AQA
+        uses: AdoptOpenJDK/run-aqa@v1
+        with:
+          build_list: ${{ matrix.build_list }}
+          target: '_ClassLoadingTest'
+          jdksource: 'install-jdk'
+          version: ${{ matrix.version }}
+          openjdk_testRepo: '${{ steps.extract_branch.outputs.repo }}:${{ steps.extract_branch.outputs.branch }}'
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: output_changed_based_build_list
+          path: ./**/output_*/

--- a/.github/workflows/directoriesFilesChangePR.yml
+++ b/.github/workflows/directoriesFilesChangePR.yml
@@ -9,16 +9,6 @@ on:
       - '.github/ISSUE_TEMPLATE/**'
       - '.github/*.yml'
       - 'buildenv/**'
-  push:
-    branches-ignore:
-      - 'dependabot/**'
-    paths-ignore:
-      - '.gitignore'
-      - '*.md'
-      - 'doc/**'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/*.yml'
-      - 'buildenv/**'
 jobs:
   getChangeLocation:
     runs-on: ubuntu-latest

--- a/.github/workflows/directoriesFilesChangePR.yml
+++ b/.github/workflows/directoriesFilesChangePR.yml
@@ -10,32 +10,21 @@ on:
       - '.github/*.yml'
       - 'buildenv/**'
 jobs:
-  getChangeLocation:
+  getBuildLists:
     runs-on: ubuntu-latest
     outputs:
-      location: ${{ steps.get_location.outputs.location }}
+      buildLists: ${{ steps.locations_parse.outputs.build_lists }}
     steps:
+      - uses: actions/checkout@v2
       - uses: jitterbit/get-changed-files@v1
         id: get_change
         with:
           format: space-delimited
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: echo locations
-        id: get_location
-        run: |
-          echo "::set-output name=location::$(echo ${{ steps.get_change.outputs.all }})"
-  getBuildLists:
-    runs-on: ubuntu-latest
-    needs: getChangeLocation
-    outputs:
-      buildLists: ${{ steps.locations_parse.outputs.build_lists }}
-    steps:
-      - uses: actions/checkout@v2
       - name: parse locations
         id: locations_parse
         run: |
-          git config --list
-          python3 ./.github/workflows/getBuildLists.py ${{ needs.getChangeLocation.outputs.location }}
+          python3 ./.github/workflows/getBuildLists.py ${{ steps.get_change.outputs.all }}
   testChangeBasedBuildListWithHotspotAndOpenj9:
     runs-on: ${{ matrix.os }}
     needs: getBuildLists
@@ -54,12 +43,6 @@ jobs:
           version: ${{ matrix.version }}
           source: 'nightly'
           impl: ${{ matrix.impl }}
-      - name: Extract branch and repo name
-        shell: bash
-        run: |
-          echo "::set-output name=branch::$(echo ${GITHUB_HEAD_REF})"
-          echo "::set-output name=repo::$(echo ${{ github.event.pull_request.head.repo.full_name }})"
-        id: extract_branch
       - name: AQA
         uses: AdoptOpenJDK/run-aqa@v1
         with:
@@ -67,7 +50,7 @@ jobs:
           target: '_sanity.${{ matrix.build_list }}'
           jdksource: 'install-jdk'
           version: ${{ matrix.version }}
-          openjdk_testRepo: '${{ steps.extract_branch.outputs.repo }}:${{ steps.extract_branch.outputs.branch }}'
+          openjdk_testRepo: '${{ github.event.pull_request.head.repo.full_name }}:${GITHUB_HEAD_REF}'
       - uses: actions/upload-artifact@v2
         if: failure()
         with:

--- a/.github/workflows/directoriesFilesChangePR.yml
+++ b/.github/workflows/directoriesFilesChangePR.yml
@@ -77,7 +77,7 @@ jobs:
         uses: AdoptOpenJDK/run-aqa@v1
         with:
           build_list: ${{ matrix.build_list }}
-          target: '_jdk_custom'
+          target: '_sanity.${{ matrix.build_list }}'
           jdksource: 'install-jdk'
           version: ${{ matrix.version }}
           openjdk_testRepo: '${{ steps.extract_branch.outputs.repo }}:${{ steps.extract_branch.outputs.branch }}'
@@ -118,7 +118,7 @@ jobs:
         uses: AdoptOpenJDK/run-aqa@v1
         with:
           build_list: ${{ matrix.build_list }}
-          target: '_ClassLoadingTest'
+          target: '_sanity.${{ matrix.build_list }}'
           jdksource: 'install-jdk'
           version: ${{ matrix.version }}
           openjdk_testRepo: '${{ steps.extract_branch.outputs.repo }}:${{ steps.extract_branch.outputs.branch }}'

--- a/.github/workflows/getBuildLists.py
+++ b/.github/workflows/getBuildLists.py
@@ -5,15 +5,17 @@ import json
 def main():
     print(sys.argv)
     result = []
+    # TODO: handle the change of buildenv dir
     for argument in sys.argv:
-        if (argument.startswith('perf/')):
+        if (argument.startswith('perf/') and ('perf' not in result)):
             result.append('perf')
-        elif (argument.startswith('system/')):
+        elif (argument.startswith('system/') and ('system' not in result)):
             result.append('system')
-        elif (argument.startswith('functional/')):
+        elif (argument.startswith('functional/') and ('functional' not in result)):
             result.append('functional')
-        elif (argument.startswith('openjdk/')):
+        elif (argument.startswith('openjdk/') and ('openjdk' not in result)):
             result.append('openjdk')
+
     if not result:
         result.append('skip')
     print('::set-output name=build_lists::{}'.format(json.dumps(result)))

--- a/.github/workflows/getBuildLists.py
+++ b/.github/workflows/getBuildLists.py
@@ -1,0 +1,23 @@
+import sys
+import json
+
+
+def main():
+    print(sys.argv)
+    result = []
+    for argument in sys.argv:
+        if (argument.startswith('perf/')):
+            result.append('perf')
+        elif (argument.startswith('system/')):
+            result.append('system')
+        elif (argument.startswith('functional/')):
+            result.append('functional')
+        elif (argument.startswith('openjdk/')):
+            result.append('openjdk')
+    if not result:
+        result.append('skip')
+    print('::set-output name=build_lists::{}'.format(json.dumps(result)))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Implement the certain directories trigger for Github action. Issue: #2200.
- Use jitterbit/get-changed-files to get the changed file location.
- If the file's top-level directory is among perf, system, functional and openjdk, append the target into the build_list matrix.
- Use run-aqa github action to run a build with build_list target.

### Potential Improvement:
- In the future, it should be able to check which test targets in a playlist changed and run a more specific Github workflow.

### Other Issue:
- As mentioned in #2204, this task should be combined with the Jenkins job trigger task.