### PR TITLE
Add help command to Run AQA (Comment-Triggered PR Build) Workflow 

### DIFF
--- a/.github/workflows/runAqaArgParse.py
+++ b/.github/workflows/runAqaArgParse.py
@@ -45,6 +45,7 @@ def main():
 
     parser = argparse.ArgumentParser(prog=keyword, add_help=False)
     # Improvement: Automatically resolve the valid choices for each argument populate them below, rather than hard-coding choices.
+    parser.add_argument('--help', '-h', action='store_true')
     parser.add_argument('--sdk_resource', default=['nightly'], choices=['nightly', 'releases', 'customized'], nargs='+')
     parser.add_argument('--customized_sdk_url', default=['None'], nargs='+')
     parser.add_argument('--archive_extension', default=['.tar'], choices=['.zip', '.tar', '.7z'], nargs='+')
@@ -56,6 +57,19 @@ def main():
     parser.add_argument('--tkg_repo', default=['adoptium/TKG:master'], nargs='+')
     args = vars(parser.parse_args(raw_args))
     # All args are lists of strings
+
+    # Help was requested. The simplest way to handle this is as if it were an error
+    # because stdout is reserved for workflow commands and logs.
+    if args['help']:
+        # for some reason the first tilde in this help message does not need to be escaped
+        help_msg = '''Run AQA GitHub Action Documentation
+`\\`\\`
+https://github.com/AdoptOpenJDK/openjdk-tests/blob/master/doc/RunAqa.md'
+\\`\\`\\`
+Click the above link to view the documentation for the Run AQA GitHub Workflow'''
+        print('::error ::{}'.format(help_msg))
+        sys.stderr.write(help_msg)
+        exit(2)
 
     # Map grinder platform names to github runner names
     args['platform'] = map_platforms(args['platform'])

--- a/.github/workflows/runAqaArgParse.py
+++ b/.github/workflows/runAqaArgParse.py
@@ -64,7 +64,7 @@ def main():
         # for some reason the first tilde in this help message does not need to be escaped
         help_msg = '''Run AQA GitHub Action Documentation
 `\\`\\`
-https://github.com/AdoptOpenJDK/openjdk-tests/blob/master/doc/RunAqa.md'
+https://github.com/AdoptOpenJDK/openjdk-tests/blob/master/doc/RunAqa.md
 \\`\\`\\`
 Click the above link to view the documentation for the Run AQA GitHub Workflow'''
         print('::error ::{}'.format(help_msg))

--- a/doc/RunAqa.md
+++ b/doc/RunAqa.md
@@ -15,6 +15,12 @@ Most arguments are similar to their [Jenkins Grinder](https://ci.adoptopenjdk.ne
 
 All arguments allow more than one parameter. The parameters of each argument will be used to create a matrix job that will test every combination of the parameters.
 
+### --help
+
+This argument accepts no values. When this argument is supplied, a comment will be created with a link to this documentation. All other arguments will be ignored and no builds will be started.
+
+This argument is equivalently invoked by `-h`.
+
 ### --sdk_resource
 
 Supported values are:


### PR DESCRIPTION
Adds a `--help` / `-h` argument to the Run AQA workflow #2199 which links to the documentation #2424 
![image](https://user-images.githubusercontent.com/5418647/113527817-f80c3e00-957b-11eb-98d2-cd0d6c6d8467.png)
