### PR TITLE
add suffix to ignore native tests

### DIFF
--- a/.github/workflows/directoriesFilesChangePR.yml
+++ b/.github/workflows/directoriesFilesChangePR.yml
@@ -48,7 +48,7 @@ jobs:
         uses: AdoptOpenJDK/run-aqa@v1
         with:
           build_list: ${{ matrix.build_list }}
-          target: '_sanity.${{ matrix.build_list }}'
+          target: '_sanity.${{ matrix.build_list }}.regular'
           jdksource: 'install-jdk'
           version: ${{ matrix.version }}
           openjdk_testRepo: '${{ github.event.pull_request.head.repo.full_name }}:${GITHUB_HEAD_REF}'

--- a/.github/workflows/directoriesFilesChangePR.yml
+++ b/.github/workflows/directoriesFilesChangePR.yml
@@ -48,7 +48,7 @@ jobs:
         uses: AdoptOpenJDK/run-aqa@v1
         with:
           build_list: ${{ matrix.build_list }}
-          target: '_sanity.${{ matrix.build_list }}.regular'
+          target: '_sanity.regular'
           jdksource: 'install-jdk'
           version: ${{ matrix.version }}
           openjdk_testRepo: '${{ github.event.pull_request.head.repo.full_name }}:${GITHUB_HEAD_REF}'


### PR DESCRIPTION
According to #2272, directories changed trigger for PR testing should only run the regular tests, 
by adding the suffix `.regular` to the target, native tests will be ignored.