### PR TITLE
Increase xmx for jdk_utils to prevent TimSortStackSize2 OOM

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -706,7 +706,7 @@
 			<variation>$(TEST_VARIATION_DUMP) Mode1000</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
-	$(JTREG_BASIC_OPTIONS) -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
+	$(JTREG_BASIC_OPTIONS) -vmoptions:$(Q)-Xmx1540m $(JVM_OPTIONS)$(Q) \
 	$(TIMEOUT_HANDLER) \
 	-w $(Q)$(REPORTDIR)$(D)work$(Q) \
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \


### PR DESCRIPTION
When you run that test with the xmx set to 512m and the CompressedOops
disabled, we hit an oom on jdk8. This is not the case for jdk11+
because the test has code to increase the xms and xmx values
appropriately. We've only been hitting this oom recently because
we've only just started running jdk_utils with the CompressedOops
disabled.

However, putting the change into playlist.xml means we'll see the same
oom if you try to run a grinder for this testcase, as that runs it under
the jdk_custom target which uses the small xmx value.

So this will be a temporary change, kept until the jdk8 updates project
integrates the long-term change to the test itself. See JDK-8263099.

Signed-off-by: Adam Farley <adfarley@redhat.com>