### PR TITLE
Added three system test repo specific fields to grinder job template

### DIFF
--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -225,9 +225,9 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							stringParam('OPENJDK_SHA', "", "OpenJDK SHA from which to run tests")
 							stringParam('TKG_OWNER_BRANCH', "AdoptOpenJDK:master", "TestKitGen git [owner]:[branch]. Default is AdoptOpenJDK:master")
 							stringParam('TKG_SHA', "", "TKG sha")
-              stringParam('ADOPTOPENJDK_SYSTEMTEST_OWNER_BRANCH', "Personal Adoptopenjdk/openjdk-systemtest repository owner:branch", "AdoptOpenJDK:master")
-              stringParam('OPENJ9_SYSTEMTEST_OWNER_BRANCH', "Personal eclipse/openj9-systemtest repository owner:branch", "eclipse:master")
-              stringParam('STF_OWNER_BRANCH', "Personal stf repo owner:branch", "AdoptOpenJDK:master")
+                                                        stringParam('ADOPTOPENJDK_SYSTEMTEST_OWNER_BRANCH', "Adoptium:master", "Personal Adoptium/aqa-systemtest repository owner:branch")
+                                                        stringParam('OPENJ9_SYSTEMTEST_OWNER_BRANCH', "eclipse:master", "Personal eclipse/openj9-systemtest repository owner:branch")
+                                                        stringParam('STF_OWNER_BRANCH', "Adoptium:master", "Personal stf repo owner:branch")
 							stringParam('JCK_GIT_REPO', ACTUAL_JCK_GIT_REPO, "For JCK test only")
 							booleanParam('LIGHT_WEIGHT_CHECKOUT', LIGHT_WEIGHT_CHECKOUT.toBoolean(), "Optional. Default is false for Grinders")
 

--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -214,7 +214,7 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							    separatorStyle(separatorHelpTextStyleCss)
 							    sectionHeader('Repositories where we pull test material from. Unless you are testing test code, these do not need to be changed.')
 							    sectionHeaderStyle(sectionHeaderHelpTextStyleCss)
-							}							
+							}
 							stringParam('ADOPTOPENJDK_REPO', ADOPTOPENJDK_REPO, "AdoptOpenJDK git repo. Please use ssh for zos.")
 							stringParam('ADOPTOPENJDK_BRANCH', ADOPTOPENJDK_BRANCH, "AdoptOpenJDK branch")
 							stringParam('OPENJ9_REPO', OPENJ9_REPO, "OpenJ9 git repo. Please use ssh for zos.")
@@ -225,9 +225,12 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							stringParam('OPENJDK_SHA', "", "OpenJDK SHA from which to run tests")
 							stringParam('TKG_OWNER_BRANCH', "AdoptOpenJDK:master", "TestKitGen git [owner]:[branch]. Default is AdoptOpenJDK:master")
 							stringParam('TKG_SHA', "", "TKG sha")
+              stringParam('ADOPTOPENJDK_SYSTEMTEST_OWNER_BRANCH', "Personal Adoptopenjdk/openjdk-systemtest repository owner:branch", "AdoptOpenJDK:master")
+              stringParam('OPENJ9_SYSTEMTEST_OWNER_BRANCH', "Personal eclipse/openj9-systemtest repository owner:branch", "eclipse:master")
+              stringParam('STF_OWNER_BRANCH', "Personal stf repo owner:branch", "AdoptOpenJDK:master")
 							stringParam('JCK_GIT_REPO', ACTUAL_JCK_GIT_REPO, "For JCK test only")
 							booleanParam('LIGHT_WEIGHT_CHECKOUT', LIGHT_WEIGHT_CHECKOUT.toBoolean(), "Optional. Default is false for Grinders")
