### PR TITLE
Temporarily exclude failing jck8 tests from extended.jck

### DIFF
--- a/jck/compiler.api/playlist.xml
+++ b/jck/compiler.api/playlist.xml
@@ -81,6 +81,11 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-api-signaturetest</testCaseName>
+		<disabled>
+			<comment>Temporarily disabled on aix on JDK8 for test setup issue: backlog/issues/506</comment>
+			<plat>ppc64_aix(_mixed)?</plat>
+			<version>8</version>
+		</disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>

--- a/jck/devtools.java2schema/playlist.xml
+++ b/jck/devtools.java2schema/playlist.xml
@@ -16,6 +16,11 @@
 	<include>../jck.mk</include>
 	<test>
 		<testCaseName>jck-devtools-java2schema-CustomizedMapping</testCaseName>
+		<disabled>
+			<comment>Disabled on x64 Linux + aarch64 + ppc64le + win64 on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
+			<plat>x86-64_linux(_mixed)?|aarch64_linux(_mixed)?|ppc64le_linux(_mixed)?|x86-64_windows(_mixed)?</plat>
+			<version>8</version>
+		</disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>

--- a/jck/devtools.jaxws/playlist.xml
+++ b/jck/devtools.jaxws/playlist.xml
@@ -16,6 +16,11 @@
 	<include>../jck.mk</include>
 	<test>
 		<testCaseName>jck-devtools-jaxws-mapping</testCaseName>
+		<disabled>
+			<comment>Disabled on Win32 on jdk8 due to backlog/issues/507. Awaiting potential test / setup issue resolution</comment>
+			<plat>x86-32_windows(_mixed)?|x86-64_windows(_mixed)?</plat>
+			<version>8</version>
+		</disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>

--- a/jck/devtools.schema2java/playlist.xml
+++ b/jck/devtools.schema2java/playlist.xml
@@ -16,6 +16,11 @@
 	<include>../jck.mk</include>
 	<test>
 		<testCaseName>jck-devtools-schema2java-nisttest</testCaseName>
+		<disabled>
+			<comment>Disabled on x64 Linux + aarch64 on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
+			<plat>x86-64_linux(_mixed)?|aarch64_linux(_mixed)?</plat>
+			<version>8</version>
+		</disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -33,6 +38,11 @@
 	</test>
 	<test>
 		<testCaseName>jck-devtools-schema2java-structures</testCaseName>
+		<disabled>
+			<comment>Disabled on aarch64 Linux + aarch64 on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
+			<plat>x86-64_linux(_mixed)?|aarch64_linux(_mixed)?</plat>
+			<version>8</version>
+		</disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>

--- a/jck/devtools.schema_bind/playlist.xml
+++ b/jck/devtools.schema_bind/playlist.xml
@@ -16,6 +16,11 @@
 	<include>../jck.mk</include>
 	<test>
 		<testCaseName>jck-devtools-schema_bind-bind_class</testCaseName>
+		<disabled>
+			<comment>Disabled on x64 Linux + win64 on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
+			<plat>x86-64_linux(_mixed)?|x86-64_windows(_mixed)?</plat>
+			<version>8</version>
+		</disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -33,6 +38,11 @@
 	</test>
 	<test>
 		<testCaseName>jck-devtools-schema_bind-bind_dom</testCaseName>
+		<disabled>
+			<comment>Disabled on aarch64 + ppc64le on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
+			<plat>aarch64_linux(_mixed)?|ppc64le_linux(_mixed)?</plat>
+			<version>8</version>
+		</disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -50,6 +60,11 @@
 	</test>
 	<test>
 		<testCaseName>jck-devtools-schema_bind-bind_factoryMethod</testCaseName>
+		<disabled>
+			<comment>Disabled on aarch64 + win64 on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
+			<plat>aarch64_linux(_mixed)?|x86-64_windows(_mixed)?</plat>
+			<version>8</version>
+		</disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -67,6 +82,11 @@
 	</test>
 	<test>
 		<testCaseName>jck-devtools-schema_bind-bind_globalBindings</testCaseName>
+		<disabled>
+			<comment>Disabled on aarch64 on jdk8 due to backlog/issues/302, on win64 due to backlog/issues/507. Awaiting potential test / setup issue resolution</comment>
+			<plat>aarch64_linux(_mixed)?|x86-64_windows(_mixed)?</plat>
+			<version>8</version>
+		</disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -84,6 +104,11 @@
 	</test>
 	<test>
 		<testCaseName>jck-devtools-schema_bind-bind_inlineBinaryData</testCaseName>
+		<disabled>
+			<comment>Disabled on aarch64 on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
+			<plat>aarch64_linux(_mixed)?</plat>
+			<version>8</version>
+		</disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -118,6 +143,11 @@
 	</test>
 	<test>
 		<testCaseName>jck-devtools-schema_bind-bind_property</testCaseName>
