### PR TITLE
Revert "Exclude com/sun/crypto AEAD ByteBuffer tests"

### DIFF
--- a/openjdk/ProblemList_openjdk16-openj9.txt
+++ b/openjdk/ProblemList_openjdk16-openj9.txt
@@ -349,9 +349,5 @@ java/foreign/TestVarArgs.java https://github.com/eclipse/openj9/issues/11195 gen
 ############################################################################
 
 # com_sun_crypto
-com/sun/crypto/provider/Cipher/AEAD/Encrypt.java https://github.com/eclipse/openj9/issues/11390 generic-all
-com/sun/crypto/provider/Cipher/AEAD/GCMBufferTest.java https://github.com/eclipse/openj9/issues/11390 generic-all
-com/sun/crypto/provider/Cipher/AEAD/OverlapByteBuffer.java https://github.com/eclipse/openj9/issues/11390 generic-all
-com/sun/crypto/provider/Cipher/AEAD/SameBuffer.java https://github.com/eclipse/openj9/issues/11390 generic-all
 
 ############################################################################

--- a/openjdk/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/ProblemList_openjdk17-openj9.txt
@@ -366,9 +366,5 @@ java/foreign/TestVarHandleCombinators.java https://github.com/eclipse/openj9/iss
 ############################################################################
 
 # com_sun_crypto
-com/sun/crypto/provider/Cipher/AEAD/Encrypt.java https://github.com/eclipse/openj9/issues/11390 generic-all
-com/sun/crypto/provider/Cipher/AEAD/GCMBufferTest.java https://github.com/eclipse/openj9/issues/11390 generic-all
-com/sun/crypto/provider/Cipher/AEAD/OverlapByteBuffer.java https://github.com/eclipse/openj9/issues/11390 generic-all
-com/sun/crypto/provider/Cipher/AEAD/SameBuffer.java https://github.com/eclipse/openj9/issues/11390 generic-all
 
 ############################################################################


### PR DESCRIPTION
Reverts AdoptOpenJDK/openjdk-tests#2249

Problem is resolved by
https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/266
https://github.com/ibmruntimes/openj9-openjdk-jdk16/pull/25
https://github.com/ibmruntimes/openj9-openjdk-jdk16/pull/26