### PR TITLE
Check if the curl URL is invalid before unzip the download file

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -264,8 +264,8 @@ getBinaryOpenjdk()
 						;;
 				esac
 
-				echo "_ENCODE_FILE_NEW=UNTAGGED curl -OLJSk${curl_verbosity} ${curl_options} $file"
-				_ENCODE_FILE_NEW=UNTAGGED curl -OLJSk${curl_verbosity} ${curl_options} $file
+				echo "_ENCODE_FILE_NEW=UNTAGGED curl -OLJSkf${curl_verbosity} ${curl_options} $file"
+				_ENCODE_FILE_NEW=UNTAGGED curl -OLJSkf${curl_verbosity} ${curl_options} $file
 				download_exit_code=$?
 				count=$(( $count + 1 ))
 			done

--- a/get.sh
+++ b/get.sh
@@ -221,11 +221,11 @@ getBinaryOpenjdk()
 			release_type="ga"
 		fi
 		download_url="https://api.adoptopenjdk.net/v3/binary/latest/${JDK_VERSION}/${release_type}/${os}/${arch}/jdk/${JDK_IMPL}/${heap_size}/adoptopenjdk"
-		info_url="https://api.adoptopenjdk.net/v3/assets/feature_releases/${JDK_VERSION}/${release_type}?architecture=${arch}&heap_size=${heap_size}&image_type=jdk&jvm_impl=${JDK_IMPL}&os=${os}&page=0&page_size=10&project=jdk&vendor=adoptopenjdk"
+		info_url="https://api.adoptopenjdk.net/v3/assets/feature_releases/${JDK_VERSION}/${release_type}?architecture=${arch}&heap_size=${heap_size}&image_type=jdk&jvm_impl=${JDK_IMPL}&os=${os}&project=jdk&vendor=adoptopenjdk"
 
 		if [ "$JDK_VERSION" != "8" ] || [ "$JDK_IMPL" != "hotspot" ]; then
 			download_url+=" https://api.adoptopenjdk.net/v3/binary/latest/${JDK_VERSION}/${release_type}/${os}/${arch}/testimage/${JDK_IMPL}/${heap_size}/adoptopenjdk"
-			info_url+=" https://api.adoptopenjdk.net/v3/assets/feature_releases/${JDK_VERSION}/${release_type}?architecture=${arch}&heap_size=${heap_size}&image_type=testimage&jvm_impl=${JDK_IMPL}&os=${os}&page=0&page_size=10&project=jdk&vendor=adoptopenjdk"
+			info_url+=" https://api.adoptopenjdk.net/v3/assets/feature_releases/${JDK_VERSION}/${release_type}?architecture=${arch}&heap_size=${heap_size}&image_type=testimage&jvm_impl=${JDK_IMPL}&os=${os}&project=jdk&vendor=adoptopenjdk"
 		fi
 	else
 		download_url=""

--- a/get.sh
+++ b/get.sh
@@ -287,8 +287,9 @@ getBinaryOpenjdk()
 		done
 	fi
 
-	# check the download file. if the file is less than or equal to 8kb(the defualt download file's size), 
-	# it canno be a valid download, then show up error message and exit
+	# check the download file using command du
+	# if the file is less than or equal to 8k(the defualt download file's size), 
+	# it cannot be a valid download, then show up error message and exit
 	if [[ `du -s | awk '{ print $1 }'` -le 8 ]]; then
 		echo "Download failure, invalid downlad links: $download_url."
 		exit 1

--- a/get.sh
+++ b/get.sh
@@ -289,14 +289,16 @@ getBinaryOpenjdk()
 		done
 	fi
 
-	if [ "${info_url}" != "" ]; then
+	if [[ -n $info_url ]]; then
 		for info in $info_url
 		do
-			release_info=$(curl -Is $info | grep "HTTP/")
-			validate=( $release_info )
-			if [[ ${validate[-2]} != 200 ]]; then
-				echo "Download failure, invalid downlad links."
-				exit 1
+			if [[ $info_url == https://api.adoptopenjdk.net* ]]; then
+				release_info=$(curl -Is $info | grep "HTTP/")
+				validate=( $release_info )
+				if [[ ${validate[-2]} != 200 ]]; then
+					echo "Download failure, invalid downlad links."
+					exit 1
+				fi
 			fi
 		done
 	fi

--- a/get.sh
+++ b/get.sh
@@ -264,8 +264,8 @@ getBinaryOpenjdk()
 						;;
 				esac
 
-				echo "_ENCODE_FILE_NEW=UNTAGGED curl -OLJSkf${curl_verbosity} ${curl_options} $file"
-				_ENCODE_FILE_NEW=UNTAGGED curl -OLJSkf${curl_verbosity} ${curl_options} $file
+				echo "_ENCODE_FILE_NEW=UNTAGGED curl -OLJSk${curl_verbosity} ${curl_options} $file"
+				_ENCODE_FILE_NEW=UNTAGGED curl -OLJSk${curl_verbosity} ${curl_options} $file
 				download_exit_code=$?
 				count=$(( $count + 1 ))
 			done
@@ -285,6 +285,13 @@ getBinaryOpenjdk()
 			fi
 			set -e
 		done
+	fi
+
+	# check the download file. if the file is less than or equal to 8kb(the defualt download file's size), 
+	# it canno be a valid download, then show up error message and exit
+	if [[ `du -s | awk '{ print $1 }'` -le 8 ]]; then
+		echo "Download failure, invalid downlad links: $download_url."
+		exit 1
 	fi
 
 	jar_files=`ls`

--- a/get.sh
+++ b/get.sh
@@ -289,6 +289,8 @@ getBinaryOpenjdk()
 		done
 	fi
 
+	# use openapi, try to get the information of the download file
+	# if it returns the status code other than 200, it means the parameters provided by user forms some invalid link, then fails early
 	if [[ -n $info_url ]]; then
 		for info in $info_url
 		do


### PR DESCRIPTION
As mentioned in #1828, if the URL used to retrieved adoptopenjdk is invalid (returning 404), it's better to give the error immediately, instead of waiting until the unzip step.

As the output shows below, after the fix, if the URL is invalid, it will return curl error immediately and entering the retry step, instead of trying to unzip the file.

```
$ ./openjdk-tests/get.sh -s /home/ppx/Desktop/binarySDK -t /home/ppx/Desktop/openjdk-tests -j 16 -p arm_linux -r nightly --openj9_repo https://github.com/eclipse/openj9.git --openj9_branch master --tkg_repo https://github.com/AdoptOpenJDK/TKG.git --tkg_branch master
TESTDIR: /home/ppx/Desktop/openjdk-tests
get jdk binary...
_ENCODE_FILE_NEW=UNTAGGED curl -OLJSkfs  https://api.adoptopenjdk.net/v3/binary/latest/16/ea/linux/arm/jdk/openj9/normal/adoptopenjdk
curl: (22) The requested URL returned error: 404 
curl error code: 22. Sleep 300 secs, then retry 1...
check for adoptopenjdk. If found, the file will be removed.
_ENCODE_FILE_NEW=UNTAGGED curl -OLJSkfs  https://api.adoptopenjdk.net/v3/binary/latest/16/ea/linux/arm/jdk/openj9/normal/adoptopenjdk
curl: (22) The requested URL returned error: 404 
curl error code: 22. Sleep 300 secs, then retry 2...

```