### PR TITLE
Disable ParallelStreamsLoadTest slow OSRG modes on Windows

### DIFF
--- a/system/lambdaLoadTest/playlist.xml
+++ b/system/lambdaLoadTest/playlist.xml
@@ -184,8 +184,20 @@
 		<disabled>
 			<comment>https://github.com/eclipse/openj9/issues/11904</comment>
 			<variation>Mode107-OSRG</variation>
+			<plat>.*windows.*</plat>
+		</disabled>
+		<disabled>
+			<comment>https://github.com/eclipse/openj9/issues/11904</comment>
 			<variation>Mode110-OSRG</variation>
+			<plat>.*windows.*</plat>
+		</disabled>
+		<disabled>
+			<comment>https://github.com/eclipse/openj9/issues/11904</comment>
 			<variation>Mode610-OSRG</variation>
+			<plat>.*windows.*</plat>
+		</disabled>
+		<disabled>
+			<comment>https://github.com/eclipse/openj9/issues/11904</comment>
 			<variation>Mode612-OSRG</variation>
 			<plat>.*windows.*</plat>
 		</disabled>


### PR DESCRIPTION
Fixes https://github.com/AdoptOpenJDK/openjdk-tests/pull/2316#issuecomment-788569942

The OSRG modes run slow only on Windows, and contribute to Windows
special.system tests timing out. The Mode Mode107-OSRG (24) can timeout
the 60min limit and fail.

Issue https://github.com/eclipse/openj9/issues/11904

variation: (24) Mode107-OSRG
JVM_OPTIONS:  -Xgcpolicy:optthruput -Xdebug
-Xrunjdwp:transport=dt_socket,address=8888,server=y,onthrow=no.pkg.foo,launch=echo
-Xjit:enableOSR,enableOSROnGuardFailure,count=1,disableAsyncCompilation
Windows 11: 67min
aix 8: 9min, 11: 4min
osx 8: 3min, 11: 5min
plinux 8: 2min, 11: 4min
xlinux 8: 4min, 11: 10min
zlinux 8: 4min, 11: 6min

variation: (25) Mode110-OSRG
JVM_OPTIONS:
-Xjit:enableOSR,enableOSROnGuardFailure,count=1,disableAsyncCompilation
-Xgcpolicy:gencon
Windows 11: 32min
aix 8: 4min, 11: 5min
osx 8: 3min, 11: 2min
plinux 8: 4min, 11: 5min
xlinux 8: 4min, 11: 6min
zlinux 8: 1min, 11: 2min

variation: (26) Mode610-OSRG
JVM_OPTIONS:  -Xcompressedrefs
-Xjit:enableOSR,enableOSROnGuardFailure,count=1,disableAsyncCompilation
-Xgcpolicy:gencon
Windows 11: 25min
aix 8: 4min, 11: 5min
osx 8: 3min, 11: 2min
plinux 8: 3min, 11: 4min
xlinux 8: 5min, 11: 6min
zlinux 8: 2min, 11: 2min

variation: (27) Mode612-OSRG
JVM_OPTIONS:  -Xcompressedrefs -Xgcpolicy:gencon
-Xjit:enableOSR,enableOSROnGuardFailure,count=1,disableAsyncCompilation
Windows 11: 33min
aix 8: 4min, 11: 5min
osx 8: 2min, 11: 4min
plinux 8: 3min, 11: 5min
xlinux 8: 4min, 11: 6min
zlinux 8: 1min, 11: 2min

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>