### PR TITLE
use sw.os.alpine-linux label instead of sw.os.musl for Alpine

### DIFF
--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -103,7 +103,7 @@ def PLATFORM_MAP = [
     ],
     'x86-64_alpine-linux' : [
         'SPEC' : 'alpine-linux',
-        'LABEL' : 'ci.role.test&&hw.arch.x86&&sw.os.musl',
+        'LABEL' : 'ci.role.test&&hw.arch.x86&&sw.os.alpine-linux',
     ],
     'x86-32_linux' : [
         'SPEC' : 'linux_x86',


### PR DESCRIPTION
Ref: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1929#issuecomment-790781251

Signed-off-by: Stewart X Addison <sxa@redhat.com>