### PR TITLE
Prevent from retrying when curl command is missing

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -236,7 +236,8 @@ getBinaryOpenjdk()
 			set +e
 			count=0
 			download_exit_code=-1
-			while [ $download_exit_code != 0 ] && [ $count -le 5  ]
+			# when the command is not found (code 127), do not retry
+			while [ $download_exit_code != 0 ] && [ $download_exit_code != 127 ] && [ $count -le 5  ]
 			do
 				if [ $count -gt 0 ]; then
 					sleep_time=300


### PR DESCRIPTION
As mentioned in #1830, the script will keep retrying when curl command cannot be found.

Fix it by checking `download_exit_code` at the beginning of each loop. When `download_exit_code` is 127(command is not found), skip the retry step. Below is the new error message when curl is missing:

```
$ ./openjdk-tests/get.sh -s /home/ppx/Desktop/binarySDK -t /home/ppx/Desktop/openjdk-tests -p x86-64_linux -r customized -c https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_x64_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz --openj9_repo https://github.com/eclipse/openj9.git --openj9_branch master --tkg_repo https://github.com/AdoptOpenJDK/TKG.git --tkg_branch master
TESTDIR: /home/ppx/Desktop/openjdk-tests
get jdk binary...
_ENCODE_FILE_NEW=UNTAGGED curl -OLJSks  https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_x64_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz
./openjdk-tests/get.sh: line 268: curl: command not found
curl error code: 127
Failed to retrieve https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_x64_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz, exiting. This is what we received of the file and MD5 sum:
ls: cannot access 'https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_x64_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz': No such file or directory
md5sum: 'https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jdk_x64_linux_openj9_11.0.10_9_openj9-0.24.0.tar.gz': No such file or directory

```