### PR TITLE
OpenJ9 JDK17 Exclude java/lang/Thread/UncaughtExceptionsTest.java

### DIFF
--- a/openjdk/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/ProblemList_openjdk17-openj9.txt
@@ -84,6 +84,7 @@ java/lang/System/LoggerFinder/modules/LoggerInImageTest.java	https://github.com/
 java/lang/System/LoggerFinder/modules/NamedLoggerForImageTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
 java/lang/System/LoggerFinder/modules/UnnamedLoggerForImageTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1267	macosx-all
 java/lang/Thread/UncaughtExceptions.sh	https://github.com/eclipse/openj9/issues/6690	generic-all
+java/lang/Thread/UncaughtExceptionsTest.java	https://github.com/eclipse/openj9/issues/11930	generic-all
 java/lang/ThreadGroup/SetMaxPriority.java	https://github.com/eclipse/openj9/issues/6691	generic-all
 java/lang/Throwable/SuppressedExceptions.java	https://github.com/eclipse/openj9/issues/6692	generic-all
 java/lang/annotation/AnnotationsInheritanceOrderRedefinitionTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297	generic-all


### PR DESCRIPTION
OpenJ9 `JDK17` Exclude `java/lang/Thread/UncaughtExceptionsTest.java`

Related https://github.com/eclipse/openj9/issues/11930

Signed-off-by: Jason Feng <fengj@ca.ibm.com>