### PR TITLE
OpenJ9 AArch64: Enable a BigInteger test back again

### DIFF
--- a/openjdk/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/ProblemList_openjdk11-openj9.txt
@@ -142,8 +142,6 @@ sun/management/HotspotThreadMBean/GetInternalThreads.java	https://github.com/Ado
 
 # jdk_math
 
-java/math/BigInteger/LargeValueExceptions.java	https://github.com/eclipse/openj9/issues/9082	linux-aarch64
-
 ############################################################################
 
 # jdk_net


### PR DESCRIPTION
This commit enables the following test, which used to fail with timeouts
on AArch64:

- java/math/BigInteger/LargeValueExceptions.java (eclipse/openj9#9082)

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>