### PR TITLE
Exclude long-running tests on s390 JDK8 HS extended.openjdk tests

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -14,7 +14,8 @@
 
 # hotspot_all
 
-compiler/7184394/TestAESMain.java   https://github.com/AdoptOpenJDK/openjdk-tests/issues/1051   linux-s390x
+compiler/7184394/TestAESMain.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1051	linux-s390x
+compiler/intrinsics/sha/TestSHA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1051	linux-s390x
 
 ############################################################################
 
@@ -197,6 +198,7 @@ java/nio/channels/DatagramChannel/SendToUnresolved.java	https://github.com/Adopt
 java/nio/channels/Selector/RacyDeregister.java	https://bugs.openjdk.java.net/browse/JDK-8161083	aix-all
 java/nio/channels/AsyncCloseAndInterrupt.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/593	aix-all
 sun/nio/ch/TestMaxCachedBufferSize.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1051 linux-s390x
+sun/nio/cs/FindDecoderBugs.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1051	linux-s390x
 sun/nio/cs/OLD/TestIBMDB.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1051 linux-s390x
 
 ############################################################################
@@ -211,6 +213,7 @@ sun/rmi/runtime/Log/6409194/NoConsoleOutput.java https://bugs.openjdk.java.net/b
 
 # jdk_security
 
+com/sun/crypto/provider/KeyAgreement/SupportedDHParamGens.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1051	linux-s390x
 java/security/KeyPairGenerator/SolarisShortDSA.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1051	linux-s390x
 java/security/MessageDigest/TestDigestIOStream.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1051	linux-s390x
 sun/security/pkcs11/KeyStore/SecretKeysBasic.sh	https://bugs.openjdk.java.net/browse/JDK-8189603	linux-all,macosx-all,windows-all
@@ -261,6 +264,7 @@ sun/tools/jstatd/TestJstatdPortAndServer.java	https://github.com/AdoptOpenJDK/op
 sun/tools/jstatd/TestJstatdServer.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/115	linux-all
 sun/misc/Version/Version.java https://bugs.openjdk.java.net/browse/JDK-8244548 generic-all
 com/sun/tools/attach/StartManagementAgent.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/115	generic-all
+tools/pack200/CommandLineTests.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/1051	linux-s390x
 
 ############################################################################
 


### PR DESCRIPTION
On s390, JDK8 with Hotspot has no JIT. This results in a number of
tests running for over an hour, eventually causing an
extended.openjdk test run on Jenkins to be aborted due to the usual
10hr timeout.

While it seems likely we will not be running extended.openjdk on s390
(for JDK8 on Hotspot, anyway) for much longer, I'm excluding these
tests for now so that the test bucket is viable, should we choose to
run it again in the future.

Signed-off-by: Adam Farley <adfarley@redhat.com>