### PR TITLE
Fix mapping from x86-64_mac to macos GitHub runner in Comment Triggered PR Build Workflow

### DIFF
--- a/.github/workflows/runAqaArgParse.py
+++ b/.github/workflows/runAqaArgParse.py
@@ -9,7 +9,7 @@ def map_platforms(platforms):
     
     platform_map = {
         'x86-64_windows': 'windows-latest',
-        'x86-64_mac': 'mac-latest',
+        'x86-64_mac': 'macos-latest',
         'x86-64_linux': 'ubuntu-latest'
     }
     


### PR DESCRIPTION
`x86-64_mac` was incorrectly mapped to `mac-latest` which is an invalid GitHub runner name. The correct GitHub runner name for MacOS is `macos-latest`