### PR TITLE
Ignore leading and trailing whitespace in parsing of comments (runAqa.yml)

### DIFF
--- a/.github/workflows/runAqaArgParse.py
+++ b/.github/workflows/runAqaArgParse.py
@@ -40,6 +40,9 @@ def main():
     # e.g. sys.argv == ['action_argparse.py', 'run', 'aqa', ...]
     raw_args = sys.argv[1 + len(keywords):]
 
+    # Strip leading and trailing whitespace. Remove empty arguments that may result after stripping.
+    raw_args = list(filter(lambda empty: empty, map(lambda s: s.strip(), raw_args)))
+
     parser = argparse.ArgumentParser(prog=keyword, add_help=False)
     # Improvement: Automatically resolve the valid choices for each argument populate them below, rather than hard-coding choices.
     parser.add_argument('--sdk_resource', default=['nightly'], choices=['nightly', 'releases'], nargs='+')
@@ -48,20 +51,19 @@ def main():
     parser.add_argument('--platform', default=['x86-64_linux'], nargs='+')
     parser.add_argument('--jdk_version', default=['8'], nargs='+')
     parser.add_argument('--jdk_impl', default=['openj9'], choices=['hotspot', 'openj9'], nargs='+')
-    args = parser.parse_args(raw_args)
+    args = vars(parser.parse_args(raw_args))
+    # All args are lists of strings
 
-    output = {
-      'sdk_resource': args.sdk_resource,
-      'build_list': args.build_list,
-      'target': underscore_targets(args.target),
-      'platform': map_platforms(args.platform),
-      'jdk_version': args.jdk_version,
-      'jdk_impl': args.jdk_impl
-    }
-    # Set parameters as output: As JSON, and each item individually
-    print('::set-output name=build_parameters::{}'.format(json.dumps(output)))
-    for key, value in output.items():
-      print('::set-output name={}::{}'.format(key, value))
+    # Map grinder platform names to github runner names
+    args['platform'] = map_platforms(args['platform'])
+
+    # Underscore the targets if necessary
+    args['target'] = underscore_targets(args['target'])
+
+    # Output the arguments
+    print('::set-output name=build_parameters::{}'.format(json.dumps(args)))
+    for key, value in args.items():
+        print('::set-output name={}::{}'.format(key, value))
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Fixes the issue in which extra whitespace caused the parser to read them as extra arguments, leading to odd error messages. For example, ending the comment with a mix of spaces and newlines results in an error such as this:
![image](https://user-images.githubusercontent.com/5418647/109544491-ddc6d800-7a84-11eb-820a-3115625398ce.png)

Also simplifies the mapping of comment/command arguments to outputs in the code.