### PR TITLE
Remove waitForANodeToBecomeActive post-parallel

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -885,11 +885,7 @@ def run_parallel_tests() {
 	if (params.PARALLEL && params.PARALLEL != "None") {
 		stage ("Parallel Tests") {
 			def childJobs = parallel parallel_tests
-			if (params.ACTIVE_NODE_TIMEOUT && params.ACTIVE_NODE_TIMEOUT.isInteger()) {
-				waitForANodeToBecomeActive("$LABEL", params.ACTIVE_NODE_TIMEOUT)
-			} else {
-				waitForANodeToBecomeActive("$LABEL", "0")
-			}
+
 			node {
 				def buildResult = ""
 				childJobs.each {
@@ -915,30 +911,6 @@ def run_parallel_tests() {
 				}
 			}
 		}
-	}
-}
-
-def waitForANodeToBecomeActive(def label, String activeNodeTimeoutString) {
-	def nodes = nodesByLabel(label).size()
-	if (nodes < 1) {
-		// If no active node matches the label, we see if there's a timeout value set.
-		// If there is, we wait and check again periodically. If not, we fail immediately.
-
-		int activeNodeTimeout = activeNodeTimeoutString as Integer
-
-		echo "Cannot find an active node matching this label: " + label
-		echo "Will now wait until " + activeNodeTimeoutString + " minutes (ACTIVE_NODE_TIMEOUT) has passed, re-checking periodically."
-
-		while (activeNodeTimeout > 0) {
-			sleep(60 * 1000) // 1 minute sleep
-			activeNodeTimeout--
-			if (nodesByLabel(LABEL).size() > 0) {
-				echo "A node matching the aforementioned label has become active."
-				return
-			}
-		}
-
-		assert false : "Timed out waiting for a machine that matches the LABEL: " + LABEL + " to become active."
 	}
 }
 


### PR DESCRIPTION
This step is unnecessary now that we run
on any node.

Follow up to #2295

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>