### PR TITLE
Update curl download response validation to use more acceptable bash syntax

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -294,11 +294,12 @@ getBinaryOpenjdk()
 	if [[ -n $info_url ]]; then
 		for info in $info_url
 		do
-			if [[ $info_url == https://api.adoptopenjdk.net* ]]; then
-				release_info=$(curl -Is $info | grep "HTTP/")
-				validate=( $release_info )
-				if [[ ${validate[-2]} != 200 ]]; then
-					echo "Download failure, invalid downlad links."
+			if [[ $info == https://api.adoptopenjdk.net* ]]; then
+				http_resp_info=$(curl -Is "$info" | grep "HTTP/")
+				# 2nd field of HTTP status line is the http response code (both HTTP/1.1 & 2)
+				validate=$(echo "${http_resp_info}" | tr -s ' ' | cut -d' ' -f2)
+				if [[ ${validate} != 200 ]]; then
+					echo "Download failure, invalid download link: ${info}."
 					exit 1
 				fi
 			fi


### PR DESCRIPTION
Change download http status validation to use more standard shell cmds, rather than bash array -ve subscript.
Also, correct download links for loop reference.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>