### PR TITLE
Allow the use of a customized SDK in comment triggered PR builds (runAqa.yml)

### DIFF
--- a/.github/workflows/runAqa.yml
+++ b/.github/workflows/runAqa.yml
@@ -65,6 +65,8 @@ jobs:
           comment_body = `
           @${{ github.actor }} Build(s) started with the following parameters:
           - sdk_resource: ${{ steps.argparse.outputs.sdk_resource }}
+          - customized_sdk_url: ${{ steps.argparse.outputs.customized_sdk_url }}
+          - archive_extension: ${{ steps.argparse.outputs.archive_extension }}
           - build_list: ${{ steps.argparse.outputs.build_list }}
           - target: ${{ steps.argparse.outputs.target }}
           - platform: ${{ steps.argparse.outputs.platform }}
@@ -83,6 +85,8 @@ jobs:
       run: |
         echo build_parameters: ${{ steps.argparse.outputs.build_parameters }}
         echo sdk_resource: ${{ steps.argparse.outputs.sdk_resource }}
+        echo customized_sdk_url: ${{ steps.argparse.outputs.customized_sdk_url }}
+        echo archive_extension: ${{ steps.argparse.outputs.archive_extension }}
         echo build_list: ${{ steps.argparse.outputs.build_list }}
         echo target: ${{ steps.argparse.outputs.target }}
         echo platform: ${{ steps.argparse.outputs.platform }}
@@ -97,10 +101,19 @@ jobs:
       matrix: ${{ fromJson(needs.parseComment.outputs.build_parameters) }}
     steps:
     - uses: AdoptOpenJDK/install-jdk@v1
+      if: matrix.sdk_resource != 'customized'
       with:
         version: ${{ matrix.jdk_version }}
         source: ${{ matrix.sdk_resource }}
+        sourceType: 'buildType'
         impl: ${{ matrix.jdk_impl }}
+    - uses: AdoptOpenJDK/install-jdk@v1
+      if: matrix.sdk_resource == 'customized'
+      with:
+        version: ${{ matrix.jdk_version }}
+        source: ${{ matrix.customized_sdk_url }}
+        archiveExtension: ${{ matrix.archive_extension }}
+        sourceType: 'url'
     # get-pr step by @Simran-B https://github.com/actions/checkout/issues/331#issuecomment-707103442
     - uses: actions/github-script@v3
       id: get-pr

--- a/.github/workflows/runAqa.yml
+++ b/.github/workflows/runAqa.yml
@@ -114,6 +114,7 @@ jobs:
         source: ${{ matrix.customized_sdk_url }}
         archiveExtension: ${{ matrix.archive_extension }}
         sourceType: 'url'
+        impl: ${{ matrix.jdk_impl }}
     # get-pr step by @Simran-B https://github.com/actions/checkout/issues/331#issuecomment-707103442
     - uses: actions/github-script@v3
       id: get-pr

--- a/.github/workflows/runAqaArgParse.py
+++ b/.github/workflows/runAqaArgParse.py
@@ -43,14 +43,11 @@ def main():
     # Strip leading and trailing whitespace. Remove empty arguments that may result after stripping.
     raw_args = list(filter(lambda empty: empty, map(lambda s: s.strip(), raw_args)))
 
-    # nil value because arguments can not be empty or else github actions will complain of a missing value in the runBuild matrix job.
-    na = ['n/a']
-
     parser = argparse.ArgumentParser(prog=keyword, add_help=False)
     # Improvement: Automatically resolve the valid choices for each argument populate them below, rather than hard-coding choices.
     parser.add_argument('--sdk_resource', default=['nightly'], choices=['nightly', 'releases', 'customized'], nargs='+')
-    parser.add_argument('--customized_sdk_url', default=na, nargs='+')
-    parser.add_argument('--archive_extension', default=na, choices=['.zip', '.tar', '.7z'], nargs='+')
+    parser.add_argument('--customized_sdk_url', default=['None'], nargs='+')
+    parser.add_argument('--archive_extension', default=['.tar'], choices=['.zip', '.tar', '.7z'], nargs='+')
     parser.add_argument('--build_list', default=['openjdk'], choices=['openjdk', 'functional', 'system', 'perf', 'external'], nargs='+')
     parser.add_argument('--target', default=['_jdk_math'], nargs='+')
     parser.add_argument('--platform', default=['x86-64_linux'], nargs='+')
@@ -66,8 +63,8 @@ def main():
     args['target'] = underscore_targets(args['target'])
 
     # If 'customized' sdk_resource, then customized_sdk_url and archive_extension must be present.
-    if 'customized' in args['sdk_resource'] and (args['customized_sdk_url'] == na or args['archive_extension'] == na):
-        err_msg = '--customized_sdk_url and --archive_extension must be provided if sdk_resource is set to customized.'
+    if 'customized' in args['sdk_resource'] and args['customized_sdk_url'] == ['None']:
+        err_msg = '--customized_sdk_url must be provided if sdk_resource is set to customized.'
         print('::error ::{}'.format(err_msg))
         sys.stderr.write(err_msg)
         exit(2)


### PR DESCRIPTION
Allows the use of a customized SDK in comment triggered PR builds (runAqa.yml) as per #2296 
Introduces two new parameters and one new option for `jdk_resource`.
- The `customized_sdk_url` argument accepts a URL that points to a JDK, expected to be in a zip, tar, or 7z format.
- The `archive_extension` argument must be supplied alongside the `customized_sdk_url`  and can be either `.zip`, `.tar`, or `.7z`. This should match the file from `customized_sdk_url`. For `.tar.gz` file formats, use the `.tar` option.
- The `customized` option for `jdk_resource` will download and install the JDK from `customized_sdk_url`, extracting the archive  based on the provided `archive_extension`.
- 
Note: The `jdk_impl` argument has no effect if `jdk_resource` is set to `customized`

Known issues:
- The `customized_sdk_url` can not be one that causes a redirect, otherwise it will fail. See issue AdoptOpenJDK/install-jdk#12

Potential improvements:
- Determine the `archive_extension` based on the URL provided in `customized_sdk_url` instead of asking the user to supply it. This would be better implemented in the `AdoptOpenJDK/install-jdk` action itself rather than in this workflow. See issue AdoptOpenJDK/install-jdk#13
- Add flags for TEST_IMAGES_REQUIRED and DEBUG_IMAGES_REQUIRED. See issue AdoptOpenJDK/install-jdk#14

Example usage/run:
![image](https://user-images.githubusercontent.com/5418647/109561512-7fa4ef80-7a9a-11eb-86dc-1fb0d5983f01.png)
