### PR TITLE
Include compiler-api-signaturetest back on osx

### DIFF
--- a/jck/compiler.api/playlist.xml
+++ b/jck/compiler.api/playlist.xml
@@ -81,10 +81,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-api-signaturetest</testCaseName>
-		<disabled>
-			<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-			<plat>x86-64_mac(_mixed)?</plat>
-		</disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>


### PR DESCRIPTION
- Include back compiler-api-signaturetest back on osx 

Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>