### PR TITLE
Exclude jdk_net related failed tests temporarily

### DIFF
--- a/openjdk/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/ProblemList_openjdk11-openj9.txt
@@ -148,12 +148,14 @@ java/math/BigInteger/LargeValueExceptions.java	https://github.com/eclipse/openj9
 
 # jdk_net
 
+java/net/DatagramSocket/SetGetSendBufferSize.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/2245 macosx-all
 java/net/Inet4Address/PingThis.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1127	aix-all
 # java/net/Inet6Address/B6206527.java on macosx-all issue https://github.com/AdoptOpenJDK/openjdk-tests/issues/1524
 # java/net/Inet6Address/B6206527.java on macosx-all issue https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1085
 java/net/Inet6Address/B6206527.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1105 linux-all,macosx-all
 java/net/MulticastSocket/Promiscuous.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699 linux-s390x
 java/net/MulticastSocket/SetLoopbackMode.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699 linux-s390x
+java/net/MulticastSocket/SetOutgoingIf.java  https://github.com/AdoptOpenJDK/openjdk-tests/issues/2246 aix-all
 java/net/MulticastSocket/Test.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699 linux-s390x
 java/net/Socket/asyncClose/AsyncClose.java	https://github.com/eclipse/openj9/issues/4560    generic-all
 java/net/httpclient/websocket/BlowupOutputQueue.java https://github.com/eclipse/openj9/issues/4298 macosx-all
@@ -165,6 +167,7 @@ java/net/httpclient/websocket/PendingPongBinaryClose.java https://github.com/ecl
 java/net/httpclient/websocket/PendingPongTextClose.java https://github.com/eclipse/openj9/issues/4298 macosx-all
 java/net/httpclient/websocket/PendingTextPingClose.java https://github.com/eclipse/openj9/issues/4298 macosx-all
 java/net/httpclient/websocket/PendingTextPongClose.java https://github.com/eclipse/openj9/issues/4298 macosx-all
+java/net/HttpURLConnection/HttpURLConWithProxy.java  https://github.com/eclipse/openj9/issues/10860  generic-all
 # java/net/ipv6tests/B6521014.java on macosx-all issue	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1524
 # java/net/ipv6tests/B6521014.java on macosx-all issue https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1085
 java/net/ipv6tests/B6521014.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1105 linux-all,macosx-all

--- a/openjdk/ProblemList_openjdk11.txt
+++ b/openjdk/ProblemList_openjdk11.txt
@@ -75,6 +75,7 @@ jdk/modules/incubator/ImageModules.java	https://github.com/AdoptOpenJDK/openjdk-
 
 # jdk_net
 
+java/net/DatagramSocket/SetGetSendBufferSize.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/2245 macosx-all
 java/net/Inet4Address/PingThis.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1127	aix-all
 java/net/Inet6Address/B6206527.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1524	macosx-all
 java/net/InetAddress/BadDottedIPAddress.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/593	linux-all
@@ -82,6 +83,7 @@ java/net/InetAddress/CachedUnknownHostName.java	https://github.com/AdoptOpenJDK/
 java/net/InetAddress/IPv4Formats.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/593	linux-all
 java/net/MulticastSocket/Promiscuous.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699    linux-s390x
 java/net/MulticastSocket/SetLoopbackMode.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699    linux-s390x
+java/net/MulticastSocket/SetOutgoingIf.java  https://github.com/AdoptOpenJDK/openjdk-tests/issues/2246 aix-all
 java/net/MulticastSocket/Test.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699    linux-s390x
 java/net/SocketPermission/SocketPermissionCollection.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/593	linux-all
 java/net/SocketPermission/Wildcard.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/593	linux-all

--- a/openjdk/ProblemList_openjdk15-openj9.txt
+++ b/openjdk/ProblemList_openjdk15-openj9.txt
@@ -172,10 +172,14 @@ sun/management/HotspotThreadMBean/GetInternalThreads.java	https://github.com/Ado
 # jdk_net
 
 java/net/Inet4Address/PingThis.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1127	aix-all
