### PR TITLE
Disable JFR tests on AIX.

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -1013,6 +1013,10 @@
 	</test>
 	<test>
 		<testCaseName>jdk_jfr</testCaseName>
+		<disabled>
+			<comment>https://bugs.openjdk.java.net/browse/JDK-8203290</comment>
+			<plat>.*aix.*</plat>
+		</disabled>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
@@ -1066,7 +1070,7 @@
 	<test>
 		<testCaseName>jdk_foreign_native</testCaseName>
 		<disabled>
-			<comment>https://github.com/AdoptOpenJDK/openjdk-tests/issues/2218#issuecomment-770048450</comment>
+			<comment>https://github.com/eclipse/openj9/issues/11760</comment>
 			<version>16+</version>
 			<impl>openj9</impl>
 		</disabled>

--- a/perf/dacapo/playlist.xml
+++ b/perf/dacapo/playlist.xml
@@ -63,7 +63,7 @@
 	<test>
 		<testCaseName>dacapo-jython</testCaseName>
 		<disabled>
-			<comment>https://github.com/AdoptOpenJDK/openjdk-tests/issues/2256#issuecomment-777850091</comment>
+			<comment>https://github.com/eclipse/openj9/issues/11942</comment>
 			<version>16+</version>
 			<impl>openj9</impl>
 		</disabled>


### PR DESCRIPTION
Disable JFR tests on AIX.
JFR tests don't run on AIX with JDK11+, which are actually disabled by require property `@requires vm.hasJFR`. As no test selected test jobs still fail. Will just disable for all version.

https://ci.adoptopenjdk.net/job/Test_openjdk11_hs_extended.openjdk_ppc64_aix/22/console

```
01:47:30  Test results: no tests selected
01:47:39  Report written to /home/jenkins/workspace/Test_openjdk11_hs_extended.openjdk_ppc64_aix/jvmtest/openjdk/report/html/report.html
01:47:39  Results written to /home/jenkins/workspace/Test_openjdk11_hs_extended.openjdk_ppc64_aix/openjdk-tests/TKG/output_16189619473542/jdk_jfr_1/work
01:47:39  
01:47:39  jdk_jfr_1_FAILED
```

Correct two disable comment link.

Close #2256 
Close #2218 

Signed-off-by: Sophia Guo <sophia.gwf@gmail.com>