### PR TITLE
Remove BUILDS_TO_KEEP limit on Grinder

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -328,11 +328,6 @@ def createJob( TEST_JOB_NAME, ARCH_OS ) {
 		}
 	}
 
-	//Due to limited space, reduce BUILDS_TO_KEEP for Grinder_XXX
-	if (TEST_JOB_NAME.startsWith("Grinder_")) {
-		jobParams.put('BUILDS_TO_KEEP', 5)
-	}
-
 	def templatePath = 'openjdk-tests/buildenv/jenkins/testJobTemplate'
 
 	if (params.LIGHT_WEIGHT_CHECKOUT) {


### PR DESCRIPTION
Remove BUILDS_TO_KEEP limit on Grinder and use the default value.
The default value is 10.

Signed-off-by: lanxia <lan_xia@ca.ibm.com>