-java/net/MulticastSocket/Promiscuous.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699 linux-s390x
+java/net/MulticastSocket/NoLoopbackPackets.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/2246 aix-all
+java/net/MulticastSocket/B6427403.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/2246 aix-all
+java/net/MulticastSocket/Promiscuous.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699 linux-s390x,aix-all
 java/net/MulticastSocket/PromiscuousIPv6.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699	linux-s390x
-java/net/MulticastSocket/SetLoopbackMode.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699 linux-s390x
-java/net/MulticastSocket/Test.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699 linux-s390x
+java/net/MulticastSocket/SetLoopbackMode.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699 linux-s390x,aix-all
+java/net/MulticastSocket/SetOutgoingIf.java  https://github.com/AdoptOpenJDK/openjdk-tests/issues/2246 aix-all
+java/net/MulticastSocket/Test.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699 linux-s390x,aix-all
+java/net/Socket/asyncClose/Race.java https://github.com/eclipse/openj9/issues/8596 aix-all
 java/net/Socket/asyncClose/AsyncClose.java https://github.com/eclipse/openj9/issues/4560 generic-all
 java/net/SocketPermission/SocketPermissionTest.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1650 aix-all
 java/net/httpclient/websocket/BlowupOutputQueue.java https://github.com/eclipse/openj9/issues/4298 macosx-all
@@ -187,6 +191,7 @@ java/net/httpclient/websocket/PendingPongBinaryClose.java https://github.com/ecl
 java/net/httpclient/websocket/PendingPongTextClose.java https://github.com/eclipse/openj9/issues/4298 macosx-all
 java/net/httpclient/websocket/PendingTextPingClose.java https://github.com/eclipse/openj9/issues/4298 macosx-all
 java/net/httpclient/websocket/PendingTextPongClose.java https://github.com/eclipse/openj9/issues/4298 macosx-all
+java/net/HttpURLConnection/HttpURLConWithProxy.java  https://github.com/eclipse/openj9/issues/10860  generic-all
 
 ############################################################################
 

--- a/openjdk/ProblemList_openjdk15.txt
+++ b/openjdk/ProblemList_openjdk15.txt
@@ -94,9 +94,12 @@ java/net/httpclient/http2/BadHeadersTest.java	https://github.com/AdoptOpenJDK/op
 java/net/httpclient/DigestEchoClientSSL.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/893	linux-all
 java/net/httpclient/ResponseBodyBeforeError.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/893	linux-all
 java/net/httpclient/ResponsePublisher.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/893	linux-all
-java/net/MulticastSocket/Promiscuous.java               https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699    linux-s390x
-java/net/MulticastSocket/SetLoopbackMode.java     https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699    linux-s390x
-java/net/MulticastSocket/Test.java                             https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699    linux-s390x
+java/net/MulticastSocket/NoLoopbackPackets.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/2246 aix-all
+java/net/MulticastSocket/B6427403.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/2246 aix-all
+java/net/MulticastSocket/Promiscuous.java               https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699    linux-s390x,aix-all
+java/net/MulticastSocket/SetLoopbackMode.java     https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699    linux-s390x,aix-all
+java/net/MulticastSocket/SetOutgoingIf.java  https://github.com/AdoptOpenJDK/openjdk-tests/issues/2246 aix-all
+java/net/MulticastSocket/Test.java                             https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699    linux-s390x,aix-all
 #java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/AdoptOpenJDK/openjdk-tests/issues/1016
 #java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699 linux-s390x
 java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267 macosx-all,linux-s390x

--- a/openjdk/ProblemList_openjdk16-openj9.txt
+++ b/openjdk/ProblemList_openjdk16-openj9.txt
@@ -186,12 +186,19 @@ sun/management/HotspotThreadMBean/GetInternalThreads.java	https://github.com/Ado
 
 # jdk_net
 
+java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/2245 aix-all
 java/net/Inet4Address/PingThis.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1127	aix-all
-java/net/MulticastSocket/Promiscuous.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699 linux-s390x
+java/net/MulticastSocket/NoLoopbackPackets.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/2246 aix-all
+java/net/MulticastSocket/B6427403.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/2246 aix-all
+java/net/MulticastSocket/Promiscuous.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699 linux-s390x,aix-all
 java/net/MulticastSocket/PromiscuousIPv6.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699	linux-s390x
