### PR TITLE
Allow for cgroups in MEMORY_SIZE detection

### DIFF
--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -18,7 +18,7 @@ MEMORY_SIZE:=1024
 OS:=$(shell uname -s)
 
 ifeq ($(OS),Linux)
-	NPROCS:=$(shell KPROCS=`grep -c ^processor /proc/cpuinfo`; CGPROCS=`if [ -r /sys/fs/cgroup/cpu,cpuacct/cgroup.procs ]; then wc -l < /sys/fs/cgroup/cpu,cpuacct/cgroup.procs; else echo "$$KPROCS"; fi`; if [ "$${KPROCS}" -lt "$${CGPROCS}" ]; then echo "$${KPROCS}"; else echo "$${CGPROCS}"; fi)
+	NPROCS:=$(shell KPROCS=`grep -c ^processor /proc/cpuinfo`; CGPROCS=`if [ -r /sys/fs/cgroup/cpu/cpu.cfs_quota_us ]; then cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us | sed 's/.....$$//g'; else echo "$$KPROCS"; fi`; if [ "$${KPROCS}" -lt "$${CGPROCS}" ]; then echo "$${KPROCS}"; else echo "$${CGPROCS}"; fi)
 	MEMORY_SIZE:=$(shell KMEMMB=`awk '/^MemTotal:/{print int($$2/1024)}' /proc/meminfo`; if [ -r /sys/fs/cgroup/memory/memory.limit_in_bytes]; then CGMEM=`cat /sys/fs/cgroup/memory/memory.limit_in_bytes`; else CGMEM=`expr $${KMEMMB} \* 1024`; fi; CGMEMMB=`expr $${CGMEM} / 1048576`; if [ "$${KMEMMB}" -lt "$${CGMEMMB}" ]; then echo "$${KMEMMB}"; else echo "$${CGMEMMB}"; fi)
 endif
 ifeq ($(OS),Darwin)

--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -18,10 +18,8 @@ MEMORY_SIZE:=1024
 OS:=$(shell uname -s)
 
 ifeq ($(OS),Linux)
-	NPROCS:=$(shell grep -c ^processor /proc/cpuinfo)
-	MEMORY_SIZE:=$(shell \
-		expr `cat /proc/meminfo | grep MemTotal | awk '{print $$2}'` / 1024 \
-		)
+	NPROCS:=$(shell KPROCS=`grep -c ^processor /proc/cpuinfo`; CGPROCS=`if [ -r /sys/fs/cgroup/cpu,cpuacct/cgroup.procs ]; then wc -l < /sys/fs/cgroup/cpu,cpuacct/cgroup.procs; else echo "$$KPROCS"; fi`; if [ "$${KPROCS}" -lt "$${CGPROCS}" ]; then echo "$${KPROCS}"; else echo "$${CGPROCS}"; fi)
+	MEMORY_SIZE:=$(shell KMEMMB=`awk '/^MemTotal:/{print int($$2/1024)}' /proc/meminfo`; if [ -r /sys/fs/cgroup/memory/memory.limit_in_bytes]; then CGMEM=`cat /sys/fs/cgroup/memory/memory.limit_in_bytes`; else CGMEM=`expr $${KMEMMB} \* 1024`; fi; CGMEMMB=`expr $${CGMEM} / 1048576`; if [ "$${KMEMMB}" -lt "$${CGMEMMB}" ]; then echo "$${KMEMMB}"; else echo "$${CGMEMMB}"; fi)
 endif
 ifeq ($(OS),Darwin)
 	NPROCS:=$(shell sysctl -n hw.ncpu)

--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -18,8 +18,8 @@ MEMORY_SIZE:=1024
 OS:=$(shell uname -s)
 
 ifeq ($(OS),Linux)
-	NPROCS:=$(shell KPROCS=`grep -c ^processor /proc/cpuinfo`; CGPROCS=`if [ -r /sys/fs/cgroup/cpu/cpu.cfs_quota_us ]; then cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us | sed 's/.....$$//g'; else echo "$$KPROCS"; fi`; if [ "$${KPROCS}" -lt "$${CGPROCS}" ]; then echo "$${KPROCS}"; else echo "$${CGPROCS}"; fi)
-	MEMORY_SIZE:=$(shell KMEMMB=`awk '/^MemTotal:/{print int($$2/1024)}' /proc/meminfo`; if [ -r /sys/fs/cgroup/memory/memory.limit_in_bytes]; then CGMEM=`cat /sys/fs/cgroup/memory/memory.limit_in_bytes`; else CGMEM=`expr $${KMEMMB} \* 1024`; fi; CGMEMMB=`expr $${CGMEM} / 1048576`; if [ "$${KMEMMB}" -lt "$${CGMEMMB}" ]; then echo "$${KMEMMB}"; else echo "$${CGMEMMB}"; fi)
+	NPROCS:=$(shell grep -c ^processor /proc/cpuinfo)
+	MEMORY_SIZE:=$(shell KMEMMB=`awk '/^MemTotal:/{print int($$2/1024)}' /proc/meminfo`; if [ -r /sys/fs/cgroup/memory/memory.limit_in_bytes ]; then CGMEM=`cat /sys/fs/cgroup/memory/memory.limit_in_bytes`; else CGMEM=`expr $${KMEMMB} \* 1024`; fi; CGMEMMB=`expr $${CGMEM} / 1048576`; if [ "$${KMEMMB}" -lt "$${CGMEMMB}" ]; then echo "$${KMEMMB}"; else echo "$${CGMEMMB}"; fi)
 endif
 ifeq ($(OS),Darwin)
 	NPROCS:=$(shell sysctl -n hw.ncpu)


### PR DESCRIPTION
This is a bit unpleasant but if we're in a restricted docker container we need to restrict the number of CPUs and RAM quantity selected otherwise it'll mis-detect the physical machine's quantity and overwhelm the container and probably exhaust the container's RAM. While it won't affect other containers, but will likely cause lots of timeouts as the container tries to deal with all the process contention and result in potentially intermittent hard-to-diagnose test failures. I'm not sure how many Linux systems won't have /sys/fs/cgroup but I've put some detection in to cover the case where that doesn't exist (It should fall back to the same values as before)

This is an enhancement to https://github.com/AdoptOpenJDK/openjdk-tests/pull/1427 and will hopefully resolve https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/2002 (Also Ref: General container issue https://github.com/AdoptOpenJDK/openjdk-tests/issues/2138)

I'm going to run some more testing on this, but it seems to do the right thing in several of the checks I've done.

Signed-off-by: Stewart X Addison <sxa@redhat.com>