### PR TITLE
Have one disable tag for each version

### DIFF
--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -385,7 +385,6 @@
 		<testCaseName>jck-runtime-api-java_awt</testCaseName>
 		<disabled>
 			<comment>Disabled on osx for infrastructure/issues/5254, and on rest for backlog/issues/485. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-			<version>8</version>
 			<version>11</version>
 		</disabled>
 		<disabled>
@@ -480,6 +479,9 @@
 		<disabled>
 			<comment>Disabled on all platforms due to backlog/issues/462. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
 			<version>11</version>
+		</disabled>
+		<disabled>
+			<comment>Disabled on all platforms due to backlog/issues/462. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
 			<version>8</version>
 		</disabled>
 		<variations>
@@ -528,6 +530,10 @@
 			<comment>Disabled on win for backlog/issues/488. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
 			<plat>x86-64_windows(_mixed)?</plat>
 			<version>11</version>
+		</disabled>
+		<disabled>
+			<comment>Disabled on win for backlog/issues/488. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
+			<plat>x86-64_windows(_mixed)?</plat>
 			<version>8</version>
 		</disabled>
 		<variations>
@@ -752,6 +758,9 @@
 		<disabled>
 			<comment>Disabled on all platforms due to backlog/issues/461. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
 			<version>11</version>
+		</disabled>
+		<disabled>
+			<comment>Disabled on all platforms due to backlog/issues/461. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
 			<version>8</version>
 		</disabled>
 		<variations>


### PR DESCRIPTION
1) TKG requires that we have a single version tag under each disable tag - that was fixed 
2) The awt test actually should not be disabled completely on 8. Specific disabling of sub-tests were delivered for awt suite in jck8.jtx in separate pr. 

Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>