### PR TITLE
temporarily fix bug of get changed files

### DIFF
--- a/.github/workflows/directoriesFilesChangePR.yml
+++ b/.github/workflows/directoriesFilesChangePR.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: jitterbit/get-changed-files@v1
         id: get_change
+        continue-on-error: true
         with:
           format: space-delimited
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### A fix for issue in #2241
Currently, the [get changed files](https://github.com/jitterbit/get-changed-files) used in #2241 frequently produces [Head vs base ahead error](https://github.com/jitterbit/get-changed-files/issues/7).

The temporary workaround is to add `continue-on-error: true` until the issue is fixed.