### PR TITLE
Add customized TKG option to Comment-Triggered PR Build workflow

### DIFF
--- a/.github/workflows/runAqa.yml
+++ b/.github/workflows/runAqa.yml
@@ -70,6 +70,7 @@ jobs:
           - platform: ${{ steps.argparse.outputs.platform }}
           - jdk_version: ${{ steps.argparse.outputs.jdk_version }}
           - jdk_impl: ${{ steps.argparse.outputs.jdk_impl }}
+          - tkg_repo: ${{ steps.argparse.outputs.tkg_repo }}
 
           Workflow Run ID: [${{ steps.workflow_run_info.outputs.id }}](${{ steps.workflow_run_info.outputs.url }})
           `;
@@ -88,6 +89,7 @@ jobs:
         echo platform: ${{ steps.argparse.outputs.platform }}
         echo jdk_version: ${{ steps.argparse.outputs.jdk_version }}
         echo jdk_impl: ${{ steps.argparse.outputs.jdk_impl }}
+        echo tkg_repo: ${{ steps.argparse.outputs.tkg_repo }}
 
   runBuild:
     runs-on: ${{ matrix.platform }}
@@ -126,6 +128,7 @@ jobs:
          jdksource: 'install-jdk'
          version: ${{ matrix.jdk_version }}
          openjdk_testRepo: '${{ fromJSON(steps.get-pr.outputs.result).head.repo.full_name }}:${{ fromJSON(steps.get-pr.outputs.result).head.ref }}'
+         tkgRepo: ${{ matrix.tkg_repo }}
     - uses: actions/upload-artifact@v2
       if: failure()
       with:

--- a/.github/workflows/runAqa.yml
+++ b/.github/workflows/runAqa.yml
@@ -128,7 +128,7 @@ jobs:
          jdksource: 'install-jdk'
          version: ${{ matrix.jdk_version }}
          openjdk_testRepo: '${{ fromJSON(steps.get-pr.outputs.result).head.repo.full_name }}:${{ fromJSON(steps.get-pr.outputs.result).head.ref }}'
-         tkgRepo: ${{ matrix.tkg_repo }}
+         tkg_Repo: ${{ matrix.tkg_repo }}
     - uses: actions/upload-artifact@v2
       if: failure()
       with:

--- a/.github/workflows/runAqaArgParse.py
+++ b/.github/workflows/runAqaArgParse.py
@@ -51,6 +51,7 @@ def main():
     parser.add_argument('--platform', default=['x86-64_linux'], nargs='+')
     parser.add_argument('--jdk_version', default=['8'], nargs='+')
     parser.add_argument('--jdk_impl', default=['openj9'], choices=['hotspot', 'openj9'], nargs='+')
+    parser.add_argument('--tkg_repo', default=['adoptium/TKG:master'], nargs='+')
     args = vars(parser.parse_args(raw_args))
     # All args are lists of strings
 


### PR DESCRIPTION
Related to issue #2399
Adds an option to specify a custom TKG repo to pass to the `AdoptOpenJDK/run-aqa@v1` action.
Example:
![image](https://user-images.githubusercontent.com/5418647/111921354-b9de2d00-8a59-11eb-9727-f52f7fa04a41.png)
