### PR TITLE
Exclude DeadSSLLdapTimeoutTest on jdk8

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk8-openj9.txt
@@ -325,4 +325,6 @@ sun/util/logging/PlatformLoggerTest.java	https://github.com/AdoptOpenJDK/openjdk
 
 # jdk_other
 
+com/sun/jndi/ldap/DeadSSLLdapTimeoutTest.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/2351 generic-all
+
 ############################################################################

--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -352,6 +352,7 @@ sun/util/calendar/zi/TestZoneInfo310.java		https://github.com/eclipse/openj9/iss
 
 # jdk_other
 
+com/sun/jndi/ldap/DeadSSLLdapTimeoutTest.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/2351 generic-all
 jdk/lambda/vm/InterfaceAccessFlagsTest.java	https://github.com/AdoptOpenJDK/openjdk-tests/issues/126	linux-all
 
 ############################################################################


### PR DESCRIPTION
Signed-off-by: Simon Rushton <srushton@redhat.com>