-							
+
 							parameterSeparatorDefinition {
 							    name('NON_AQA_TEST_REPOS')
 							    separatorStyle(separatorStyleCss)
@@ -245,7 +248,7 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							stringParam('VENDOR_TEST_SHAS', "", "Optional. Addtional test shas")
 							stringParam('VENDOR_TEST_DIRS', VENDOR_TEST_DIRS, "Optional. Addtional test dirs")
               stringParam('USER_CREDENTIALS_ID', USER_CREDENTIALS_ID, "Optional. User credential ID")
-														
+
 							parameterSeparatorDefinition {
 							    name('PLATFORM_AND_MACHINE')
 							    separatorStyle(separatorStyleCss)
@@ -266,7 +269,7 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							stringParam('EXTRA_DOCKER_ARGS', EXTRA_DOCKER_ARGS, "Extra docker args")
 							stringParam('SSH_AGENT_CREDENTIAL', SSH_AGENT_CREDENTIAL, "Optional. Only use when ssh credentials are needed")
 							stringParam('ACTIVE_NODE_TIMEOUT', "", "Number of minutes we will wait for a label-matching node to become active.")
-							
+
 							parameterSeparatorDefinition {
 							    name('JDK_SELECTION_PARAMS')
 							    separatorStyle(separatorStyleCss)
@@ -286,8 +289,8 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							stringParam('CUSTOMIZED_SDK_URL_CREDENTIAL_ID', "", "Only use this if you are pulling an JDK from a site that needs credential")
 							stringParam('UPSTREAM_JOB_NAME', "", "Upstream job name from the same Jenkins server to download JDK")
 							stringParam('UPSTREAM_JOB_NUMBER', "", "Upstream job number from the same Jenkins server to download JDK.")
-							booleanParam('AUTO_DETECT', AUTO_DETECT.toBoolean(), "Optional. Default is to enable AUTO_DETECT")							
-							
+							booleanParam('AUTO_DETECT', AUTO_DETECT.toBoolean(), "Optional. Default is to enable AUTO_DETECT")
+
 							parameterSeparatorDefinition {
 							    name('TEST_SELECTION_PARAMS')
 							    separatorStyle(separatorStyleCss)
@@ -303,7 +306,7 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							stringParam('BUILD_LIST', "${ACTUAL_BUILD_LIST}", "Specific test directory to compile, set blank for all projects to be compiled")
 							stringParam('TARGET', "${ACTUAL_TARGET}", "Test TARGET to execute")
 							stringParam('CUSTOM_TARGET', "", "Only used when the custom target is specified in TARGET , e.g. jdk_custom, langtools_custom, etc., CUSTOM_TARGET=path to the test class to execute")
-							
+
 							parameterSeparatorDefinition {
 							    name('TEST_OPTIONS_PARAMS')
 							    separatorStyle(separatorStyleCss)
@@ -319,11 +322,11 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							choiceParam('TEST_FLAG', ['', 'JITAAS', 'AOT'], "Optional. Only set to JITAAS/AOT for JITAAS/AOT feature testing.")
 							stringParam('EXTRA_OPTIONS', EXTRA_OPTIONS, "Use this to append options to the test command")
 							stringParam('JVM_OPTIONS', "", "Use this to replace the test original command line options")
-							stringParam('BUILD_IDENTIFIER', "", "build identifier")	
+							stringParam('BUILD_IDENTIFIER', "", "build identifier")
 							stringParam('ITERATIONS',"1", "Number of times to repeat execution of test target")
 							stringParam('TIME_LIMIT', TIME_LIMIT, "time limit")
-							
-							
+
+
 							parameterSeparatorDefinition {
 							    name('TEST_PARALLELIZATION_PARAMS')
 							    separatorStyle(separatorStyleCss)
@@ -341,7 +344,7 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							booleanParam('PERSONAL_BUILD', false, "Is this a personal build?")
 							stringParam('UPSTREAM_TEST_JOB_NAME', "", "Auto-populated. Upstream test job name. It will be used together with PARALLEL=Dynamic")
 							stringParam('UPSTREAM_TEST_JOB_NUMBER', "", "Auto-populated. Upstream test job number. It will be used together with PARALLEL=Dynamic")
-							
+
 							parameterSeparatorDefinition {
 							    name('POST_RUN_PARAMS')
 							    separatorStyle(separatorStyleCss)

--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -225,9 +225,9 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							stringParam('OPENJDK_SHA', "", "OpenJDK SHA from which to run tests")
 							stringParam('TKG_OWNER_BRANCH', "AdoptOpenJDK:master", "TestKitGen git [owner]:[branch]. Default is AdoptOpenJDK:master")
 							stringParam('TKG_SHA', "", "TKG sha")
-                                                        stringParam('ADOPTOPENJDK_SYSTEMTEST_OWNER_BRANCH', "Adoptium:master", "Personal Adoptium/aqa-systemtest repository owner:branch")
-                                                        stringParam('OPENJ9_SYSTEMTEST_OWNER_BRANCH', "eclipse:master", "Personal eclipse/openj9-systemtest repository owner:branch")
-                                                        stringParam('STF_OWNER_BRANCH', "Adoptium:master", "Personal stf repo owner:branch")
+							stringParam('ADOPTOPENJDK_SYSTEMTEST_OWNER_BRANCH', "Adoptium:master", "Personal Adoptium/aqa-systemtest repository owner:branch")
+							stringParam('OPENJ9_SYSTEMTEST_OWNER_BRANCH', "eclipse:master", "Personal eclipse/openj9-systemtest repository owner:branch")
+							stringParam('STF_OWNER_BRANCH', "Adoptium:master", "Personal stf repo owner:branch")
 							stringParam('JCK_GIT_REPO', ACTUAL_JCK_GIT_REPO, "For JCK test only")
 							booleanParam('LIGHT_WEIGHT_CHECKOUT', LIGHT_WEIGHT_CHECKOUT.toBoolean(), "Optional. Default is false for Grinders")
 

--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -225,9 +225,9 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							stringParam('OPENJDK_SHA', "", "OpenJDK SHA from which to run tests")
 							stringParam('TKG_OWNER_BRANCH', "AdoptOpenJDK:master", "TestKitGen git [owner]:[branch]. Default is AdoptOpenJDK:master")
 							stringParam('TKG_SHA', "", "TKG sha")
-							stringParam('ADOPTOPENJDK_SYSTEMTEST_OWNER_BRANCH', "Adoptium:master", "Personal Adoptium/aqa-systemtest repository owner:branch")
+							stringParam('ADOPTOPENJDK_SYSTEMTEST_OWNER_BRANCH', "adoptium:master", "Personal Adoptium/aqa-systemtest repository owner:branch")
 							stringParam('OPENJ9_SYSTEMTEST_OWNER_BRANCH', "eclipse:master", "Personal eclipse/openj9-systemtest repository owner:branch")
-							stringParam('STF_OWNER_BRANCH', "Adoptium:master", "Personal stf repo owner:branch")
+							stringParam('STF_OWNER_BRANCH', "adoptium:master", "Personal stf repo owner:branch")
 							stringParam('JCK_GIT_REPO', ACTUAL_JCK_GIT_REPO, "For JCK test only")
 							booleanParam('LIGHT_WEIGHT_CHECKOUT', LIGHT_WEIGHT_CHECKOUT.toBoolean(), "Optional. Default is false for Grinders")
 

--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -225,7 +225,7 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							stringParam('OPENJDK_SHA', "", "OpenJDK SHA from which to run tests")
 							stringParam('TKG_OWNER_BRANCH', "AdoptOpenJDK:master", "TestKitGen git [owner]:[branch]. Default is AdoptOpenJDK:master")
 							stringParam('TKG_SHA', "", "TKG sha")
-							stringParam('ADOPTOPENJDK_SYSTEMTEST_OWNER_BRANCH', "adoptium:master", "Personal Adoptium/aqa-systemtest repository owner:branch")
+							stringParam('ADOPTOPENJDK_SYSTEMTEST_OWNER_BRANCH', "AdoptOpenJDK:master", "Personal Adoptium/aqa-systemtest repository owner:branch")
 							stringParam('OPENJ9_SYSTEMTEST_OWNER_BRANCH', "eclipse:master", "Personal eclipse/openj9-systemtest repository owner:branch")
 							stringParam('STF_OWNER_BRANCH', "adoptium:master", "Personal stf repo owner:branch")
 							stringParam('JCK_GIT_REPO', ACTUAL_JCK_GIT_REPO, "For JCK test only")


### PR DESCRIPTION
Added the following three system test repo specific fields to grinder job template :
| Field Name | Description | Default value |
| ------------  | ------------ | --------------- |
| ADOPTOPENJDK_SYSTEMTEST_OWNER_BRANCH | Personal Adoptopenjdk/openjdk-systemtest repository owner:branch | AdoptOpenJDK:master|
| OPENJ9_SYSTEMTEST_OWNER_BRANCH | Personal eclipse/openj9-systemtest repository owner:branch | eclipse:master|
| STF_OWNER_BRANCH | Personal stf repo owner:branch | AdoptOpenJDK:master|

Fixes #2519 