### PR TITLE
reportStatus job enhancements (runAqa.yml)

### DIFF
--- a/.github/workflows/runAqa.yml
+++ b/.github/workflows/runAqa.yml
@@ -10,6 +10,7 @@ jobs:
       workflow_url: ${{ steps.workflow_run_info.outputs.url }}
       workflow_id: ${{ steps.workflow_run_info.outputs.id }}
       build_parameters: ${{ steps.argparse.outputs.build_parameters }}
+      failed: ${{ steps.failure_report.outputs.failed }} # For reportStatus to check if parseComment has already reported a failure (in parsing).
     steps:
     - name: Get workflow run info
       run: |
@@ -52,6 +53,10 @@ jobs:
             repo: context.repo.repo,
             body: comment_body
           })
+    - name: Failure report
+      if: failure()
+      run: echo ::set-output name=failed::true
+      id: failure_report
     - name: Create success comment
       uses: actions/github-script@v3
       with:
@@ -129,8 +134,8 @@ jobs:
 
   reportFailure:
     runs-on: ubuntu-latest
-    if: failure()
     needs: [parseComment, runBuild]
+    if: failure() && !needs.parseComment.outputs.failed
     steps:
     - name: Create comment
       uses: actions/github-script@v3
@@ -150,8 +155,8 @@ jobs:
 
   reportCancelled:
     runs-on: ubuntu-latest
-    if: cancelled()
     needs: [parseComment, runBuild]
+    if: cancelled()
     steps:
     - name: Create comment
       uses: actions/github-script@v3
@@ -171,8 +176,8 @@ jobs:
 
   reportSuccess:
     runs-on: ubuntu-latest
-    if: success()
     needs: [parseComment, runBuild]
+    if: success()
     steps:
     - name: Create comment
       uses: actions/github-script@v3

--- a/.github/workflows/runAqa.yml
+++ b/.github/workflows/runAqa.yml
@@ -7,8 +7,15 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.event.comment.body, 'run aqa') && github.event.issue.pull_request
     outputs:
+      workflow_url: ${{ steps.workflow_run_info.outputs.url }}
+      workflow_id: ${{ steps.workflow_run_info.outputs.id }}
       build_parameters: ${{ steps.argparse.outputs.build_parameters }}
     steps:
+    - name: Get workflow run info
+      run: |
+        echo ::set-output name=url::$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+        echo ::set-output name=id::$GITHUB_RUN_ID
+      id: workflow_run_info
     - uses: actions/checkout@v2
     - name: Parse parameters
       env:
@@ -45,11 +52,6 @@ jobs:
             repo: context.repo.repo,
             body: comment_body
           })
-    - name: Get workflow run info
-      run: |
-        echo ::set-output name=url::$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
-        echo ::set-output name=id::$GITHUB_RUN_ID
-      id: workflow_run_info
     - name: Create success comment
       uses: actions/github-script@v3
       with:
@@ -125,27 +127,19 @@ jobs:
         name: test_output
         path: ./**/output_*/
 
-  reportStatus:
+  reportFailure:
     runs-on: ubuntu-latest
-    if: always() && startsWith(github.event.comment.body, 'run aqa') && github.event.issue.pull_request
-    needs: runBuild
+    if: failure()
+    needs: [parseComment, runBuild]
     steps:
-    - name: Get workflow run info
-      run: |
-        echo ::set-output name=url::$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
-        echo ::set-output name=id::$GITHUB_RUN_ID
-      id: workflow_run_info
-    - uses: martialonline/workflow-status@v2
-      id: workflow_status
-    - name: Create fail comment
-      if: steps.workflow_status.outputs.status == 'failure'
+    - name: Create comment
       uses: actions/github-script@v3
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
           comment_body = `
           @${{ github.actor }} Build(s) failed.
-          Workflow Run ID: [${{ steps.workflow_run_info.outputs.id }}](${{ steps.workflow_run_info.outputs.url }})
+          Workflow Run ID: [${{ needs.parseComment.outputs.workflow_id }}](${{ needs.parseComment.outputs.workflow_url }})
           `;
           github.issues.createComment({
             issue_number: context.issue.number,
@@ -153,15 +147,20 @@ jobs:
             repo: context.repo.repo,
             body: comment_body
           })
-    - name: Create cancelled comment
-      if: steps.workflow_status.outputs.status == 'cancelled'
+
+  reportCancelled:
+    runs-on: ubuntu-latest
+    if: cancelled()
+    needs: [parseComment, runBuild]
+    steps:
+    - name: Create comment
       uses: actions/github-script@v3
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
           comment_body = `
           @${{ github.actor }} Build(s) cancelled.
-          Workflow Run ID: [${{ steps.workflow_run_info.outputs.id }}](${{ steps.workflow_run_info.outputs.url }})
+          Workflow Run ID: [${{ needs.parseComment.outputs.workflow_id }}](${{ needs.parseComment.outputs.workflow_url }})
           `;
           github.issues.createComment({
             issue_number: context.issue.number,
@@ -169,15 +168,20 @@ jobs:
             repo: context.repo.repo,
             body: comment_body
           })
-    - name: Create success comment
-      if: steps.workflow_status.outputs.status == 'success'
+
+  reportSuccess:
+    runs-on: ubuntu-latest
+    if: success()
+    needs: [parseComment, runBuild]
+    steps:
+    - name: Create comment
       uses: actions/github-script@v3
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
           comment_body = `
           @${{ github.actor }} Build(s) successful.
-          Workflow Run ID: [${{ steps.workflow_run_info.outputs.id }}](${{ steps.workflow_run_info.outputs.url }})
+          Workflow Run ID: [${{ needs.parseComment.outputs.workflow_id }}](${{ needs.parseComment.outputs.workflow_url }})
           `;
           github.issues.createComment({
             issue_number: context.issue.number,


### PR DESCRIPTION
Factored out the workflow_run_info step from reportStatus and moved it into the parseComment job.
Uses github actions' built-in success(), failure(), and cancelled() conditionals instead of a custom github action for status reporting, resulting in better reliability.
As a result, reportStatus has been broken up into three jobs, one for each status.

Fixes two issues mentioned in #2222 
> Depending on when the workflow was cancelled, the status report comment may say "Build(s) successful!" instead of "Build(s) cancelled!" because the runBuild part of the workflow was skipped while the parseComment part of the workflow was successful.

> A "Build(s) failed" error message is displayed even when no builds were started. A minor issue but I see no obvious fix. (See example error below)

Also fixes another issue in which a build may fail yet the reportStatus job will still report a success due to a discrepency in the run order of the jobs.

I have checked to make sure this change does not reproduce issue #2289 