### PR TITLE
Exclude jdk8 hotspot s390xLinux and Windows com/sun/jdi sanity.openjdk testcases

### DIFF
--- a/openjdk/ProblemList_openjdk8.txt
+++ b/openjdk/ProblemList_openjdk8.txt
@@ -268,6 +268,51 @@ com/sun/tools/attach/StartManagementAgent.java	https://github.com/AdoptOpenJDK/o
 
 com/sun/jdi/RedefineCrossEvent.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/227	macosx-all
 com/sun/jdi/ProcessAttachTest.sh  https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1274  macosx-all
+com/sun/jdi/JdbMethodExitTest.sh                https://github.com/AdoptOpenJDK/openjdk-tests/issues/2415 windows-all,linux-s390x
+com/sun/jdi/Redefine-g.sh                       https://github.com/AdoptOpenJDK/openjdk-tests/issues/2415 windows-all,linux-s390x
+com/sun/jdi/AllLineLocations.java               https://github.com/AdoptOpenJDK/openjdk-tests/issues/2408 linux-s390x
+com/sun/jdi/EarlyReturnTest.java                https://github.com/AdoptOpenJDK/openjdk-tests/issues/2408 linux-s390x
+com/sun/jdi/MethodExitReturnValuesTest.java     https://github.com/AdoptOpenJDK/openjdk-tests/issues/2408 linux-s390x
+com/sun/jdi/NativeInstanceFilter.java           https://github.com/AdoptOpenJDK/openjdk-tests/issues/2408 linux-s390x
+com/sun/jdi/PopAndStepTest.java                 https://github.com/AdoptOpenJDK/openjdk-tests/issues/2408 linux-s390x
+com/sun/jdi/PopAsynchronousTest.java            https://github.com/AdoptOpenJDK/openjdk-tests/issues/2408 linux-s390x
+com/sun/jdi/PopSynchronousTest.java             https://github.com/AdoptOpenJDK/openjdk-tests/issues/2408 linux-s390x
+com/sun/jdi/RedefineCrossStart.java             https://github.com/AdoptOpenJDK/openjdk-tests/issues/2408 linux-s390x
+com/sun/jdi/redefineMethod/RedefineTest.java    https://github.com/AdoptOpenJDK/openjdk-tests/issues/2408 linux-s390x
+com/sun/jdi/RedefineMulti.sh			https://github.com/AdoptOpenJDK/openjdk-tests/issues/2415 windows-all
+com/sun/jdi/RedefinePop.sh			https://github.com/AdoptOpenJDK/openjdk-tests/issues/2415 windows-all
+com/sun/jdi/RedefineStep.sh			https://github.com/AdoptOpenJDK/openjdk-tests/issues/2415 windows-all
+com/sun/jdi/RedefineTTYLineNumber.sh		https://github.com/AdoptOpenJDK/openjdk-tests/issues/2415 windows-all
+com/sun/jdi/StringConvertTest.sh		https://github.com/AdoptOpenJDK/openjdk-tests/issues/2415 windows-all
+com/sun/jdi/WatchFramePop.sh			https://github.com/AdoptOpenJDK/openjdk-tests/issues/2415 windows-all
+com/sun/jdi/ArrayLengthDumpTest.sh		https://github.com/AdoptOpenJDK/openjdk-tests/issues/2415 windows-all
+com/sun/jdi/BreakpointWithFullGC.sh		https://github.com/AdoptOpenJDK/openjdk-tests/issues/2415 windows-all
+com/sun/jdi/CatchAllTest.sh			https://github.com/AdoptOpenJDK/openjdk-tests/issues/2415 windows-all
+com/sun/jdi/CatchCaughtTest.sh			https://github.com/AdoptOpenJDK/openjdk-tests/issues/2415 windows-all
+com/sun/jdi/CatchPatternTest.sh			https://github.com/AdoptOpenJDK/openjdk-tests/issues/2415 windows-all
+com/sun/jdi/CommandCommentDelimiter.sh		https://github.com/AdoptOpenJDK/openjdk-tests/issues/2415 windows-all
+com/sun/jdi/DeoptimizeWalk.sh			https://github.com/AdoptOpenJDK/openjdk-tests/issues/2415 windows-all
+com/sun/jdi/EvalArgs.sh				https://github.com/AdoptOpenJDK/openjdk-tests/issues/2415 windows-all
+com/sun/jdi/EvalArraysAsList.sh			https://github.com/AdoptOpenJDK/openjdk-tests/issues/2415 windows-all
+com/sun/jdi/EvalInterfaceStatic.sh		https://github.com/AdoptOpenJDK/openjdk-tests/issues/2415 windows-all
+com/sun/jdi/GetLocalVariables3Test.sh		https://github.com/AdoptOpenJDK/openjdk-tests/issues/2415 windows-all
+com/sun/jdi/GetLocalVariables4Test.sh		https://github.com/AdoptOpenJDK/openjdk-tests/issues/2415 windows-all
+com/sun/jdi/JdbLockTest.sh			https://github.com/AdoptOpenJDK/openjdk-tests/issues/2415 windows-all
+com/sun/jdi/JdbMissStep.sh			https://github.com/AdoptOpenJDK/openjdk-tests/issues/2415 windows-all
+com/sun/jdi/JdbVarargsTest.sh			https://github.com/AdoptOpenJDK/openjdk-tests/issues/2415 windows-all
+com/sun/jdi/MixedSuspendTest.sh			https://github.com/AdoptOpenJDK/openjdk-tests/issues/2415 windows-all
+com/sun/jdi/NotAField.sh			https://github.com/AdoptOpenJDK/openjdk-tests/issues/2415 windows-all
+com/sun/jdi/NullLocalVariable.sh		https://github.com/AdoptOpenJDK/openjdk-tests/issues/2415 windows-all
+com/sun/jdi/RedefineAbstractClass.sh		https://github.com/AdoptOpenJDK/openjdk-tests/issues/2415 windows-all
+com/sun/jdi/RedefineAddPrivateMethod.sh		https://github.com/AdoptOpenJDK/openjdk-tests/issues/2415 windows-all
+com/sun/jdi/RedefineAnnotation.sh		https://github.com/AdoptOpenJDK/openjdk-tests/issues/2415 windows-all
+com/sun/jdi/RedefineChangeClassOrder.sh		https://github.com/AdoptOpenJDK/openjdk-tests/issues/2415 windows-all
+com/sun/jdi/RedefineClasses.sh			https://github.com/AdoptOpenJDK/openjdk-tests/issues/2415 windows-all
+com/sun/jdi/RedefineClearBreakpoint.sh		https://github.com/AdoptOpenJDK/openjdk-tests/issues/2415 windows-all
+com/sun/jdi/RedefineException.sh		https://github.com/AdoptOpenJDK/openjdk-tests/issues/2415 windows-all
+com/sun/jdi/RedefineFinal.sh			https://github.com/AdoptOpenJDK/openjdk-tests/issues/2415 windows-all
+com/sun/jdi/RedefineImplementor.sh		https://github.com/AdoptOpenJDK/openjdk-tests/issues/2415 windows-all
+com/sun/jdi/RedefineIntConstantToLong.sh	https://github.com/AdoptOpenJDK/openjdk-tests/issues/2415 windows-all
 
 ############################################################################
 


### PR DESCRIPTION
PR https://github.com/AdoptOpenJDK/openjdk-tests/pull/2376/files
unexcluded these tests as a "trial", but the following issues still remain=>

Exclude from jdk8 hotspot failing com/sun/jdi testcases for issues:
https://github.com/AdoptOpenJDK/openjdk-tests/issues/2415 - Needs a fix upstreaming
https://github.com/AdoptOpenJDK/openjdk-tests/issues/2408 - Permanent exclude due to limitation of jdi on jdk8 hs zLinux zero impl

Signed-off-by: Andrew Leonard <anleonar@redhat.com>