### PR TITLE
Remove ParallelStreamsLoadTest_special_J9 long running modes 113, 614

### DIFF
--- a/system/lambdaLoadTest/playlist.xml
+++ b/system/lambdaLoadTest/playlist.xml
@@ -187,7 +187,6 @@
 			<variation>Mode104</variation>
 			<variation>Mode107</variation>
 			<variation>Mode112</variation>
-			<variation>Mode113</variation>
 			<variation>Mode121</variation>
 			<variation>Mode122</variation>
 			<variation>Mode145</variation>
@@ -202,7 +201,6 @@
 			<variation>Mode556</variation>
 			<variation>Mode557</variation>
 			<variation>Mode607</variation>
-			<variation>Mode614</variation>
 			<variation>Mode615</variation>
 			<variation>Mode687</variation>
 			<variation>Mode688</variation>


### PR DESCRIPTION
Modes 113 and 614 take too long to run across all platforms, and
contribute to special.system timeout problems on Windows.

(5) 113: -Xgcpolicy:gencon
-Xjit:count=0,optlevel=warm,gcOnResolve,rtResolve -Xmn512k
-Xnocompressedrefs
aix 8: 23min, 11: 31min
osx 8: 10min, 11: 20min
plinux 8: 18min, 11: 23min
xlinux 8: 25min, 11: 40min
zlinux 8: 12min, 11: 14min
Windows 11: 30min

(20) 614: -Xcompressedrefs -Xgcpolicy:gencon -Xjit:counts="- - - - - - 1
1 1 1000 250 250 - - - 10000 100000
10000",gcOnResolve,rtResolve,sampleInterval=2,scorchingSampleThreshold=10000,quickProfile
-Xmn512k -Xcheck:gc:vmthreads:all:quiet
aix 8: 19min, 11: 27min
osx 8: 17min, 11: 17min
plinux 8: 18min, 11: 22min
xlinux 8: 24min, 11: 33min
zlinux 8: 10min, 11: 14min
Windows 11: 27min

FYI https://github.com/eclipse/openj9/issues/11904#issuecomment-783517960 for some information about the ParallelStreamsLoadTest