### PR TITLE
Only pass LIGHTWEIGHT to DSL if defined

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -337,7 +337,9 @@ def createJob( TEST_JOB_NAME, ARCH_OS ) {
 
 	def templatePath = 'openjdk-tests/buildenv/jenkins/testJobTemplate'
 
-	jobParams.put('LIGHT_WEIGHT_CHECKOUT', params.LIGHT_WEIGHT_CHECKOUT)
+	if (params.LIGHT_WEIGHT_CHECKOUT) {
+		jobParams.put('LIGHT_WEIGHT_CHECKOUT', params.LIGHT_WEIGHT_CHECKOUT)
+	}
 
 	def create = jobDsl targets: templatePath, ignoreExisting: false, additionalParameters: jobParams
 	return create


### PR DESCRIPTION
- Currently it will put NULL which will cause
  toBoolean() to fail

Related #2251

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>