-java/net/MulticastSocket/SetLoopbackMode.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699 linux-s390x
-java/net/MulticastSocket/Test.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699 linux-s390x
+java/net/MulticastSocket/SetLoopbackMode.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699 linux-s390x,aix-all
+java/net/MulticastSocket/SetOutgoingIf.java  https://github.com/AdoptOpenJDK/openjdk-tests/issues/2246 aix-all
+java/net/MulticastSocket/Test.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699 linux-s390x,aix-all
 java/net/Socket/asyncClose/AsyncClose.java https://github.com/eclipse/openj9/issues/4560 generic-all
+java/net/Socket/asyncClose/Race.java https://github.com/eclipse/openj9/issues/8596 aix-all
+java/net/Socket/SocketReadInterruptTest.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/2247 linux-all,aix-all,macosx-all
+java/net/Socket/SocketAcceptInterruptTest.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/2247 linux-all,aix-all,macosx-all
 java/net/SocketPermission/SocketPermissionTest.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1650 aix-all
 java/net/httpclient/websocket/BlowupOutputQueue.java https://github.com/eclipse/openj9/issues/4298 macosx-all
 java/net/httpclient/websocket/PendingBinaryPingClose.java https://github.com/eclipse/openj9/issues/4298 macosx-all

--- a/openjdk/ProblemList_openjdk16.txt
+++ b/openjdk/ProblemList_openjdk16.txt
@@ -75,11 +75,14 @@ java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/Adopt
 ############################################################################
 
 # jdk_net
+java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/2245 aix-all
 java/net/Inet4Address/PingThis.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1127	aix-all
 java/net/InetAddress/BadDottedIPAddress.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/593	linux-all
 java/net/InetAddress/CachedUnknownHostName.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/593	linux-all
 java/net/InetAddress/IPv4Formats.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/593	linux-all
 java/net/MulticastSocket/PromiscuousIPv6.java	https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699	linux-s390x
+java/net/Socket/SocketReadInterruptTest.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/2247 linux-all,aix-all,macosx-all
+java/net/Socket/SocketAcceptInterruptTest.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/2247 linux-all,aix-all,macosx-all
 java/net/SocketPermission/SocketPermissionCollection.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/593	linux-all
 java/net/SocketPermission/SocketPermissionTest.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1650 aix-all
 java/net/SocketPermission/Wildcard.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/593	linux-all
@@ -94,9 +97,12 @@ java/net/httpclient/http2/BadHeadersTest.java	https://github.com/AdoptOpenJDK/op
 java/net/httpclient/DigestEchoClientSSL.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/893	linux-all
 java/net/httpclient/ResponseBodyBeforeError.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/893	linux-all
 java/net/httpclient/ResponsePublisher.java	https://github.com/AdoptOpenJDK/openjdk-build/issues/893	linux-all
-java/net/MulticastSocket/Promiscuous.java               https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699    linux-s390x
-java/net/MulticastSocket/SetLoopbackMode.java     https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699    linux-s390x
-java/net/MulticastSocket/Test.java                             https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699    linux-s390x
+java/net/MulticastSocket/NoLoopbackPackets.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/2246 aix-all
+java/net/MulticastSocket/B6427403.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/2246 aix-all
+java/net/MulticastSocket/Promiscuous.java               https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699    linux-s390x,aix-all
+java/net/MulticastSocket/SetLoopbackMode.java     https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699    linux-s390x,aix-all
+java/net/MulticastSocket/SetOutgoingIf.java  https://github.com/AdoptOpenJDK/openjdk-tests/issues/2246 aix-all
+java/net/MulticastSocket/Test.java                             https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699    linux-s390x,aix-all
 #java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/AdoptOpenJDK/openjdk-tests/issues/1016
 #java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/699 linux-s390x
 java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267 macosx-all,linux-s390x


### PR DESCRIPTION
- exclude jdk_net failed tests temporarily
- for jdk 11, 15, and 16 on related  platforms
- related issues are listed with each excluded test

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>