### PR TITLE
Excluding ResetPeakMemoryUsage on openj9

### DIFF
--- a/openjdk/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/ProblemList_openjdk11-openj9.txt
@@ -133,6 +133,7 @@ sun/management/HotspotRuntimeMBean/GetSafepointCount.java	https://github.com/Ado
 sun/management/HotspotRuntimeMBean/GetSafepointSyncTime.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/932 generic-all
 sun/management/HotspotRuntimeMBean/GetTotalSafepointTime.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/932 generic-all
 sun/management/HotspotThreadMBean/GetInternalThreads.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/932 generic-all
+java/lang/management/MemoryMXBean/ResetPeakMemoryUsage.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
 
 ############################################################################
 

--- a/openjdk/ProblemList_openjdk12-openj9.txt
+++ b/openjdk/ProblemList_openjdk12-openj9.txt
@@ -161,6 +161,8 @@ sun/management/HotspotRuntimeMBean/GetSafepointCount.java	https://github.com/Ado
 sun/management/HotspotRuntimeMBean/GetSafepointSyncTime.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/932 generic-all
 sun/management/HotspotRuntimeMBean/GetTotalSafepointTime.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/932 generic-all
 sun/management/HotspotThreadMBean/GetInternalThreads.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/932 generic-all
+java/lang/management/MemoryMXBean/ResetPeakMemoryUsage.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+
 ############################################################################
 
 # jdk_jmx

--- a/openjdk/ProblemList_openjdk13-openj9.txt
+++ b/openjdk/ProblemList_openjdk13-openj9.txt
@@ -147,6 +147,7 @@ sun/management/HotspotRuntimeMBean/GetSafepointCount.java	https://github.com/Ado
 sun/management/HotspotRuntimeMBean/GetSafepointSyncTime.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/932 generic-all
 sun/management/HotspotRuntimeMBean/GetTotalSafepointTime.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/932 generic-all
 sun/management/HotspotThreadMBean/GetInternalThreads.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/932 generic-all
+java/lang/management/MemoryMXBean/ResetPeakMemoryUsage.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
 
 ############################################################################
 

--- a/openjdk/ProblemList_openjdk14-openj9.txt
+++ b/openjdk/ProblemList_openjdk14-openj9.txt
@@ -139,6 +139,7 @@ sun/management/HotspotRuntimeMBean/GetSafepointCount.java	https://github.com/Ado
 sun/management/HotspotRuntimeMBean/GetSafepointSyncTime.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/932 generic-all
 sun/management/HotspotRuntimeMBean/GetTotalSafepointTime.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/932 generic-all
 sun/management/HotspotThreadMBean/GetInternalThreads.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/932 generic-all
+java/lang/management/MemoryMXBean/ResetPeakMemoryUsage.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
 
 ############################################################################
 

--- a/openjdk/ProblemList_openjdk15-openj9.txt
+++ b/openjdk/ProblemList_openjdk15-openj9.txt
@@ -157,6 +157,7 @@ sun/management/HotspotRuntimeMBean/GetSafepointCount.java	https://github.com/Ado
 sun/management/HotspotRuntimeMBean/GetSafepointSyncTime.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/932 generic-all
 sun/management/HotspotRuntimeMBean/GetTotalSafepointTime.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/932 generic-all
 sun/management/HotspotThreadMBean/GetInternalThreads.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/932 generic-all
+java/lang/management/MemoryMXBean/ResetPeakMemoryUsage.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
 
 ############################################################################
 

--- a/openjdk/ProblemList_openjdk16-openj9.txt
+++ b/openjdk/ProblemList_openjdk16-openj9.txt
@@ -172,6 +172,7 @@ sun/management/HotspotRuntimeMBean/GetSafepointCount.java	https://github.com/Ado
 sun/management/HotspotRuntimeMBean/GetSafepointSyncTime.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/932 generic-all
 sun/management/HotspotRuntimeMBean/GetTotalSafepointTime.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/932 generic-all
 sun/management/HotspotThreadMBean/GetInternalThreads.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/932 generic-all
+java/lang/management/MemoryMXBean/ResetPeakMemoryUsage.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
 
 ############################################################################
 

--- a/openjdk/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/ProblemList_openjdk17-openj9.txt
@@ -173,6 +173,7 @@ sun/management/HotspotRuntimeMBean/GetSafepointCount.java	https://github.com/Ado
 sun/management/HotspotRuntimeMBean/GetSafepointSyncTime.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/932 generic-all
 sun/management/HotspotRuntimeMBean/GetTotalSafepointTime.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/932 generic-all
 sun/management/HotspotThreadMBean/GetInternalThreads.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/932 generic-all
+java/lang/management/MemoryMXBean/ResetPeakMemoryUsage.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
This PR is to exclude hotspot related jdk_management test on openj9.
java/lang/management/MemoryMXBean/ResetPeakMemoryUsage.java - exclusion on openj9 for jdk11

