### PR TITLE
Prevent reportStatus job in runAqa.yml from running on every comment

### DIFF
--- a/.github/workflows/runAqa.yml
+++ b/.github/workflows/runAqa.yml
@@ -127,7 +127,7 @@ jobs:
 
   reportStatus:
     runs-on: ubuntu-latest
-    if: always()
+    if: always() && startsWith(github.event.comment.body, 'run aqa') && github.event.issue.pull_request
     needs: runBuild
     steps:
     - name: Get workflow run info


### PR DESCRIPTION
Fixes issue #2289 

Prevents reportStatus from running on every comment by checking for the same conditions as parseComment:
- The comment must begin with `run aqa` keyword
- The comment must be a PR comment