+		<disabled>
+			<comment>Disabled on x64 Linux + win64 on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
+			<plat>x86-64_linux(_mixed)?|x86-64_windows(_mixed)?</plat>
+			<version>8</version>
+		</disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -135,6 +165,11 @@
 	</test>
 	<test>
 		<testCaseName>jck-devtools-schema_bind-bind_schemaBindings</testCaseName>
+		<disabled>
+			<comment>Disabled on ppc64le Linux on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
+			<plat>ppc64le_linux(_mixed)?</plat>
+			<version>8</version>
+		</disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>

--- a/jck/devtools.xml_schema/playlist.xml
+++ b/jck/devtools.xml_schema/playlist.xml
@@ -16,6 +16,11 @@
 	<include>../jck.mk</include>
 	<test>
 		<testCaseName>jck-devtools-xml_schema-boeingData</testCaseName>
+		<disabled>
+			<comment>Disabled on x64 Linux + aarch64 + ppc64le + win32 on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
+			<plat>x86-64_linux(_mixed)?|aarch64_linux(_mixed)?|ppc64le_linux(_mixed)?|x86-32_windows(_mixed)?</plat>
+			<version>8</version>
+		</disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -33,6 +38,11 @@
 	</test>
 	<test>
 		<testCaseName>jck-devtools-xml_schema-msData</testCaseName>
+		<disabled>
+			<comment>Disabled on aarch64 Linux + ppc64le on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
+			<plat>aarch64_linux(_mixed)?|ppc64le_linux(_mixed)?</plat>
+			<version>8</version>
+		</disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -50,6 +60,11 @@
 	</test>
 	<test>
 		<testCaseName>jck-devtools-xml_schema-nistData</testCaseName>
+		<disabled>
+			<comment>Disabled on x64 Linux on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
+			<plat>x86-64_linux(_mixed)?|aarch64_linux(_mixed)?</plat>
+			<version>8</version>
+		</disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -67,6 +82,11 @@
 	</test>
 	<test>
 		<testCaseName>jck-devtools-xml_schema-sunData</testCaseName>
+		<disabled>
+			<comment>Disabled on x64 Linux on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
+			<plat>x86-64_linux(_mixed)?||aarch64_linux(_mixed)?</plat>
+			<version>8</version>
+		</disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>

--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -385,7 +385,13 @@
 		<testCaseName>jck-runtime-api-java_awt</testCaseName>
 		<disabled>
 			<comment>Disabled on osx for infrastructure/issues/5254, and on rest for backlog/issues/485. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
+			<version>8</version>
 			<version>11</version>
+		</disabled>
+		<disabled>
+			<comment>Disabled on win64 on jdk8 due to backlog/issues/504. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
+			<plat>x86-64_windows(_mixed)?</plat>
+			<version>8</version>
 		</disabled>
 		<variations>
 			<variation>NoOptions</variation>
@@ -405,6 +411,11 @@
 			<comment>Disabled on osx for infrastructure/issues/5254; on aix for backlog/issues/486. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
 			<plat>x86-64_mac(_mixed)?|ppc64_aix(_mixed)?</plat>
 			<version>11</version>
+		</disabled>
+		<disabled>
+			<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
+			<plat>x86-64_mac(_mixed)?</plat>
+			<version>8</version>
 		</disabled>
 		<variations>
 			<variation>NoOptions</variation>
@@ -469,6 +480,7 @@
 		<disabled>
 			<comment>Disabled on all platforms due to backlog/issues/462. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
 			<version>11</version>
+			<version>8</version>
 		</disabled>
 		<variations>
 			<variation>NoOptions</variation>
@@ -516,6 +528,7 @@
 			<comment>Disabled on win for backlog/issues/488. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
 			<plat>x86-64_windows(_mixed)?</plat>
 			<version>11</version>
+			<version>8</version>
 		</disabled>
 		<variations>
 			<variation>NoOptions</variation>
@@ -739,6 +752,7 @@
 		<disabled>
 			<comment>Disabled on all platforms due to backlog/issues/461. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
 			<version>11</version>
+			<version>8</version>
 		</disabled>
 		<variations>
 			<variation>NoOptions</variation>
@@ -849,6 +863,11 @@
 		<disabled>
 			<comment>Disabled on osx for infrastructure/issues/5254, on win for backlog/issues/487 and on others for backlog/issues/484. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
 			<version>11</version>
+		</disabled>
+		<disabled>
+			<comment>Disabled on osx on jdk8 due to backlog/issues/5254 and on win32 due to backlog/issues/503. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
+			<plat>x86-64_mac(_mixed)?|x86-32_windows(_mixed)?</plat>
+			<version>8</version>
 		</disabled>
 		<variations>
 			<variation>NoOptions</variation>


### PR DESCRIPTION
Temporarily exclude failing jck8 tests from extended.jck
For details, please see: backlog/issues/500

Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>