### PR TITLE
Update timeout logic

### DIFF
--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -223,30 +223,14 @@ if (JDK_VERSIONS.size() > 1 || JDK_IMPLS.size() > 1 || PLATFORMS.size() >1 || PL
         println "LABEL: ${LABEL}"
 
         stage('Queue') {
-            def nodes = nodesByLabel(LABEL).size()
-            if (nodes < 1) {
-                // If no active node matches the label, we see if there's a timeout value set.
-                // If there is, we wait and check again periodically. If not, we fail immediately.
+            if (nodesByLabel(LABEL).size() < 1) {
+                int ACTIVE_NODE_TIMEOUT = params.ACTIVE_NODE_TIMEOUT ? params.ACTIVE_NODE_TIMEOUT : 0
 
-                boolean didnt_find_node = true
-
-                if (params.ACTIVE_NODE_TIMEOUT && params.ACTIVE_NODE_TIMEOUT.isInteger()) {
-                    int activeNodeTimeout = params.ACTIVE_NODE_TIMEOUT as Integer
-                    echo "Cannot find an active node matching this label: " + label
-                    echo "Will now wait until " + activeNodeTimeoutString + " minutes (ACTIVE_NODE_TIMEOUT) has passed, re-checking periodically."
-                    while (activeNodeTimeout > 0) {
-                        sleep(60 * 1000) // 1 minute sleep
-                        activeNodeTimeout--
-                        if (nodesByLabel(LABEL).size() > 0) {
-                            didnt_find_node = false
-                            echo "A node matching the aforementioned label has become active."
-                            break;
-                        }
+                timeout(ACTIVE_NODE_TIMEOUT) {
+                    // node(LABEL) has to be used for spinning up a dynamic vm agent
+                    node(LABEL) {
+                        echo "find the node ${env.NODE_NAME}"
                     }
-                }
-
-                if (didnt_find_node) {
-                    assert false : "Cannot find any machine that matches the LABEL: " + LABEL
                 }
             }
 


### PR DESCRIPTION
We can use Jenkins timeout to simplify the logic. The test build will be aborted if the timeout is reached.
By default, if there is no node available, abort the test build immediately. If ACTIVE_NODE_TIMEOUT is set,
we will set timeout to ACTIVE_NODE_TIMEOUT. Also, for dynamic vm agent, we need to use node(LABEL) directly
to spin up the agent. nodesByLabel(LABEL).size() will not work.

Signed-off-by: lanxia <lan_xia@ca.ibm.com>