### PR TITLE
Excluding CheckHandles.java test from 32bit Windows

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -343,7 +343,7 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
-		<platformRequirements>os.win</platformRequirements>
+		<platformRequirements>os.win,bits.64</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>jdk_lang_ref_FinalizeOverride_j9</testCaseName>


### PR DESCRIPTION
This test was designed for jdk15, and backported as far as jdk11
because jdk8 and 9 were confirmed to not have the issue the test
was designed to detect.

Since JDK8 was the last openjdk major version supported (by the
openjdk project) on windows 32bit, and there appears no indication
that this test has ever passed on 32bit windows, I assert that this
test was never intended to run on 32bit windows.

Since the test currently doesn't *work* on windows 32bit either, for
reasons I believe to be related to name mangling, my solution
is for us to stop running the test on a platform it's not
intended for.

Signed-off-by: Adam Farley <adfarley@redhat.com>