### PR TITLE
Use any node for copying TAP files in parallel test builds

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -890,7 +890,7 @@ def run_parallel_tests() {
 			} else {
 				waitForANodeToBecomeActive("$LABEL", "0")
 			}
-			node("$LABEL") {
+			node {
 				def buildResult = ""
 				childJobs.each {
 					cjob ->


### PR DESCRIPTION
Resolve: https://github.com/AdoptOpenJDK/openjdk-tests/issues/2262

Signed-off-by: lanxia <lan_xia@ca.ibm.com>