### PR TITLE
Only run foreign native test on x86_64 or aarch64 platforms

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -938,10 +938,6 @@
 	<test>
 		<testCaseName>jdk_foreign_native</testCaseName>
 		<disabled>
-			<comment>https://github.com/AdoptOpenJDK/openjdk-tests/issues/2265#issuecomment-779731603</comment>
-			<plat>.*(ppc|arm|390).*</plat>
-		</disabled>
-		<disabled>
 			<comment>https://github.com/AdoptOpenJDK/openjdk-tests/issues/2218#issuecomment-770048450</comment>
 			<subset>16+</subset>
 			<impl>openj9</impl>
@@ -970,6 +966,7 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<platformRequirements>bits.64,^arch.ppc,^arch.390,^arch.riscv,^os.zos,^os.sunos</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>jdk_instrument</testCaseName>


### PR DESCRIPTION
This test requires CLinker, and the upstream community has no
current intention to port it to new platforms. So we need to exclude
the test on platforms that aren't x86-64 or aarch64.

Signed-off-by: Adam Farley <adfarley@redhat.com>