### PR TITLE
Exclude dacapo-jython for OpenJ9 JDK16+

### DIFF
--- a/perf/dacapo/playlist.xml
+++ b/perf/dacapo/playlist.xml
@@ -70,6 +70,11 @@
 		<groups>
 			<group>perf</group>
 		</groups>
+		<disabled>
+			<comment>https://github.com/eclipse/openj9/issues/11942</comment>
+			<subset>16+</subset>
+			<impl>openj9</impl>
+		</disabled>
 	</test>
 	<test>
 		<testCaseName>dacapo-luindex</testCaseName>


### PR DESCRIPTION
Related: https://github.com/eclipse/openj9/issues/11942

Signed-off-by: Jason Feng <fengj@ca.ibm.com>