### PR TITLE
Handle a git command's request for a username on Windows

### DIFF
--- a/openjdk/build.xml
+++ b/openjdk/build.xml
@@ -188,16 +188,25 @@
 								<property name="jdkName" value="openjdk-aarch64-jdk8u" />
 							</then>
 							<else>
-								<echo message="git ls-remote -h https://github.com/AdoptOpenJDK/openjdk-jdk${JDK_VERSION}u.git" />
-								<exec executable="git" resultproperty="repo.exist" failonerror="false">
-									<arg line="ls-remote -h https://github.com/AdoptOpenJDK/openjdk-jdk${JDK_VERSION}u.git" />
-								</exec>
+								<trycatch>
+									<try>
+										<echo message="Using a git ls-remote command to determine if the jdk source repo has an available 'u' version yet." />
+										<echo message="git ls-remote -h https://github.com/AdoptOpenJDK/openjdk-jdk${JDK_VERSION}u.git" />
+										<exec executable="git" resultproperty="repo.exist" failonerror="true" timeout="30000">
+											<env key="GIT_TERMINAL_PROMPT" value="0"/>
+											<arg line="ls-remote -h https://github.com/AdoptOpenJDK/openjdk-jdk${JDK_VERSION}u.git" />
+										</exec>
+									</try>
+								</trycatch>
 								<if>
 									<equals arg1="${repo.exist}" arg2="0" />
 									<then>
+										<echo message="Command passed. Setting repo name to the 'u' version." />
 										<property name="jdkName" value="openjdk-jdk${JDK_VERSION}u" />
 									</then>
 									<else>
+										<echo message="Command failed, or tried to ask for a username due to access restrictions. Or both." />
+										<echo message="Setting repo name to the non-'u' version." />
 										<property name="jdkName" value="openjdk-jdk${JDK_VERSION}" />
 									</else>
 								</if>


### PR DESCRIPTION
If we call git ls-remote on Window, when the repo doesn't exist,
the command asks for a username and hangs.

This change disables the request for a username and provides more
useful error messages. It also handles the problem appropriately,
so instead of failing the build, it correctly sets the repo location
to the non-'u' version.

Added some timeout-handling code as well, in case someone's running
this on a version of git older than 2.3, which may ignore the env
var we're using to suppress the username request.

Signed-off-by: Adam Farley <adfarley@redhat.com>