### PR TITLE
Check for SDK_RESOURCE value

### DIFF
--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -165,8 +165,8 @@ def JDK_IMPLS = params.JDK_IMPL.trim().split("\\s*,\\s*");
 
 // if multiple JDK_VERSION / JDK_IMPL / PLATFORM are provided, run test jobs in parallel
 if (JDK_VERSIONS.size() > 1 || JDK_IMPLS.size() > 1 || PLATFORMS.size() >1 || PLATFORMS.contains("all")) {
-    if (SDK_RESOURCE != 'nightly' && SDK_RESOURCE != 'release') {
-        assert false : "Multiple Grinders should run with SDK_RESOURCE=nightly or release."
+    if (SDK_RESOURCE != 'nightly' && SDK_RESOURCE != 'releases') {
+        assert false : "Multiple Grinders should run with SDK_RESOURCE=nightly or releases."
     } else {
         testJobs = [:]
         PLATFORMS.each { PLATFORM ->


### PR DESCRIPTION
Fix typo. For multiple Grinders, the code should check for SDK_RESOURCE=releases, not release.

Signed-off-by: lanxia <lan_xia@ca.ibm.com>